### PR TITLE
VSP-246 [iOS] After editing a file's meta data, when returning back to the list of files refresh the page

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 		F53D0A1C25FB71960080579F /* FileDetailsDateCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D0A1A25FB71960080579F /* FileDetailsDateCollectionViewCell.swift */; };
 		F53D0A1D25FB71960080579F /* FileDetailsDateCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = F53D0A1B25FB71960080579F /* FileDetailsDateCollectionViewCell.xib */; };
 		F540B76125EE8CD9009D331A /* ImagePreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F540B76025EE8CD9009D331A /* ImagePreviewViewController.swift */; };
+		F54596C325FF737200E0BC5F /* FilePreviewNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54596C225FF737200E0BC5F /* FilePreviewNavigationController.swift */; };
 		F58EBC2E25DE963800D2D383 /* SharedFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58EBC2D25DE963800D2D383 /* SharedFilesViewModel.swift */; };
 		F58EBC8425DFFB9600D2D383 /* MyFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58EBC8325DFFB9600D2D383 /* MyFilesViewModel.swift */; };
 /* End PBXBuildFile section */
@@ -572,6 +573,7 @@
 		F53D0A1A25FB71960080579F /* FileDetailsDateCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDetailsDateCollectionViewCell.swift; sourceTree = "<group>"; };
 		F53D0A1B25FB71960080579F /* FileDetailsDateCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FileDetailsDateCollectionViewCell.xib; sourceTree = "<group>"; };
 		F540B76025EE8CD9009D331A /* ImagePreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewViewController.swift; sourceTree = "<group>"; };
+		F54596C225FF737200E0BC5F /* FilePreviewNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewNavigationController.swift; sourceTree = "<group>"; };
 		F58EBC2D25DE963800D2D383 /* SharedFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFilesViewModel.swift; sourceTree = "<group>"; };
 		F58EBC8325DFFB9600D2D383 /* MyFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFilesViewModel.swift; sourceTree = "<group>"; };
 		F8E2C57314DE2C2792A40D54 /* Pods-Permanent.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Permanent.release.xcconfig"; path = "Target Support Files/Pods-Permanent/Pods-Permanent.release.xcconfig"; sourceTree = "<group>"; };
@@ -654,6 +656,7 @@
 				BCF906632587B0C200DF1B64 /* MembersViewController.swift */,
 				5EE3E11025A72ED0009BACA8 /* AccountSettingsViewController.swift */,
 				5E46217125C17C5A007642BE /* AccountInfoViewController.swift */,
+				F54596C225FF737200E0BC5F /* FilePreviewNavigationController.swift */,
 				5E8BFEA825DEA02C00454F16 /* FilePreviewViewController.swift */,
 				5ED581B725EE4AB100A5A79E /* FileDetailsViewController.swift */,
 				F540B76025EE8CD9009D331A /* ImagePreviewViewController.swift */,
@@ -1626,6 +1629,7 @@
 				BCF4E5DB255C3782003505BA /* AttachmentRecordVO.swift in Sources */,
 				06644A8B24EBF4CD003CD359 /* CustomView.swift in Sources */,
 				BC6D3B4D2514E57500390927 /* NetworkSessionProtocol.swift in Sources */,
+				F54596C325FF737200E0BC5F /* FilePreviewNavigationController.swift in Sources */,
 				BCD948DA258CAF6400089F86 /* ShareListType.swift in Sources */,
 				BCEECD8025ADC87500A4520E /* SharebyURLVOTokenPayload.swift in Sources */,
 				06644A8924EA78F5003CD359 /* ViewModelDelegateInterface.swift in Sources */,

