### PR TITLE
VSP-508 [iOS] Add sharing management to the share modal – remove, change perms, etc. before full release

### DIFF
--- a/Permanent/Models/Data/ShareVO.swift
+++ b/Permanent/Models/Data/ShareVO.swift
@@ -17,7 +17,8 @@ struct ShareVO: Model {
 
 struct ShareVOData: Model {
     let shareID, folderLinkID, archiveID: Int?
-    let accessRole, type, status, requestToken: String?
+    var accessRole: String?
+    let type, status, requestToken: String?
     let previewToggle: JSONAny?
     let folderVO: FolderVOData?
     let recordVO: RecordVOData?

--- a/Permanent/Models/Payloads.swift
+++ b/Permanent/Models/Payloads.swift
@@ -316,7 +316,7 @@ struct Payloads {
             ]
         ]
     }
-    static func acceptShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int) -> RequestParameters {
+    static func updateShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int, accessRole: AccessRole) -> RequestParameters {
         return [
             "RequestVO": [
                 "data": [[
@@ -324,7 +324,7 @@ struct Payloads {
                         "shareId": shareId,
                         "folder_linkId": folderLinkId,
                         "archiveId": archiveId,
-                        "accessRole": "access.role.viewer",
+                        "accessRole": accessRole,
                         "type": "type.share.record",
                         "status": "status.generic.ok"
                     ]
@@ -334,7 +334,7 @@ struct Payloads {
             ]
         ]
     }
-    static func denyShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int) -> RequestParameters{
+    static func deleteShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int) -> RequestParameters{
         return [
             "RequestVO": [
                 "data": [[

--- a/Permanent/Models/Payloads.swift
+++ b/Permanent/Models/Payloads.swift
@@ -316,23 +316,22 @@ struct Payloads {
             ]
         ]
     }
-    static func updateShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int, accessRole: AccessRole) -> RequestParameters {
-        return [
+    static func updateShareRequest(shareVO: ShareVOData) -> RequestParameters {
+        guard let shareVOJson = try? JSONEncoder().encode(shareVO),
+           let shareVODict = try? JSONSerialization.jsonObject(with: shareVOJson, options: []) else {
+            return []
+        }
+        
+        let updateDict = [
             "RequestVO": [
                 "data": [[
-                    "ShareVO": [
-                        "shareId": shareId,
-                        "folder_linkId": folderLinkId,
-                        "archiveId": archiveId,
-                        "accessRole": accessRole,
-                        "type": "type.share.record",
-                        "status": "status.generic.ok"
-                    ]
+                    "ShareVO": shareVODict
                 ]],
                 "apiKey": Constants.API.apiKey,
                 "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
             ]
         ]
+        return updateDict
     }
     static func deleteShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int) -> RequestParameters{
         return [

--- a/Permanent/Network/APIErrors.swift
+++ b/Permanent/Network/APIErrors.swift
@@ -101,3 +101,17 @@ enum MembersOperationsError: String {
         }
     }
 }
+
+enum ShareOperationsError: String {
+    case noShareSelf = "warning.share.no_share_self"
+    
+    var description: String {
+        switch self {
+
+        case .noShareSelf:
+            return "You cannot share an item with yourself".localized()
+        default:
+            return .errorMessage
+        }
+    }
+}

--- a/Permanent/Network/AccountEndpoint.swift
+++ b/Permanent/Network/AccountEndpoint.swift
@@ -29,7 +29,7 @@ enum AccountEndpoint {
     /// Updates user data
     case updateUserData(accountId: String, updateData: UpdateUserData)
     /// Update Share request
-    case updateShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int)
+    case updateShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int, accessRole: AccessRole)
     /// Revoke Share request
     case deleteShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int)
 }
@@ -80,10 +80,10 @@ extension AccountEndpoint: RequestProtocol {
             return Payloads.getUserData(accountId: id)
         case .updateUserData(accountId: let accountId, updateData: let updateData):
             return Payloads.updateUserData(accountId: accountId,updateUserData: updateData)
-        case .updateShareRequest(shareId: let shareId, folderLinkId: let folderLinkId, archiveId: let archiveId):
-            return Payloads.acceptShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId)
+        case .updateShareRequest(shareId: let shareId, folderLinkId: let folderLinkId, archiveId: let archiveId, accessRole: let AccessRole):
+            return Payloads.updateShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId, accessRole: AccessRole)
         case .deleteShareRequest(shareId: let shareId, folderLinkId: let folderLinkId, archiveId: let archiveId):
-            return Payloads.denyShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId)
+            return Payloads.deleteShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId)
         }
     }
 

