### PR TITLE
VSP-296 [iOS] Tag section height is not correct for long tags in the File Details Screen

### DIFF
--- a/Permanent/Storyboards/Main.storyboard
+++ b/Permanent/Storyboards/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3PZ-n9-y83">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="3PZ-n9-y83">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -116,7 +116,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="42G-RC-aoy">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="70.5"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="70.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="My archive" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iq0-2Q-Eqk" userLabel="Title Label">
                                         <rect key="frame" x="20" y="10" width="82.5" height="20.5"/>
@@ -140,7 +140,7 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="frN-Y0-fth">
-                                <rect key="frame" x="0.0" y="70.5" width="600" height="529.5"/>
+                                <rect key="frame" x="0.0" y="114.5" width="414" height="747.5"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="9WN-xr-ona" id="pt8-m2-Erl"/>
@@ -179,17 +179,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="omS-9f-CUF" userLabel="Sheet View">
-                                <rect key="frame" x="0.0" y="478" width="600" height="122"/>
+                                <rect key="frame" x="0.0" y="740" width="414" height="122"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DRf-8Z-8AG">
-                                        <rect key="frame" x="20" y="26" width="560" height="70"/>
+                                        <rect key="frame" x="20" y="26" width="374" height="70"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qjy-La-xkC" userLabel="Upload Button" customClass="RoundedButton" customModule="Permanent" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="560" height="30"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="374" height="30"/>
                                                 <state key="normal" title="Button"/>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="POQ-5N-4NZ" userLabel="New Folder Button" customClass="RoundedButton" customModule="Permanent" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="40" width="560" height="30"/>
+                                                <rect key="frame" x="0.0" y="40" width="374" height="30"/>
                                                 <state key="normal" title="Button"/>
                                             </button>
                                         </subviews>
@@ -246,7 +246,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" keyboardDismissMode="onDrag" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="hg6-6n-Slu">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="obu-zM-U3y">
                                     <size key="itemSize" width="128" height="128"/>
@@ -296,10 +296,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="y2M-Jn-8xg">
-                                <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                             </mapView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="hYK-Iv-vz3" customClass="AutoCompletionTextField">
-                                <rect key="frame" x="5" y="5" width="590" height="45"/>
+                                <rect key="frame" x="5" y="49" width="404" height="45"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="GfC-be-zGR"/>
                                 </constraints>
@@ -342,14 +342,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="sal-mZ-q0y">
-                                <rect key="frame" x="12" y="0.0" width="478" height="56"/>
+                                <rect key="frame" x="12" y="44" width="292" height="56"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="YJ0-am-f1E"/>
                                 </constraints>
                                 <textInputTraits key="textInputTraits" returnKeyType="done"/>
                             </searchBar>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ern-RS-tpK" customClass="RoundedButton" customModule="Permanent" customModuleProvider="target">
-                                <rect key="frame" x="495" y="10" width="90" height="36"/>
+                                <rect key="frame" x="309" y="54" width="90" height="36"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="TWt-K2-FtU"/>
                                     <constraint firstAttribute="width" constant="90" id="jrb-pb-yfL"/>
@@ -360,7 +360,7 @@
                                 </connections>
                             </button>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="GvI-GM-dz5">
-                                <rect key="frame" x="22" y="56" width="558" height="544"/>
+                                <rect key="frame" x="22" y="100" width="372" height="762"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="pdU-en-vQb">
                                     <size key="itemSize" width="128" height="128"/>
@@ -405,6 +405,20 @@
             <point key="canvasLocation" x="2823" y="1632"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="Ern-RS-tpK">
+            <size key="intrinsicContentSize" width="46" height="30"/>
+        </designable>
+        <designable name="POQ-5N-4NZ">
+            <size key="intrinsicContentSize" width="46" height="30"/>
+        </designable>
+        <designable name="hYK-Iv-vz3">
+            <size key="intrinsicContentSize" width="32" height="34"/>
+        </designable>
+        <designable name="qjy-La-xkC">
+            <size key="intrinsicContentSize" width="46" height="30"/>
+        </designable>
+    </designables>
     <resources>
         <image name="chevron.left" catalog="system" width="96" height="128"/>
         <systemColor name="systemBackgroundColor">

