### PR TITLE
VSP-557 [iOS] The archive manager is not accessible when using a public archive

### DIFF
--- a/Permanent/Models/Data/ArchiveVO.swift
+++ b/Permanent/Models/Data/ArchiveVO.swift
@@ -37,7 +37,8 @@ struct ArchiveVOData: Model {
     let birthDay, company, archiveVODescription: JSONAny?
     let archiveID: Int?
     let publicDT, archiveNbr: String?
-    let archiveVOPublic, view, viewProperty: JSONAny?
+    let view, viewProperty: JSONAny?
+    let archiveVOPublic: Int?
     let vaultKey: String?
     let thumbArchiveNbr: JSONAny?
     let type, thumbStatus: String?

--- a/Permanent/ViewModels/AuthViewModel.swift
+++ b/Permanent/ViewModels/AuthViewModel.swift
@@ -279,7 +279,11 @@ class AuthViewModel: ViewModelInterface {
     }
     
     func setCurrentArchive(_ archive: ArchiveVOData) {
-        try? PreferencesManager.shared.setCodableObject(archive, forKey: Constants.Keys.StorageKeys.archive)
+        do {
+            try PreferencesManager.shared.setCodableObject(archive, forKey: Constants.Keys.StorageKeys.archive)
+        } catch {
+            print(error)
+        }
     }
     
     func getCurrentArchive() -> ArchiveVOData? {


### PR DESCRIPTION
## ArchiveVO:
- changed the type of archiveVOPublic to the correct one

## AuthVM:
- added basic error handling when saving an archive
