### PR TITLE
VSP-545 [iOS] When having a single archive, do not show change archive button in Share Preview Screen

### DIFF
--- a/Permanent/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
+++ b/Permanent/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
@@ -35,7 +35,7 @@ class SharePreviewViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+    
         configureUI()
         setupCollectionView()
         viewModel.start()
@@ -92,6 +92,13 @@ class SharePreviewViewController: UIViewController {
             
             currentArchiveName.text = "The <ARCHIVE_NAME> Archive".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: archiveName)
         }
+        
+        viewModel.updateAccountArchives { [self] in
+            if let accountArchives = viewModel.accountArchives,
+               accountArchives.count == 1 {
+                currentArchiveContainer.isHidden = true
+            }
+        }
     }
     
     fileprivate func setupCollectionView() {
@@ -130,6 +137,7 @@ class SharePreviewViewController: UIViewController {
         let archivesVC = UIViewController.create(withIdentifier: .archives, from: .archives) as! ArchivesViewController
         archivesVC.delegate = self
         archivesVC.isManaging = false
+        archivesVC.accountArchives = self.viewModel.accountArchives
         
         let navController = NavigationController(rootViewController: archivesVC)
         present(navController, animated: true, completion: nil)

--- a/Permanent/Scenes/Share Preview/ViewModels/SharePreviewViewModelDelegate.swift
+++ b/Permanent/Scenes/Share Preview/ViewModels/SharePreviewViewModelDelegate.swift
@@ -17,13 +17,17 @@ protocol SharePreviewViewModelDelegate {
     
     var numberOfItems: Int { get }
     
-    func itemFor(row: Int) -> File 
+    func itemFor(row: Int) -> File
+    
+    var accountArchives: [ArchiveVOData]? { get }
     
     // Events
     
     func start()
     
     func performAction()
+    
+    func updateAccountArchives(completion: @escaping () -> ())
     
     var isBusy: Bool { get }
         

--- a/Permanent/ViewControllers/ArchivesViewController.swift
+++ b/Permanent/ViewControllers/ArchivesViewController.swift
@@ -24,6 +24,8 @@ class ArchivesViewController: BaseViewController<ArchivesViewModel> {
     weak var delegate: ArchivesViewControllerDelegate?
     var isManaging = true
     
+    var accountArchives : [ArchiveVOData]?
+    
     private let overlayView = UIView()
     private var tableViewSections: [ArchiveVOData.Status] = []
     
@@ -199,14 +201,23 @@ class ArchivesViewController: BaseViewController<ArchivesViewModel> {
         
         viewModel?.getAccountInfo({ [self] account, error in
             if error == nil {
-                viewModel?.getAccountArchives { [self] accountArchives, error in
+                if let currentArchives = self.accountArchives {
                     hideSpinner()
                     
-                    if error == nil {
-                        tableView.reloadData()
-                        updateCurrentArchive()
-                    } else {
-                        showAlert(title: .error, message: .errorMessage)
+                    viewModel?.allArchives = currentArchives
+                    self.accountArchives = nil
+                    tableView.reloadData()
+                    updateCurrentArchive()
+                } else {
+                    viewModel?.getAccountArchives { [self] accountArchives, error in
+                        hideSpinner()
+                        
+                        if error == nil {
+                            tableView.reloadData()
+                            updateCurrentArchive()
+                        } else {
+                            showAlert(title: .error, message: .errorMessage)
+                        }
                     }
                 }
             } else {

--- a/Permanent/ViewModels/ArchivesViewModel.swift
+++ b/Permanent/ViewModels/ArchivesViewModel.swift
@@ -112,7 +112,7 @@ class ArchivesViewModel: ViewModelInterface {
                 let accountArchives = model.results.first?.data
                 
                 self.allArchives.removeAll()
-                accountArchives?.forEach{ archive in
+                accountArchives?.forEach { archive in
                     if let archiveVOData = archive.archiveVO, archiveVOData.status != .pending || archiveVOData.status != .unknown {
                         self.allArchives.append(archiveVOData)
                     }


### PR DESCRIPTION
Implemented hide "Change archive" button in Share preview screen if the user have only one archive.