--- a/Permanent/Network/AccountEndpoint.swift
+++ b/Permanent/Network/AccountEndpoint.swift
@@ -29,7 +29,7 @@ enum AccountEndpoint {
     /// Updates user data
     case updateUserData(accountId: String, updateData: UpdateUserData)
     /// Update Share request
-    case updateShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int, accessRole: AccessRole)
+    case updateShareRequest(shareVO: ShareVOData)
     /// Revoke Share request
     case deleteShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int)
 }
@@ -80,8 +80,8 @@ extension AccountEndpoint: RequestProtocol {
             return Payloads.getUserData(accountId: id)
         case .updateUserData(accountId: let accountId, updateData: let updateData):
             return Payloads.updateUserData(accountId: accountId,updateUserData: updateData)
-        case .updateShareRequest(shareId: let shareId, folderLinkId: let folderLinkId, archiveId: let archiveId, accessRole: let AccessRole):
-            return Payloads.updateShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId, accessRole: AccessRole)
+        case .updateShareRequest(let shareVO):
+            return Payloads.updateShareRequest(shareVO: shareVO)
         case .deleteShareRequest(shareId: let shareId, folderLinkId: let folderLinkId, archiveId: let archiveId):
             return Payloads.deleteShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId)
         }

--- a/Permanent/Storyboards/Share.storyboard
+++ b/Permanent/Storyboards/Share.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -97,6 +97,7 @@
                             <constraint firstItem="bEG-4x-ta0" firstAttribute="top" secondItem="U3K-nQ-DBc" secondAttribute="top" constant="30" id="vRR-og-AKP"/>
                         </constraints>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <connections>
                         <outlet property="createLinkButton" destination="eyh-Xi-naH" id="zFd-ng-l8G"/>
                         <outlet property="descriptionLabel" destination="PoA-Pj-khG" id="XAc-Ae-CIT"/>
@@ -201,6 +202,7 @@
                             <constraint firstItem="DVS-Ag-zFY" firstAttribute="top" secondItem="mIi-D7-d70" secondAttribute="bottom" constant="10" id="xgM-NC-PmI"/>
                         </constraints>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <connections>
                         <outlet property="autoApproveSwitchView" destination="8xd-fw-Fc4" id="lcf-BI-SWc"/>
                         <outlet property="autoApproveTooltipLabel" destination="pjZ-WT-n5G" id="P4w-rG-5si"/>
@@ -583,6 +585,7 @@
                             <constraint firstItem="BuB-Gr-iVF" firstAttribute="height" secondItem="eVQ-eX-BfZ" secondAttribute="height" id="uwu-z4-csq"/>
                         </constraints>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <connections>
                         <outlet property="backButton" destination="1dv-wK-LXr" id="0v8-JD-0Yp"/>
                         <outlet property="collectionView" destination="JPq-vy-INN" id="fkm-hs-ZhW"/>
@@ -748,6 +751,7 @@
                             <constraint firstItem="vp2-F5-rLO" firstAttribute="trailing" secondItem="IIX-dP-AYX" secondAttribute="trailing" id="y7O-S1-GKD"/>
                         </constraints>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <connections>
                         <outlet property="actionButton" destination="Qpj-CF-mcr" id="jST-cg-oUj"/>
                         <outlet property="archiveImage" destination="MQa-ME-Dth" id="q1u-PS-S23"/>

--- a/Permanent/ViewControllers/ShareViewController.swift
+++ b/Permanent/ViewControllers/ShareViewController.swift
@@ -241,6 +241,8 @@ extension ShareViewController: UITableViewDelegate, UITableViewDataSource {
                     self?.view.showNotificationBanner(title: .denyShareRequest)
                     cell.hideBottomButtons(status: true)
                     
+                    self?.getShareLink(option: .retrieve)
+                    
                 case .error(message: let message):
                     self?.showErrorAlert(message: message)
                 }