--- a/Permanent/ViewControllers/FileDetailsViewController.swift
+++ b/Permanent/ViewControllers/FileDetailsViewController.swift
@@ -330,11 +330,22 @@ extension FileDetailsViewController: UICollectionViewDelegateFlowLayout {
                 return CGSize(width: UIScreen.main.bounds.width, height: 65)
             }
         case .tags:
-            let cellHeight: CGFloat = 40
-            let countTags = viewModel?.recordVO?.recordVO?.tagVOS?.count ?? 0
-            //Logic for cell height: for being able to show only 2.5 lines when there are more then 3 tags associated to current file
-            let cellHeightByTagsNumber :CGFloat = CGFloat(( countTags > 3 ) ? ( (cellHeight * 3) + 13 ) : ( cellHeight * 2 ))
-            return CGSize(width: UIScreen.main.bounds.width, height: cellHeightByTagsNumber)
+            let tagLabelCellHeight: CGFloat = 45
+            let tagCellHeight: CGFloat = 38
+            let collectionViewWidthConstrains: CGFloat = 45.0
+            let tagAdditionalSpacing: CGFloat = 40
+            
+            //Logic for cell height: for being able to show only 2.5 lines when there are more then 3 tags associated to current fill
+            let tagsName: [String] = viewModel?.recordVO?.recordVO?.tagVOS?.compactMap({ $0.name}) ?? []
+            
+            let tagsWidth = tagsName.map({ NSAttributedString(string: $0, attributes: [NSAttributedString.Key.font: Text.style8.font as Any]) }).map({($0.boundingRect(with: CGSize(width: collectionView.bounds.width, height: 30), options: [], context: nil).size.width) + tagAdditionalSpacing })
+            let tagsWidthSum = tagsWidth.reduce(0, +) + collectionViewWidthConstrains
+            let dividedTagsWidthBySreenWidth: CGFloat = (tagsWidthSum / view.frame.width).rounded(.up)
+
+            //Set tags cell height in regard with screen width and total tag cells width
+            let cellHeightByTagsWidth :CGFloat = CGFloat((dividedTagsWidthBySreenWidth > 1) ? ((tagLabelCellHeight + (dividedTagsWidthBySreenWidth + 1) * tagCellHeight )) : (tagLabelCellHeight + tagCellHeight ))
+
+            return CGSize(width: UIScreen.main.bounds.width, height: cellHeightByTagsWidth)
         default:
             return CGSize(width: UIScreen.main.bounds.width, height: 65)
         }

