### PR TITLE
VSP-613 [iOS] Remove pin length limit

### DIFF
--- a/Permanent/Assets/Localization/en.lproj/Localizable.strings
+++ b/Permanent/Assets/Localization/en.lproj/Localizable.strings
@@ -23,7 +23,7 @@
 "Email" = "Email";
 "EmailAlreadyUsed" = "This email is already in use.";
 "EmailSent" = "An email with instructions to change your password has been sent at %@.";
-"EnterCode" = "Enter the 4-digit code";
+"EnterCode" = "Enter the verification code";
 "EnterEmail" = "Enter your email here";
 "EnterVerificationCode" = "Enter verification code";
 "Error" = "Error";

--- a/Permanent/ViewControllers/Authentication/CodeVerificationController.swift
+++ b/Permanent/ViewControllers/Authentication/CodeVerificationController.swift
@@ -92,13 +92,6 @@ extension CodeVerificationController: UITextFieldDelegate {
         (textField as? TextField)?.toggleBorder(active: false)
     }
     
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let text = textField.text else { return true }
-        let newLength = text.count + string.count - range.length
-        
-        return newLength <= 4 // TODO: Make a property in TextField for this value
-    }
-    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         view.endEditing(true)
         scrollView.setContentOffset(.zero, animated: true)


### PR DESCRIPTION
- Removed pin limit in the Verification Screen
- Adjusted the text to no longer mention how many digits the code has