--- a/Permanent/ViewControllers/FilePreviewNavigationController.swift
+++ b/Permanent/ViewControllers/FilePreviewNavigationController.swift
@@ -1,0 +1,65 @@
+//
+//  FilePreviewNavigationController.swift
+//  Permanent
+//
+//  Created by Vlad Alexandru Rusu on 15.03.2021.
+//
+
+import UIKit
+
+protocol FilePreviewNavigationControllerDelegate: class {
+    func filePreviewNavigationControllerWillClose(_ filePreviewNavigationVC: FilePreviewNavigationController, hasChanges: Bool)
+}
+
+class FilePreviewNavigationController: UINavigationController {
+    
+    weak var filePreviewNavDelegate: FilePreviewNavigationControllerDelegate?
+    
+    var hasChanges: Bool = false
+    
+    override init(rootViewController: UIViewController) {
+        super.init(rootViewController: rootViewController)
+        
+        addCloseButton(toViewController: rootViewController)
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func setViewControllers(_ viewControllers: [UIViewController], animated: Bool) {
+        super.setViewControllers(viewControllers, animated: animated)
+        
+        if let vc = viewControllers.first {
+            addCloseButton(toViewController: vc)
+        }
+    }
+    
+    func addCloseButton(toViewController vc: UIViewController) {
+        let leftButtonImage: UIImage!
+        if #available(iOS 13.0, *) {
+            leftButtonImage = UIImage(systemName: "xmark", withConfiguration: UIImage.SymbolConfiguration(weight: .regular))
+        } else {
+            leftButtonImage = UIImage(named: "close")
+        }
+        
+        vc.navigationItem.leftBarButtonItem = UIBarButtonItem(image: leftButtonImage, style: .plain, target: self, action: #selector(closeButtonAction(_:)))
+    }
+    
+    @objc private func closeButtonAction(_ sender: Any) {
+        filePreviewNavDelegate?.filePreviewNavigationControllerWillClose(self, hasChanges: hasChanges)
+        
+        if let topVC = topViewController as? FilePreviewViewController {
+            topVC.willClose()
+        } else if let topVC = topViewController as? FileDetailsViewController {
+            topVC.willClose()
+        }
+        
+        dismiss(animated: true, completion: nil)
+    }
+
+}

--- a/Permanent/ViewControllers/FilePreviewViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewViewController.swift
@@ -24,46 +24,20 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         super.viewDidLoad()
         initUI()
         
-        viewModel = FilePreviewViewModel(file: file)
+        showSpinner()
+        if viewModel == nil {
+            viewModel = FilePreviewViewModel(file: file)
+            
+            viewModel?.getRecord(file: file, then: { record in
+                self.loadRecord()
+            })
+        } else {
+            loadRecord()
+        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
-        showSpinner()
-        
-        viewModel?.getRecord(file: file, then: { record in
-            guard let fileVO = self.viewModel?.fileVO(),
-                  let fileName = self.viewModel?.fileName()
-            else {
-                return
-            }
-                  
-            if let localURL = self.fileHelper.url(forFileNamed: fileName),
-               let contentType = fileVO.contentType {
-                switch self.file.type {
-                case FileType.image:
-                    self.loadImage(withURL: localURL, contentType: contentType)
-                case FileType.video:
-                    self.loadVideo(withURL: localURL, contentType: contentType)
-                default:
-                    self.loadMisc(withURL: localURL)
-                }
-            } else if let downloadURLString = fileVO.downloadURL,
-                      let contentType = fileVO.contentType,
-                      let downloadURL = URL(string: downloadURLString) {
-                switch self.file.type {
-                case FileType.image:
-                    self.loadImage(withURL: downloadURL, contentType: contentType)
-                case FileType.video:
-                    self.loadVideo(withURL: downloadURL, contentType: contentType)
-                default:
-                    self.loadMisc(withURL: downloadURL)
-                }
-            } else {
-                self.showErrorAlert(message: .errorMessage)
-            }
-        })
     }
 
     func initUI() {
@@ -73,14 +47,6 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         
         let infoButton = UIBarButtonItem(image: .info, style: .plain, target: self, action: #selector(infoButtonAction(_:)))
         navigationItem.rightBarButtonItems = [shareButton, infoButton]
-
-        let leftButtonImage: UIImage!
-        if #available(iOS 13.0, *) {
-            leftButtonImage = UIImage(systemName: "xmark", withConfiguration: UIImage.SymbolConfiguration(weight: .regular))
-        } else {
-            leftButtonImage = UIImage(named: "close")
-        }
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: leftButtonImage, style: .plain, target: self, action: #selector(closeButtonAction(_:)))
         
         navigationItem.title = file.name
     }
@@ -102,7 +68,44 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         return webView
     }
     
+    func willClose() {
+        removeVideoPlayer()
+    }
+    
     // MARK: - Load methods