--- a/Permanent/ViewControllers/ShareViewController.swift
+++ b/Permanent/ViewControllers/ShareViewController.swift
@@ -103,11 +103,10 @@ class ShareViewController: BaseViewController<ShareLinkViewModel> {
                         self?.hideSpinner()
                         
                         if status == .success {
-                            
+                            self?.view.showNotificationBanner(title: "Access role was successfully changed".localized())
                         } else {
-                            
+                            self?.view.showNotificationBanner(title: .errorMessage, backgroundColor: .brightRed, textColor: .white)
                         }
-                        
                         self?.getShareLink(option: .retrieve)
                     })
                 }
@@ -271,11 +270,10 @@ extension ShareViewController: UITableViewDelegate, UITableViewDataSource {
                                         self?.viewModel?.denyButtonAction(shareVO: model, then: { status in
                                             self?.hideSpinner()
                                             if status == .success {
-                                                
+                                                self?.view.showNotificationBanner(title: "Archive successfully removed".localized())
                                             } else {
-                                                
+                                                self?.view.showNotificationBanner(title: .errorMessage, backgroundColor: .brightRed, textColor: .white)
                                             }
-                                            
                                             self?.getShareLink(option: .retrieve)
                                         })
                                        },

--- a/Permanent/ViewModels/ShareLinkViewModel.swift
+++ b/Permanent/ViewModels/ShareLinkViewModel.swift
@@ -151,15 +151,10 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
         }
     }
     
