### PR TITLE
[iOS] Get the Permanent share menu into the share sheet

### DIFF
--- a/Permanent/ViewControllers/FilePreviewListViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewListViewController.swift
@@ -59,8 +59,7 @@ class FilePreviewListViewController: BaseViewController<FilesViewModel> {
     }
     
     func setupNavigationBar() {
-        let shareButtonImage = UIBarButtonItem.SystemItem.action
-        let shareButton = UIBarButtonItem(barButtonSystemItem: shareButtonImage, target: self, action: #selector(shareButtonAction(_:)))
+        let shareButton = UIBarButtonItem(image: .more, style: .plain, target: self, action: #selector(shareButtonAction(_:)))
         
         let infoButton = UIBarButtonItem(image: .info, style: .plain, target: self, action: #selector(infoButtonAction(_:)))
         navigationItem.rightBarButtonItems = [shareButton, infoButton]
@@ -82,7 +81,7 @@ class FilePreviewListViewController: BaseViewController<FilesViewModel> {
     }
     
     @objc private func shareButtonAction(_ sender: Any) {
-        (pageVC.viewControllers?.first as! FilePreviewViewController).shareButtonAction(sender)
+        (pageVC.viewControllers?.first as! FilePreviewViewController).showShareMenu(sender)
     }
     
     @objc private func infoButtonAction(_ sender: Any) {

--- a/Permanent/ViewControllers/FilePreviewViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewViewController.swift
@@ -77,8 +77,8 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     
     func initUI() {
         styleNavBar()
-        let shareButtonImage = UIBarButtonItem.SystemItem.action
-        let shareButton = UIBarButtonItem(barButtonSystemItem: shareButtonImage, target: self, action: #selector(shareButtonAction(_:)))
+        
+        let shareButton = UIBarButtonItem(image: UIImage(named: "more")!, style: .plain, target: self, action: #selector(showShareMenu(_:)))
         
         let infoButton = UIBarButtonItem(image: .info, style: .plain, target: self, action: #selector(infoButtonAction(_:)))
         navigationItem.rightBarButtonItems = [shareButton, infoButton]
@@ -215,30 +215,22 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     }
     
     // MARK: - Actions
-    @objc func shareButtonAction(_ sender: Any) {
-        if let fileName = self.viewModel?.fileName(),
-            let localURL = fileHelper.url(forFileNamed: fileName) {
-            share(url: localURL)
-        } else {
-            let preparingAlert = UIAlertController(title: "Preparing File..".localized(), message: nil, preferredStyle: .alert)
-            preparingAlert.addAction(UIAlertAction(title: .cancel, style: .cancel, handler: { _ in
-                self.viewModel?.cancelDownload()
-            }))
-            
-            present(preparingAlert, animated: true) {
-                if let record = self.viewModel?.recordVO {
-                    self.viewModel?.download(record, fileType: self.file.type, onFileDownloaded: { url, _ in
-                        if let url = url {
-                            self.dismiss(animated: true) {
-                                self.share(url: url)
-                            }
-                        } else {
-                            self.dismiss(animated: true, completion: nil)
-                        }
-                    })
-                }
+
+    @objc func showShareMenu(_ sender: Any) {
+        var actions: [PRMNTAction] = []
+        
+        actions.append(PRMNTAction(title: "Share to Another App".localized(), color: .primary, handler: { [self] action in
+            shareWithOtherApps()
+        }))
+        
+        actions.append(PRMNTAction(title: "Share in Permanent".localized(), color: .primary, handler: { [self] action in
+            if let file = self.viewModel?.file {
+                shareInApp(file: file)
             }
-        }
+        }))
+    
+        let actionSheet = PRMNTActionSheetViewController(title: "", actions: actions)
+        present(actionSheet, animated: true, completion: nil)
     }
     
     @objc func infoButtonAction(_ sender: Any) {
@@ -296,6 +288,48 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     
     private func htmlBody(withContent content: String) -> String {
         return "<html><body style=\"width:\(UIScreen.main.scale * view.frame.width);height:\(UIScreen.main.scale * view.frame.height);background-color:#000000;margin:0;padding:0;\">\(content)</body></html>"
+    }
+    
+    func shareWithOtherApps() {
+        if let fileName = self.viewModel?.fileName(),
+            let localURL = fileHelper.url(forFileNamed: fileName) {
+            share(url: localURL)
+        } else {
+            let preparingAlert = UIAlertController(title: "Preparing File..".localized(), message: nil, preferredStyle: .alert)
+            preparingAlert.addAction(UIAlertAction(title: .cancel, style: .cancel, handler: { _ in
+                self.viewModel?.cancelDownload()
+            }))
+
+            present(preparingAlert, animated: true) {
+                if let record = self.viewModel?.recordVO {
+                    self.viewModel?.download(record, fileType: self.file.type, onFileDownloaded: { url, _ in
+                        if let url = url {
+                            self.dismiss(animated: true) {
+                                self.share(url: url)
+                            }
+                        } else {
+                            self.dismiss(animated: true, completion: nil)
+                        }
+                    })
+                }
+            }
+        }
+    }
+    
+    func shareInApp(file: FileViewModel) {
+        guard
+            let shareVC = UIViewController.create(
+                withIdentifier: .share,
+                from: .share
+            ) as? ShareViewController
+        else {
+            return
+        }
+
+        shareVC.sharedFile = file
+        
+        let shareNavController = FilePreviewNavigationController(rootViewController: shareVC)
+        present(shareNavController, animated: true)
     }
 }
 

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -29,6 +29,9 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     private var isSearchActive: Bool = false
     private lazy var mediaRecorder = MediaRecorder(presentationController: self, delegate: self)
     
+    let fileHelper = FileHelper()
+    let documentInteractionController = UIDocumentInteractionController()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -784,8 +787,14 @@ extension MainViewController: FABActionSheetDelegate {
     func showFileActionSheet(file: FileViewModel, atIndexPath indexPath: IndexPath) {
         var actions: [PRMNTAction] = []
         if file.permissions.contains(.share) {
-            actions.append(PRMNTAction(title: "Share".localized(), color: .primary, handler: { [self] action in
-                share(file: file)
+            if file.type.isFolder == false {
+                actions.append(PRMNTAction(title: "Share to Another App".localized(), color: .primary, handler: { [self] action in
+                    shareWithOtherApps(file: file)
+                }))
+            }
+            
+            actions.append(PRMNTAction(title: "Share in Permanent".localized(), color: .primary, handler: { [self] action in
+                shareInApp(file: file)
             }))
         }
         
@@ -934,7 +943,7 @@ extension MainViewController: MediaRecorderDelegate {
 
 // MARK: - FileActionSheetDelegate
 extension MainViewController {
-    func share(file: FileViewModel) {
+    func shareInApp(file: FileViewModel) {
         guard
             let shareVC = UIViewController.create(
                 withIdentifier: .share,
@@ -948,6 +957,44 @@ extension MainViewController {
         
         let shareNavController = FilePreviewNavigationController(rootViewController: shareVC)
         present(shareNavController, animated: true)
+    }
+    
+    func shareWithOtherApps(file: FileViewModel) {
+        if let localURL = fileHelper.url(forFileNamed: file.name) {
+            share(url: localURL)
+        } else {
+            let preparingAlert = UIAlertController(title: "Preparing File..".localized(), message: nil, preferredStyle: .alert)
+            preparingAlert.addAction(UIAlertAction(title: .cancel, style: .cancel, handler: { _ in
+                self.viewModel?.cancelDownload()
+            }))
+            
+            present(preparingAlert, animated: true) {
+                self.viewModel?.getRecord(file: file, then: { record in
+                    
+                    if let record = record {
+                        self.viewModel?.download(record, fileType: file.type, onFileDownloaded: { url, _ in
+                            if let url = url {
+                                self.dismiss(animated: true) {
+                                    self.share(url: url)
+                                }
+                            } else {
+                                self.dismiss(animated: true, completion: nil)
+                            }
+                        })
+                    }
+                })
+            }
+        }
+    }
+    
+    private func share(url: URL) {
+        // For now, dismiss the menu in case another one opens so we avoid crash.
+        documentInteractionController.dismissMenu(animated: true)
+        
+        documentInteractionController.url = url
+        documentInteractionController.uti = url.typeIdentifier ?? "public.data, public.content"
+        documentInteractionController.name = url.localizedName ?? url.lastPathComponent
+        documentInteractionController.presentOptionsMenu(from: .zero, in: view, animated: true)
     }
     
     func renameAction(file: FileViewModel, atIndexPath indexPath: IndexPath) {

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -960,7 +960,7 @@ extension MainViewController {
     }
     
     func shareWithOtherApps(file: FileViewModel) {
-        if let localURL = fileHelper.url(forFileNamed: file.name) {
+        if let localURL = fileHelper.url(forFileNamed: file.uploadFileName) {
             share(url: localURL)
         } else {
             let preparingAlert = UIAlertController(title: "Preparing File..".localized(), message: nil, preferredStyle: .alert)

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -969,18 +969,13 @@ extension MainViewController {
             }))
             
             present(preparingAlert, animated: true) {
-                self.viewModel?.getRecord(file: file, then: { record in
-                    
-                    if let record = record {
-                        self.viewModel?.download(record, fileType: file.type, onFileDownloaded: { url, _ in
-                            if let url = url {
-                                self.dismiss(animated: true) {
-                                    self.share(url: url)
-                                }
-                            } else {
-                                self.dismiss(animated: true, completion: nil)
-                            }
-                        })
+                self.viewModel?.download(file: file, onDownloadStart: { }, onFileDownloaded: { url, errorMessage in
+                    if let url = url {
+                        self.dismiss(animated: true) {
+                            self.share(url: url)
+                        }
+                    } else {
+                        self.dismiss(animated: true, completion: nil)
                     }
                 })
             }

--- a/Permanent/ViewModels/FilesViewModel.swift
+++ b/Permanent/ViewModels/FilesViewModel.swift
@@ -52,6 +52,8 @@ class FilesViewModel: NSObject, ViewModelInterface {
         return currentArchive?.permissions() ?? [.read]
     }
     
+    var shareDownloader: DownloadManagerGCD? = nil
+    
     // MARK: - Table View Logic
     
     var currentFolderIsRoot: Bool { true }
@@ -219,6 +221,24 @@ extension FilesViewModel {
                                 self.downloadQueue.safeRemoveFirst()
                             })
 
+    }
+    
+    func getRecord(file: FileViewModel, then handler: @escaping (RecordVO?) -> Void) {
+        let downloadInfo = FileDownloadInfoVM(
+            fileType: file.type,
+            folderLinkId: file.folderLinkId,
+            parentFolderLinkId: file.parentFolderLinkId
+        )
+        
+        shareDownloader = DownloadManagerGCD()
+        shareDownloader?.getRecord(downloadInfo) { (record, error) in
+            handler(record)
+        }
+    }
+    
+    func download(_ record: RecordVO, fileType: FileType, onFileDownloaded: @escaping DownloadResponse) {
+        shareDownloader = DownloadManagerGCD()
+        shareDownloader?.downloadFileData(record: record, fileType: fileType, progressHandler: nil, then: onFileDownloaded)
     }
     
     func delete(_ file: FileViewModel, then handler: @escaping ServerResponse) {


### PR DESCRIPTION
Added both file share methods("Share to Another App" and "Share in Permanent") in file manager, file viewer and file details viewer.
Changed "Share" icon from top right in file viewer and file details viewer to "More" icon