--- a/Permanent/ViewControllers/FileDetailsViewController.swift
+++ b/Permanent/ViewControllers/FileDetailsViewController.swift
@@ -333,7 +333,7 @@ extension FileDetailsViewController: UICollectionViewDelegateFlowLayout {
             let tagLabelCellHeight: CGFloat = 45
             let tagCellHeight: CGFloat = 38
             let collectionViewWidthConstrains: CGFloat = 45.0
-            let tagAdditionalSpacing: CGFloat = 40
+            let tagAdditionalSpacing: CGFloat = 37
             
             //Logic for cell height: for being able to show only 2.5 lines when there are more then 3 tags associated to current fill
             let tagsName: [String] = viewModel?.recordVO?.recordVO?.tagVOS?.compactMap({ $0.name}) ?? []
@@ -343,7 +343,7 @@ extension FileDetailsViewController: UICollectionViewDelegateFlowLayout {
             let dividedTagsWidthBySreenWidth: CGFloat = (tagsWidthSum / view.frame.width).rounded(.up)
 
             //Set tags cell height in regard with screen width and total tag cells width
-            let cellHeightByTagsWidth :CGFloat = CGFloat((dividedTagsWidthBySreenWidth > 1) ? ((tagLabelCellHeight + (dividedTagsWidthBySreenWidth + 1) * tagCellHeight )) : (tagLabelCellHeight + tagCellHeight ))
+            let cellHeightByTagsWidth :CGFloat = tagLabelCellHeight + (dividedTagsWidthBySreenWidth + 1) * tagCellHeight
 
             return CGSize(width: UIScreen.main.bounds.width, height: cellHeightByTagsWidth)
         default:

--- a/Permanent/ViewControllers/FileDetailsViewController.swift
+++ b/Permanent/ViewControllers/FileDetailsViewController.swift
@@ -337,20 +337,44 @@ extension FileDetailsViewController: UICollectionViewDelegateFlowLayout {
                 return CGSize(width: UIScreen.main.bounds.width, height: 65)
             }
         case .tags:
-            let tagLabelCellHeight: CGFloat = 45
-            let tagCellHeight: CGFloat = 38
+            /*
+             | - ( tag1 ) - (tag 2) - (tag abc) - |
+             | - (aaa) - (bbbv) - (cccc) - |
+             | - (aaa) - (bbbv) - (cccc) - |
+             */
+            
+            // Title label height + bottom spacing
+            let tagLabelCellHeight: CGFloat = 30
+            let tagCellHeight: CGFloat = 35
             let collectionViewWidthConstrains: CGFloat = 45.0
-            let tagAdditionalSpacing: CGFloat = 37
             
-            //Logic for cell height: for being able to show only 2.5 lines when there are more then 3 tags associated to current fill
-            let tagsName: [String] = viewModel?.recordVO?.recordVO?.tagVOS?.compactMap({ $0.name}) ?? []
+            // See TagsNamesCollectionViewCell for more info. 20 extra spacing in chip + 5 interitem spacing.
+            let tagAdditionalSpacing: CGFloat = 20 + 5
             
-            let tagsWidth = tagsName.map({ NSAttributedString(string: $0, attributes: [NSAttributedString.Key.font: Text.style8.font as Any]) }).map({($0.boundingRect(with: CGSize(width: collectionView.bounds.width, height: 30), options: [], context: nil).size.width) + tagAdditionalSpacing })
-            let tagsWidthSum = tagsWidth.reduce(0, +) + collectionViewWidthConstrains
-            let dividedTagsWidthBySreenWidth: CGFloat = (tagsWidthSum / view.frame.width).rounded(.up)
-
+            let tagsName: [String] = viewModel?.recordVO?.recordVO?.tagVOS?.compactMap { $0.name } ?? []
+            
+            let tagsWidth = tagsName.map {
+                NSAttributedString(string: $0, attributes: [NSAttributedString.Key.font: Text.style8.font as Any])
+            }.map {
+                $0.boundingRect(with: CGSize(width: collectionView.bounds.width, height: 30), options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).size.width.rounded(.up) + tagAdditionalSpacing
+            }
+            
+            var currentRowWidth: CGFloat = 0
+            var currentRowCount: Int = 0
+            tagsWidth.forEach { (width) in
+                if currentRowWidth + width > (view.frame.width - collectionViewWidthConstrains) {
+                    currentRowWidth = width
+                    currentRowCount += 1
+                } else {
+                    if currentRowCount == 0 {
+                        currentRowCount += 1
+                    }
+                    currentRowWidth += width
+                }
+            }
+           
             //Set tags cell height in regard with screen width and total tag cells width
-            let cellHeightByTagsWidth :CGFloat = tagLabelCellHeight + (dividedTagsWidthBySreenWidth + 1) * tagCellHeight
+            let cellHeightByTagsWidth :CGFloat = tagLabelCellHeight + CGFloat(currentRowCount) * tagCellHeight
 
             return CGSize(width: UIScreen.main.bounds.width, height: cellHeightByTagsWidth)
         default:

--- a/Permanent/ViewControllers/TagDetailsViewController.swift
+++ b/Permanent/ViewControllers/TagDetailsViewController.swift
@@ -21,6 +21,7 @@ struct SortedTagVO {
 class TagDetailsViewController: BaseViewController<FilePreviewViewModel> {
     
     var file: FileViewModel!
+    let maximumNumberOfCharactersForTagName: Int = 24
 
     weak var delegate: TagDetailsViewControllerDelegate?
     
@@ -232,5 +233,9 @@ extension TagDetailsViewController: UISearchBarDelegate {
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         addTagButtonAction(searchBar)
+    }
+    func searchBar(_ searchBar: UISearchBar, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if range.location >= maximumNumberOfCharactersForTagName { return false }
+        return true
     }
 }

--- a/Permanent/ViewControllers/TagDetailsViewController.swift
+++ b/Permanent/ViewControllers/TagDetailsViewController.swift
@@ -21,7 +21,7 @@ struct SortedTagVO {
 class TagDetailsViewController: BaseViewController<FilePreviewViewModel> {
     
     var file: FileViewModel!
-    let maximumNumberOfCharactersForTagName: Int = 24
+    let maximumNumberOfCharactersForTagName: Int = 16
 
     weak var delegate: TagDetailsViewControllerDelegate?
     

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/TagsNamesCollectionViewCell.swift
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/TagsNamesCollectionViewCell.swift
@@ -89,9 +89,9 @@ extension TagsNamesCollectionViewCell: UICollectionViewDelegateFlowLayout, UICol
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let name = tagNames[indexPath.row]
-        let attributedName = NSAttributedString(string: name, attributes: [NSAttributedString.Key.font: cellTitleLabel.font as Any])
-        let width = attributedName.boundingRect(with: CGSize(width: collectionView.bounds.width, height: 30), options: [], context: nil).size.width
+        let attributedName = NSAttributedString(string: name, attributes: [NSAttributedString.Key.font: Text.style8.font as Any])
+        let width = attributedName.boundingRect(with: CGSize(width: collectionView.bounds.width, height: 30), options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).size.width.rounded(.up)
         
-        return CGSize(width: 15 + width , height: 30)
+        return CGSize(width: 20 + width , height: 30)
     }
 }

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/TagsNamesCollectionViewCell.xib
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/TagsNamesCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -26,6 +26,9 @@
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ymb-mZ-cg3">
                         <rect key="frame" x="20" y="0.0" width="379" height="21"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="25" id="1rr-PI-Uf9"/>
+                        </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/TagsNamesCollectionViewCell.xib
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/TagsNamesCollectionViewCell.xib
@@ -31,7 +31,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" semanticContentAttribute="forceLeftToRight" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="tIw-Ir-hjd">
-                        <rect key="frame" x="20" y="26" width="379" height="448"/>
+                        <rect key="frame" x="20" y="26" width="379" height="463"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="F2B-Rc-gzj">
                             <size key="itemSize" width="128" height="128"/>
@@ -44,7 +44,7 @@
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="tIw-Ir-hjd" secondAttribute="bottom" constant="15" id="BEb-SF-3KV"/>
+                <constraint firstAttribute="bottom" secondItem="tIw-Ir-hjd" secondAttribute="bottom" id="BEb-SF-3KV"/>
                 <constraint firstItem="KNA-Oe-skc" firstAttribute="top" secondItem="Ymb-mZ-cg3" secondAttribute="bottom" constant="10" id="KVZ-H2-Ql8"/>
                 <constraint firstItem="Ymb-mZ-cg3" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="QIw-Nj-cAL"/>
                 <constraint firstAttribute="trailing" secondItem="KNA-Oe-skc" secondAttribute="trailing" constant="20" id="Y5c-I6-fRH"/>


### PR DESCRIPTION
The following were implemented : 
 - [iOS] Tag section height is not correct for long tags in the File Details Screen
 - [iOS] Show all tags in meta data detail page
 - Added a maximum limit of 24 characters for tag name.