### PR TITLE
VSP-601 [iOS] First archive in the Manage Archives Screen is cutoff at the top

### DIFF
--- a/Permanent/ViewControllers/ArchivesViewController.swift
+++ b/Permanent/ViewControllers/ArchivesViewController.swift
@@ -382,6 +382,10 @@ extension ArchivesViewController: UITableViewDataSource, UITableViewDelegate {
         return headerView
     }
     
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 50
+    }
+    
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
         if tableViewSections[indexPath.section] == .pending {
             return false


### PR DESCRIPTION
Added height attribute to TableView Header.