+    func loadRecord() {
+        guard let fileVO = self.viewModel?.fileVO(),
+              let fileName = self.viewModel?.fileName()
+        else {
+            return
+        }
+        
+        if let localURL = self.fileHelper.url(forFileNamed: fileName),
+           let contentType = fileVO.contentType {
+            switch self.file.type {
+            case FileType.image:
+                self.loadImage(withURL: localURL, contentType: contentType)
+            case FileType.video:
+                self.loadVideo(withURL: localURL, contentType: contentType)
+            default:
+                self.loadMisc(withURL: localURL)
+            }
+        } else if let downloadURLString = fileVO.downloadURL,
+                  let contentType = fileVO.contentType,
+                  let downloadURL = URL(string: downloadURLString) {
+            switch self.file.type {
+            case FileType.image:
+                self.loadImage(withURL: downloadURL, contentType: contentType)
+            case FileType.video:
+                self.loadVideo(withURL: downloadURL, contentType: contentType)
+            default:
+                self.loadMisc(withURL: downloadURL)
+            }
+        } else {
+            self.showErrorAlert(message: .errorMessage)
+        }
+    }
+    
     func loadImage(withURL url: URL, contentType: String, size: CGSize = .zero) {
         let imagePreviewVC = ImagePreviewViewController()
         addChild(imagePreviewVC)
@@ -189,16 +192,11 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         
         let fileDetailsVC = UIViewController.create(withIdentifier: .fileDetailsOnTap , from: .main) as! FileDetailsViewController
         fileDetailsVC.file = file
+        fileDetailsVC.viewModel = viewModel
         
-        navigationController?.setViewControllers([fileDetailsVC], animated: true)
+        navigationController?.setViewControllers([fileDetailsVC], animated: false)
     }
 
-    @objc private func closeButtonAction(_ sender: Any) {
-        removeVideoPlayer()
-        
-        dismiss(animated: true, completion: nil)
-    }
-    
     // MARK: - KVO
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         guard context == &playerItemContext else {

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -474,8 +474,8 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
             let fileDetailsVC = UIViewController.create(withIdentifier: .filePreview , from: .main) as! FilePreviewViewController
             fileDetailsVC.file = file
             
-            let fileDetailsNavigationController = UINavigationController(rootViewController: fileDetailsVC)
-            
+            let fileDetailsNavigationController = FilePreviewNavigationController(rootViewController: fileDetailsVC)
+            fileDetailsNavigationController.filePreviewNavDelegate = self
             fileDetailsNavigationController.modalPresentationStyle = .fullScreen
             present(fileDetailsNavigationController, animated: true)
         }
@@ -814,7 +814,6 @@ extension MainViewController: FABActionSheetDelegate {
 }
 
 // MARK: - Document Picker Delegate
-
 extension MainViewController: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         guard let currentFolder = viewModel?.currentFolder else {
@@ -825,6 +824,7 @@ extension MainViewController: UIDocumentPickerDelegate {
     }
 }
 
+// MARK: - MediaRecorderDelegate
 extension MainViewController: MediaRecorderDelegate {
     func didSelect(url: URL?) {
         guard
@@ -840,6 +840,7 @@ extension MainViewController: MediaRecorderDelegate {
     }
 }
 
+// MARK: - FileActionSheetDelegate
 extension MainViewController: FileActionSheetDelegate {
     func share(file: FileViewModel) {
         guard
@@ -873,9 +874,20 @@ extension MainViewController: FileActionSheetDelegate {
     }
 }
 
+// MARK: - SortActionSheetDelegate
 extension MainViewController: SortActionSheetDelegate {
     func didSelectOption(_ option: SortOption) {
         viewModel?.activeSortOption = option
         refreshCurrentFolder()
     }
 }
+
+// MARK: - FilePreviewNavigationControllerDelegate
+extension MainViewController: FilePreviewNavigationControllerDelegate {
+    func filePreviewNavigationControllerWillClose(_ filePreviewNavigationVC: FilePreviewNavigationController, hasChanges: Bool) {
+        if hasChanges {
+            refreshCurrentFolder()
+        }
+    }
+}
+

--- a/Permanent/ViewControllers/SharesViewController.swift
+++ b/Permanent/ViewControllers/SharesViewController.swift
@@ -312,6 +312,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
     }
 }
 
+// MARK: - UITableViewDelegate, UITableViewDataSource
 extension SharesViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel?.viewModels.count ?? 0
@@ -352,8 +353,10 @@ extension SharesViewController: UITableViewDelegate, UITableViewDataSource {
             let filePreviewVC = UIViewController.create(withIdentifier: .filePreview, from: .main) as! FilePreviewViewController
             filePreviewVC.file = file
             
-            let previewNavigationController = UINavigationController(rootViewController: filePreviewVC)
-            navigationController?.display(viewController: previewNavigationController,modally: true)
+            let fileDetailsNavigationController = FilePreviewNavigationController(rootViewController: filePreviewVC)
+            fileDetailsNavigationController.filePreviewNavDelegate = self
+            fileDetailsNavigationController.modalPresentationStyle = .fullScreen
+            present(fileDetailsNavigationController, animated: true)
         }
     }
     
