### PR TITLE
Vsp 486 Uploaded / last modified time shows UTC time rather than local time

### DIFF
--- a/Permanent/Managers/Upload/UploadOperation.swift
+++ b/Permanent/Managers/Upload/UploadOperation.swift
@@ -166,6 +166,7 @@ class UploadOperation: BaseOperation {
         
         let dateFormatter = DateFormatter()
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
         
         let creationDate = resources.creationDate!

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsDateCollectionViewCell.swift
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsDateCollectionViewCell.swift
@@ -16,7 +16,7 @@ class FileDetailsDateCollectionViewCell: FileDetailsBaseCollectionViewCell {
     var date: Date?
     static let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd h:mm a"
+        dateFormatter.dateFormat = "yyyy-MM-dd h:mm a zzz"
         
         return dateFormatter
     }()

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsDateCollectionViewCell.swift
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsDateCollectionViewCell.swift
@@ -81,6 +81,7 @@ class FileDetailsDateCollectionViewCell: FileDetailsBaseCollectionViewCell {
     
     func detailsDate() -> Date? {
         let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = TimeZone.init(secondsFromGMT: 0)
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
         
         let date: Date?
@@ -94,6 +95,7 @@ class FileDetailsDateCollectionViewCell: FileDetailsBaseCollectionViewCell {
         case .created:
             date = dateFormatter.date(from: viewModel?.recordVO?.recordVO?.derivedDT ?? "")
         case .fileCreated:
+            dateFormatter.timeZone = nil
             date = dateFormatter.date(from: viewModel?.recordVO?.recordVO?.derivedCreatedDT ?? "")
         default:
             date = nil

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsDateCollectionViewCell.swift
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsDateCollectionViewCell.swift
@@ -95,7 +95,6 @@ class FileDetailsDateCollectionViewCell: FileDetailsBaseCollectionViewCell {
         case .created:
             date = dateFormatter.date(from: viewModel?.recordVO?.recordVO?.derivedDT ?? "")
         case .fileCreated:
-            dateFormatter.timeZone = nil
             date = dateFormatter.date(from: viewModel?.recordVO?.recordVO?.derivedCreatedDT ?? "")
         default:
             date = nil


### PR DESCRIPTION
Updated the date sent to the RegisterRecord API so that it's a UTC date, since the server ignores the timezone in the date field.
Updated the UI to display the Timezone