### PR TITLE
VSP-558 [iOS] Migrate to iOS 15

### DIFF
--- a/Permanent/Scenes/PhotoPicker/AlbumsViewController.swift
+++ b/Permanent/Scenes/PhotoPicker/AlbumsViewController.swift
@@ -36,13 +36,27 @@ class AlbumsViewController: UICollectionViewController, UICollectionViewDelegate
     }
     
     func styleNavBar() {
-        navigationController?.navigationBar.barTintColor = .darkBlue
-        navigationController?.navigationBar.isTranslucent = false
-        navigationController?.navigationBar.titleTextAttributes = [
-            .foregroundColor: UIColor.white,
-            .font: Text.style14.font
-        ]
         navigationController?.navigationBar.tintColor = .white
+        
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = .darkBlue
+            appearance.titleTextAttributes = [
+                .foregroundColor: UIColor.white,
+                .font: Text.style14.font
+            ]
+            
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
+        } else {
+            navigationController?.navigationBar.barTintColor = .darkBlue
+            navigationController?.navigationBar.isTranslucent = false
+            navigationController?.navigationBar.titleTextAttributes = [
+                .foregroundColor: UIColor.white,
+                .font: Text.style14.font
+            ]
+        }
     }
     
     /// - Tag: UnregisterChangeObserver