@@ -370,8 +373,18 @@ extension SharesViewController: UITableViewDelegate, UITableViewDataSource {
     }
 }
 
+// MARK: - SharedFileActionSheetDelegate
 extension SharesViewController: SharedFileActionSheetDelegate {
     func downloadAction(file: FileViewModel) {
         download(file)
+    }
+}
+
+// MARK: - FilePreviewNavigationControllerDelegate
+extension SharesViewController: FilePreviewNavigationControllerDelegate {
+    func filePreviewNavigationControllerWillClose(_ filePreviewNavigationVC: FilePreviewNavigationController, hasChanges: Bool) {
+        if hasChanges {
+            refreshCurrentFolder()
+        }
     }
 }

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsTopCollectionViewCell.swift
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsTopCollectionViewCell.swift
@@ -10,6 +10,7 @@ import UIKit
 class FileDetailsTopCollectionViewCell: UICollectionViewCell {
     
     @IBOutlet var imageView: UIImageView!
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     
     var imageLoadedCallback: ((FileDetailsTopCollectionViewCell) -> Void)?
     
@@ -20,11 +21,15 @@ class FileDetailsTopCollectionViewCell: UICollectionViewCell {
     }
 
     func configure(with urlString: String) {
-        imageView.image = .placeholder
+        activityIndicator.startAnimating()
+        
+        imageView.image = nil
         imageView.load(urlString: urlString) { _ in
             if let imageLoadedCallback = self.imageLoadedCallback {
                 imageLoadedCallback(self)
             }
+            
+            self.activityIndicator.stopAnimating()
         }
     }
     

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsTopCollectionViewCell.xib
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsTopCollectionViewCell.xib
@@ -11,28 +11,37 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="FileDetailsTopCollectionViewCell" id="gTV-IL-0wX" customClass="FileDetailsTopCollectionViewCell" customModule="Permanent" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+            <rect key="frame" x="0.0" y="0.0" width="264" height="146"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                <rect key="frame" x="0.0" y="0.0" width="264" height="146"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="EmW-B1-oIz">
-                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                        <rect key="frame" x="0.0" y="0.0" width="264" height="146"/>
                     </imageView>
+                    <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" hidesWhenStopped="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="1V0-Df-UKj">
+                        <rect key="frame" x="122" y="63" width="20" height="20"/>
+                        <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </activityIndicatorView>
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
+                <constraint firstItem="1V0-Df-UKj" firstAttribute="centerY" secondItem="ZTg-uK-7eu" secondAttribute="centerY" id="MeO-sn-h2c"/>
                 <constraint firstItem="EmW-B1-oIz" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="Rib-SA-oon"/>
                 <constraint firstAttribute="bottom" secondItem="EmW-B1-oIz" secondAttribute="bottom" id="VPh-yM-Oqc"/>
+                <constraint firstItem="1V0-Df-UKj" firstAttribute="centerX" secondItem="ZTg-uK-7eu" secondAttribute="centerX" id="ePg-gN-RiU"/>
                 <constraint firstAttribute="trailing" secondItem="EmW-B1-oIz" secondAttribute="trailing" id="wDa-3N-Reb"/>
                 <constraint firstItem="EmW-B1-oIz" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="xJs-vr-cyg"/>
             </constraints>
+            <size key="customSize" width="264" height="146"/>
             <connections>
+                <outlet property="activityIndicator" destination="1V0-Df-UKj" id="kiI-mg-BYJ"/>
                 <outlet property="imageView" destination="EmW-B1-oIz" id="P4F-Z6-cws"/>
             </connections>
-            <point key="canvasLocation" x="-46" y="86"/>
+            <point key="canvasLocation" x="108.69565217391305" y="117.85714285714285"/>
         </collectionViewCell>
     </objects>
 </document>


### PR DESCRIPTION
- created custom navigation controller for file preview screens
- file preview navigation has delegate to main/shares screen
- file details notifies file preview navigation when a change occured
- file preview navigation notifies main/shares when a change occured in order to reload data.
- file preview and file details now share the same instance of view model, in order to reduce loading time when navigating between the two screens