### PR TITLE
VSP-595 [iOS] Sharing shares permission management - Should only be enabled for owners

### DIFF
--- a/Permanent/ViewControllers/FileDetailsViewController.swift
+++ b/Permanent/ViewControllers/FileDetailsViewController.swift
@@ -128,7 +128,7 @@ class FileDetailsViewController: BaseViewController<FilePreviewViewModel> {
             shareWithOtherApps()
         }))
         
-        actions.append(PRMNTAction(title: "Share in Permanent".localized(), color: .primary, handler: { [self] action in
+        actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
             if let file = self.viewModel?.file {
                 shareInApp(file: file)
             }

--- a/Permanent/ViewControllers/FileDetailsViewController.swift
+++ b/Permanent/ViewControllers/FileDetailsViewController.swift
@@ -127,12 +127,13 @@ class FileDetailsViewController: BaseViewController<FilePreviewViewModel> {
         actions.append(PRMNTAction(title: "Share to Another App".localized(), color: .primary, handler: { [self] action in
             shareWithOtherApps()
         }))
-        
-        actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
-            if let file = self.viewModel?.file {
-                shareInApp(file: file)
-            }
-        }))
+        if self.file.permissions.contains(.ownership) {
+            actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
+                if let file = self.viewModel?.file {
+                    shareInApp(file: file)
+                }
+            }))
+        }
     
         let actionSheet = PRMNTActionSheetViewController(title: "", actions: actions)
         present(actionSheet, animated: true, completion: nil)

--- a/Permanent/ViewControllers/FilePreviewViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewViewController.swift
@@ -243,12 +243,13 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         actions.append(PRMNTAction(title: "Share to Another App".localized(), color: .primary, handler: { [self] action in
             shareWithOtherApps()
         }))
-        
-        actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
-            if let file = self.viewModel?.file {
-                shareInApp(file: file)
-            }
-        }))
+        if self.file.permissions.contains(.ownership) {
+            actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
+                if let file = self.viewModel?.file {
+                    shareInApp(file: file)
+                }
+            }))
+        }
     
         let actionSheet = PRMNTActionSheetViewController(title: "", actions: actions)
         present(actionSheet, animated: true, completion: nil)

--- a/Permanent/ViewControllers/FilePreviewViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewViewController.swift
@@ -244,7 +244,7 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
             shareWithOtherApps()
         }))
         
-        actions.append(PRMNTAction(title: "Share in Permanent".localized(), color: .primary, handler: { [self] action in
+        actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
             if let file = self.viewModel?.file {
                 shareInApp(file: file)
             }

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -793,7 +793,7 @@ extension MainViewController: FABActionSheetDelegate {
                 }))
             }
             
-            actions.append(PRMNTAction(title: "Share in Permanent".localized(), color: .primary, handler: { [self] action in
+            actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
                 shareInApp(file: file)
             }))
         }

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -792,10 +792,11 @@ extension MainViewController: FABActionSheetDelegate {
                     shareWithOtherApps(file: file)
                 }))
             }
-            
-            actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
-                shareInApp(file: file)
-            }))
+            if file.permissions.contains(.ownership) {
+                actions.append(PRMNTAction(title: "Share via Permanent".localized(), color: .primary, handler: { [self] action in
+                    shareInApp(file: file)
+                }))
+            }
         }
         
         if file.permissions.contains(.edit) {


### PR DESCRIPTION
 - Changed share file text to : "Share via permanent" [VSP-597]
 - Fixed "Share via Permanent" option so that will not be displayed when current archive role is different than owner