### PR TITLE
VSP-528 Add migration for multiple archives model

### DIFF
--- a/Permanent/Constants/Constants.swift
+++ b/Permanent/Constants/Constants.swift
@@ -149,4 +149,5 @@ extension Constants.Keys.StorageKeys {
     static let signUpNameStorageKey = "signUpNameStorageKey"
     static let archive = "archive"
     static let defaultArchiveId = "defaultArchiveId"
+    static let modelVersion = "modelVersion"
 }

--- a/Permanent/ViewControllers/SplashViewController.swift
+++ b/Permanent/ViewControllers/SplashViewController.swift
@@ -38,6 +38,11 @@ class SplashViewController: BaseViewController<SplashViewModel> {
     }
 
     fileprivate func handleAuthState(_ status: AuthStatus) {
+        guard PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.modelVersion) ?? 0 >= 1 else {
+            handleLoggedOutState()
+            return
+        }
+        
         switch status {
         case .loggedIn:
             let authStatus = PermanentLocalAuthentication.instance.canAuthenticate()

--- a/Permanent/ViewModels/AuthViewModel.swift
+++ b/Permanent/ViewModels/AuthViewModel.swift
@@ -253,6 +253,8 @@ class AuthViewModel: ViewModelInterface {
     }
 
     fileprivate func saveStorageData(_ response: LoginResponse) {
+        PreferencesManager.shared.set(1, forKey: Constants.Keys.StorageKeys.modelVersion)
+        
         if let email = response.results?.first?.data?.first?.accountVO?.primaryEmail {
             PreferencesManager.shared.set(email, forKey: Constants.Keys.StorageKeys.emailStorageKey)
         }


### PR DESCRIPTION
- add model version storage
- check the version before authentication in order to logout the user if they have a previous version of the model
- save model version after a successful login