--- a/Permanent/Scenes/PhotoPicker/AssetGridViewController.swift
+++ b/Permanent/Scenes/PhotoPicker/AssetGridViewController.swift
@@ -140,13 +140,27 @@ class AssetGridViewController: UICollectionViewController {
     }
     
     func styleNavBar() {
-        navigationController?.navigationBar.barTintColor = .darkBlue
-        navigationController?.navigationBar.isTranslucent = false
-        navigationController?.navigationBar.titleTextAttributes = [
-            .foregroundColor: UIColor.white,
-            .font: Text.style14.font
-        ]
         navigationController?.navigationBar.tintColor = .white
+        
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = .darkBlue
+            appearance.titleTextAttributes = [
+                .foregroundColor: UIColor.white,
+                .font: Text.style14.font
+            ]
+            
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
+        } else {
+            navigationController?.navigationBar.barTintColor = .darkBlue
+            navigationController?.navigationBar.isTranslucent = false
+            navigationController?.navigationBar.titleTextAttributes = [
+                .foregroundColor: UIColor.white,
+                .font: Text.style14.font
+            ]
+        }
     }
     
     @IBAction func dismissButtonPressed(_ sender: Any) {

--- a/Permanent/ViewControllers/BaseViewController.swift
+++ b/Permanent/ViewControllers/BaseViewController.swift
@@ -41,13 +41,27 @@ class BaseViewController<T: ViewModelInterface>: UIViewController {
     }
     
     func styleNavBar() {
-        navigationController?.navigationBar.barTintColor = .darkBlue
-        navigationController?.navigationBar.isTranslucent = false
-        navigationController?.navigationBar.titleTextAttributes = [
-            .foregroundColor: UIColor.white,
-            .font: Text.style14.font
-        ]
         navigationController?.navigationBar.tintColor = .white
+        
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = .darkBlue
+            appearance.titleTextAttributes = [
+                .foregroundColor: UIColor.white,
+                .font: Text.style14.font
+            ]
+            
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
+        } else {
+            navigationController?.navigationBar.barTintColor = .darkBlue
+            navigationController?.navigationBar.isTranslucent = false
+            navigationController?.navigationBar.titleTextAttributes = [
+                .foregroundColor: UIColor.white,
+                .font: Text.style14.font
+            ]
+        }
     }
     
     func closeKeyboard() {

--- a/Permanent/ViewControllers/FileDetailsViewController.swift
+++ b/Permanent/ViewControllers/FileDetailsViewController.swift
@@ -113,7 +113,12 @@ class FileDetailsViewController: BaseViewController<FilePreviewViewModel> {
     override func styleNavBar() {
         super.styleNavBar()
         
-        navigationController?.navigationBar.barTintColor = .black
+        if #available(iOS 13.0, *) {
+            navigationController?.navigationBar.standardAppearance.backgroundColor = .black
+            navigationController?.navigationBar.scrollEdgeAppearance?.backgroundColor = .black
+        } else {
+            navigationController?.navigationBar.barTintColor = .black
+        }
     }
     
     @objc private func shareButtonAction(_ sender: Any) {

--- a/Permanent/ViewControllers/FilePreviewViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewViewController.swift
@@ -101,7 +101,12 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     override func styleNavBar() {
         super.styleNavBar()
         
-        navigationController?.navigationBar.barTintColor = .black
+        if #available(iOS 13.0, *) {
+            navigationController?.navigationBar.standardAppearance.backgroundColor = .black
+            navigationController?.navigationBar.scrollEdgeAppearance?.backgroundColor = .black
+        } else {
+            navigationController?.navigationBar.barTintColor = .black
+        }
     }
     
     func setupWebView() -> WKWebView {

--- a/Permanent/ViewControllers/LocationSetViewController.swift
+++ b/Permanent/ViewControllers/LocationSetViewController.swift
@@ -54,7 +54,12 @@ class LocationSetViewController: BaseViewController<FilePreviewViewModel> {
     override func styleNavBar() {
         super.styleNavBar()
         
-        navigationController?.navigationBar.barTintColor = .black
+        if #available(iOS 13.0, *) {
+            navigationController?.navigationBar.standardAppearance.backgroundColor = .black
+            navigationController?.navigationBar.scrollEdgeAppearance?.backgroundColor = .black
+        } else {
+            navigationController?.navigationBar.barTintColor = .black
+        }
     }
     
     func initUI() {

--- a/Permanent/ViewControllers/TagDetailsViewController.swift
+++ b/Permanent/ViewControllers/TagDetailsViewController.swift
@@ -61,7 +61,12 @@ class TagDetailsViewController: BaseViewController<FilePreviewViewModel> {
     override func styleNavBar() {
         super.styleNavBar()
         
-        navigationController?.navigationBar.barTintColor = .black
+        if #available(iOS 13.0, *) {
+            navigationController?.navigationBar.standardAppearance.backgroundColor = .black
+            navigationController?.navigationBar.scrollEdgeAppearance?.backgroundColor = .black
+        } else {
+            navigationController?.navigationBar.barTintColor = .black
+        }
     }
     
     func initUI() {

--- a/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveScreenSectionTitleTableViewCell.xib
+++ b/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveScreenSectionTitleTableViewCell.xib
@@ -10,32 +10,34 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="56" id="KGk-i7-Jjw" customClass="ArchiveScreenSectionTitleTableViewCell" customModule="Permanent" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="473" height="56"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="50" id="KGk-i7-Jjw" customClass="ArchiveScreenSectionTitleTableViewCell" customModule="Permanent" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="473" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="473" height="56"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="473" height="50"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r5D-km-Iiq">
                         <rect key="frame" x="0.0" y="0.0" width="473" height="50"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XgE-fh-iC2">
-                                <rect key="frame" x="0.0" y="0.0" width="473" height="40"/>
+                                <rect key="frame" x="0.0" y="0.0" width="473" height="50"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="XgE-fh-iC2" firstAttribute="leading" secondItem="r5D-km-Iiq" secondAttribute="leading" id="Azq-yO-eft"/>
                             <constraint firstAttribute="trailing" secondItem="XgE-fh-iC2" secondAttribute="trailing" id="CF9-I1-SqA"/>
-                            <constraint firstAttribute="bottom" secondItem="XgE-fh-iC2" secondAttribute="bottom" constant="10" id="HEB-hs-UT6"/>
+                            <constraint firstAttribute="bottom" secondItem="XgE-fh-iC2" secondAttribute="bottom" id="HEB-hs-UT6"/>
                             <constraint firstItem="XgE-fh-iC2" firstAttribute="top" secondItem="r5D-km-Iiq" secondAttribute="top" id="O2a-e7-61U"/>
                             <constraint firstAttribute="height" constant="50" id="V6w-jA-QQR"/>
                         </constraints>
                     </view>
                 </subviews>
+                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="r5D-km-Iiq" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="3VQ-57-2HE"/>
                     <constraint firstItem="r5D-km-Iiq" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="91b-xD-GBg"/>
@@ -47,7 +49,7 @@
             <connections>
                 <outlet property="topSectionTitleLabel" destination="XgE-fh-iC2" id="s5A-VX-8fs"/>
             </connections>
-            <point key="canvasLocation" x="168.84057971014494" y="84.375"/>
+            <point key="canvasLocation" x="168.84057971014494" y="82.366071428571431"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
iOS 15 extended the use of scrollEdgeAppearance. When running on apps that use iOS 14 or earlier, this property applies to navigation bars with large titles. In iOS 15, this property applies to all navigation bars.

Switched to the new UINavigationBarAppearance for configuration on all systems iOS 13+, since the legacy method is yielding unstable results.