-    func approveButtonAction(shareVO: ShareVOData, then handler: @escaping (RequestStatus) -> Void) {
-        guard let folderLinkId = shareVO.folderLinkID,
-              let archiveId = shareVO.archiveID else {
-            handler(RequestStatus.error(message: nil))
-            return
-        }
-        let shareId = shareVO.shareID ?? 0
-        
-        let acceptShareRequestOperation = APIOperation(AccountEndpoint.updateShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId,accessRole: AccessRole.viewer))
+    func approveButtonAction(shareVO: ShareVOData, accessRole: AccessRole = .viewer, then handler: @escaping (RequestStatus) -> Void) {
+        var newShareVO = shareVO
+        newShareVO.accessRole = AccessRole.apiRoleForValue(accessRole.groupName)
+        let acceptShareRequestOperation = APIOperation(AccountEndpoint.updateShareRequest(shareVO: newShareVO))
         
         acceptShareRequestOperation.execute(in: APIRequestDispatcher()) { result in
             switch result {
@@ -195,7 +190,6 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
         
         let denyShareRequestOperation = APIOperation(AccountEndpoint.deleteShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId))
         
-    
         denyShareRequestOperation.execute(in: APIRequestDispatcher()) { result in
             switch result {
             case .json(let response, _):

--- a/Permanent/ViewModels/ShareLinkViewModel.swift
+++ b/Permanent/ViewModels/ShareLinkViewModel.swift
@@ -159,9 +159,8 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
         }
         let shareId = shareVO.shareID ?? 0
         
-        let acceptShareRequestOperation = APIOperation(AccountEndpoint.updateShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId))
+        let acceptShareRequestOperation = APIOperation(AccountEndpoint.updateShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId,accessRole: AccessRole.viewer))
         
-    
         acceptShareRequestOperation.execute(in: APIRequestDispatcher()) { result in
             switch result {
             case .json(let response, _):

--- a/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveTableViewCell.swift
+++ b/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveTableViewCell.swift
@@ -15,6 +15,7 @@ class ArchiveTableViewCell: UITableViewCell {
     @IBOutlet var denyButton: RoundedButton!
     @IBOutlet var bottomButtonsView: UIStackView!
     @IBOutlet weak var bottomView: UIView!
+    @IBOutlet weak var moreButton: UIButton!
     
     var rightButtonTapAction: CellButtonTapAction?
     var approveAction: ButtonAction?
@@ -48,6 +49,7 @@ class ArchiveTableViewCell: UITableViewCell {
         relationshipLabel.text = "Friend" // TODO
         
         bottomView.isHidden = ShareStatus.status(forValue: model.status ?? "") != .pending
+        moreButton.isHidden = ShareStatus.status(forValue: model.status ?? "") == .pending
     }
     
     func hideBottomButtons(status: Bool ) {

--- a/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveTableViewCell.xib
+++ b/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveTableViewCell.xib
@@ -19,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h0w-q0-XkC" userLabel="Archive Image View">
-                        <rect key="frame" x="20" y="16" width="34" height="34"/>
+                        <rect key="frame" x="20" y="10" width="34" height="34"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="34" id="Pdf-Ak-Vab"/>
                             <constraint firstAttribute="width" constant="34" id="xQz-gH-UNN"/>
@@ -31,62 +31,84 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PO6-uJ-qlZ">
-                        <rect key="frame" x="64" y="10" width="348" height="218"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="dbV-33-rOJ">
+                        <rect key="frame" x="64" y="10" width="363" height="218"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zU3-4p-PA7" userLabel="Archive Label">
-                                <rect key="frame" x="0.0" y="0.0" width="348" height="128"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tdl-In-Vb7" userLabel="Relationship Label">
-                                <rect key="frame" x="0.0" y="128" width="348" height="50"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CFp-XX-kbh">
-                                <rect key="frame" x="0.0" y="178" width="348" height="40"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="PO6-uJ-qlZ">
+                                <rect key="frame" x="0.0" y="0.0" width="333" height="218"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="6jh-Sm-L0U">
-                                        <rect key="frame" x="0.0" y="5" width="348" height="30"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zU3-4p-PA7" userLabel="Archive Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="333" height="128"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tdl-In-Vb7" userLabel="Relationship Label">
+                                        <rect key="frame" x="0.0" y="128" width="333" height="40"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CFp-XX-kbh">
+                                        <rect key="frame" x="0.0" y="168" width="333" height="50"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-Dy-rD8" customClass="RoundedButton" customModule="Permanent" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="169" height="30"/>
-                                                <state key="normal" title="Button"/>
-                                                <connections>
-                                                    <action selector="denyAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="IW4-IM-jr8"/>
-                                                </connections>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iKI-ko-seh" customClass="RoundedButton" customModule="Permanent" customModuleProvider="target">
-                                                <rect key="frame" x="179" y="0.0" width="169" height="30"/>
-                                                <state key="normal" title="Button"/>
-                                                <connections>
-                                                    <action selector="approveAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="riT-2d-ODf"/>
-                                                </connections>
-                                            </button>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="6jh-Sm-L0U">
+                                                <rect key="frame" x="0.0" y="5" width="333" height="40"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tE3-Dy-rD8" customClass="RoundedButton" customModule="Permanent" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="161.5" height="40"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <connections>
+                                                            <action selector="denyAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="IW4-IM-jr8"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iKI-ko-seh" customClass="RoundedButton" customModule="Permanent" customModuleProvider="target">
+                                                        <rect key="frame" x="171.5" y="0.0" width="161.5" height="40"/>
+                                                        <state key="normal" title="Button"/>
+                                                        <connections>
+                                                            <action selector="approveAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="riT-2d-ODf"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
-                                    </stackView>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="6jh-Sm-L0U" firstAttribute="top" secondItem="CFp-XX-kbh" secondAttribute="top" constant="5" id="089-u2-RP6"/>
+                                            <constraint firstItem="6jh-Sm-L0U" firstAttribute="leading" secondItem="CFp-XX-kbh" secondAttribute="leading" id="TOh-0K-PfO"/>
+                                            <constraint firstAttribute="trailing" secondItem="6jh-Sm-L0U" secondAttribute="trailing" id="tpI-sz-bcn"/>
+                                            <constraint firstAttribute="bottom" secondItem="6jh-Sm-L0U" secondAttribute="bottom" constant="5" id="zPE-57-3gh"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PnZ-48-hYf">
+                                <rect key="frame" x="333" y="94" width="30" height="30"/>
                                 <constraints>
-                                    <constraint firstItem="6jh-Sm-L0U" firstAttribute="top" secondItem="CFp-XX-kbh" secondAttribute="top" constant="5" id="089-u2-RP6"/>
-                                    <constraint firstItem="6jh-Sm-L0U" firstAttribute="leading" secondItem="CFp-XX-kbh" secondAttribute="leading" id="TOh-0K-PfO"/>
-                                    <constraint firstAttribute="trailing" secondItem="6jh-Sm-L0U" secondAttribute="trailing" id="tpI-sz-bcn"/>
-                                    <constraint firstAttribute="bottom" secondItem="6jh-Sm-L0U" secondAttribute="bottom" constant="5" id="zPE-57-3gh"/>
+                                    <constraint firstAttribute="height" constant="30" id="9g5-ig-1lI"/>
+                                    <constraint firstAttribute="width" secondItem="PnZ-48-hYf" secondAttribute="height" id="gLG-5U-EcG"/>
                                 </constraints>
-                            </view>
+                                <color key="tintColor" systemColor="systemYellowColor"/>
+                                <state key="normal" image="more"/>
+                                <connections>
+                                    <action selector="moreButtonAction:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="PYj-xB-2N0"/>
+                                </connections>
+                            </button>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="PnZ-48-hYf" firstAttribute="width" secondItem="PnZ-48-hYf" secondAttribute="height" id="1iw-Kv-2pO"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="fhr-j6-Jaa"/>
+                            <constraint firstItem="PnZ-48-hYf" firstAttribute="width" secondItem="PnZ-48-hYf" secondAttribute="height" id="qfe-zV-6dx"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="PO6-uJ-qlZ" secondAttribute="trailing" constant="20" id="Jr9-Bd-32G"/>
-                    <constraint firstItem="h0w-q0-XkC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" constant="5" id="RYp-EP-fP0"/>
+                    <constraint firstItem="dbV-33-rOJ" firstAttribute="leading" secondItem="h0w-q0-XkC" secondAttribute="trailing" constant="10" id="0EP-Xp-gXo"/>
+                    <constraint firstAttribute="bottom" secondItem="dbV-33-rOJ" secondAttribute="bottom" constant="5" id="7kb-Mv-33D"/>
+                    <constraint firstItem="dbV-33-rOJ" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="O57-GD-XTu"/>
+                    <constraint firstItem="h0w-q0-XkC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="RYp-EP-fP0"/>
                     <constraint firstItem="h0w-q0-XkC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="TVq-59-fuJ"/>
-                    <constraint firstItem="PO6-uJ-qlZ" firstAttribute="leading" secondItem="h0w-q0-XkC" secondAttribute="trailing" constant="10" id="aKa-VN-a5Z"/>
-                    <constraint firstAttribute="bottom" secondItem="PO6-uJ-qlZ" secondAttribute="bottom" constant="5" id="vX2-Eu-dp5"/>
-                    <constraint firstItem="PO6-uJ-qlZ" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="wTu-bW-Sut"/>
+                    <constraint firstAttribute="trailing" secondItem="dbV-33-rOJ" secondAttribute="trailing" constant="5" id="nDz-9i-xKN"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -97,6 +119,7 @@
                 <outlet property="bottomButtonsView" destination="6jh-Sm-L0U" id="Lkn-Q3-tUJ"/>
                 <outlet property="bottomView" destination="CFp-XX-kbh" id="qKe-2F-rTr"/>
                 <outlet property="denyButton" destination="tE3-Dy-rD8" id="xav-Wr-lUQ"/>
+                <outlet property="moreButton" destination="PnZ-48-hYf" id="ptB-GQ-WgB"/>
                 <outlet property="relationshipLabel" destination="Tdl-In-Vb7" id="nW8-tC-ibu"/>
             </connections>
             <point key="canvasLocation" x="-143" y="-39"/>
@@ -104,15 +127,19 @@
     </objects>
     <designables>
         <designable name="iKI-ko-seh">
-            <size key="intrinsicContentSize" width="46" height="30"/>
+            <size key="intrinsicContentSize" width="70" height="40"/>
         </designable>
         <designable name="tE3-Dy-rD8">
-            <size key="intrinsicContentSize" width="46" height="30"/>
+            <size key="intrinsicContentSize" width="70" height="40"/>
         </designable>
     </designables>
     <resources>
+        <image name="more" width="4" height="16"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
- Modified accept/deny share request endpoints to be able to use them for update/delete share request methods.
- Add sharing management to the share modal – remove, change perms, etc. before full release
- Added UI to manage sharing permissions
- Added api response notifications.
- Added refresh metod on deny action.