### PR TITLE
VSP-609 [iOS] Remove Permanent API key

### DIFF
--- a/Permanent/Constants/Constants.swift
+++ b/Permanent/Constants/Constants.swift
@@ -86,8 +86,6 @@ extension Constants.Design {
 }
 
 extension Constants.API {
-    static let apiKey = "5aef7dd1f32e0d9ca57290e3c82b59db"
-
     static let TYPE_AUTH_CREATED_ACCOUNT_EMAIL = "type.auth.created_account_email"
     static let TYPE_AUTH_CREATED_ACCOUNT_TEXT = "type.auth.created_account_text"
     static let TYPE_AUTH_EMAIL = "type.auth.email"

--- a/Permanent/Models/APIPayload.swift
+++ b/Permanent/Models/APIPayload.swift
@@ -14,7 +14,6 @@ struct APIPayload<T: Model>: Model {
     static func make(fromData data: [T]) -> APIPayload<T> {
         let voData = RequestVOData(
             data: data,
-            apiKey: Constants.API.apiKey,
             csrf: PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)
         )
         return APIPayload(RequestVO: voData)
@@ -23,6 +22,5 @@ struct APIPayload<T: Model>: Model {
 
 struct RequestVOData<T: Model>: Model {
     let data: [T]
-    let apiKey: String
     let csrf: String?
 }

--- a/Permanent/Models/Payloads.swift
+++ b/Permanent/Models/Payloads.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 struct Payloads {
+    
+    static var csrf: String {
+        get {
+            PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+        }
+    }
+    
     static func forgotPasswordPayload(for email: String) -> RequestParameters {
         return [
             "RequestVO": [
@@ -15,8 +22,7 @@ struct Payloads {
                     "AccountVO": [
                         "primaryEmail": email
                     ]
-                ]],
-                "apiKey": Constants.API.apiKey
+                ]]
             ]
         ]
     }
@@ -31,8 +37,7 @@ struct Payloads {
                     "AccountPasswordVO": [
                         "password": credentials.password
                     ]
-                ]],
-                "apiKey": Constants.API.apiKey
+                ]]
             ]
         ]
     }
@@ -51,8 +56,7 @@ struct Payloads {
                         "password": credentials.loginCredentials.password,
                         "passwordVerify": credentials.loginCredentials.password
                     ]
-                ]],
-                "apiKey": Constants.API.apiKey
+                ]]
             ]
         ]
     }
@@ -65,8 +69,7 @@ struct Payloads {
                         "accountId": accountId
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -81,8 +84,7 @@ struct Payloads {
                         "primaryEmail": updateData.email
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -100,8 +102,7 @@ struct Payloads {
                 "data": [[
                     "AccountVO": accountDict
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -114,8 +115,7 @@ struct Payloads {
                         "accountId": accountId,
                         "primaryEmail": email
                     ]
-                ]],
-                "apiKey": Constants.API.apiKey
+                ]]
             ]
         ]
     }
@@ -131,8 +131,7 @@ struct Payloads {
                         "type": credentials.type.value,
                         "token": credentials.code
                     ]
-                ]],
-                "apiKey": Constants.API.apiKey
+                ]]
             ]
         ]
     }
@@ -146,8 +145,7 @@ struct Payloads {
                         "folder_linkId": "\(params.folderLinkId)"
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -169,8 +167,7 @@ struct Payloads {
                         "folder_linkId": params.folderLinkId
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
         
@@ -188,8 +185,7 @@ struct Payloads {
                         "uploadFileName": params.filename
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -211,8 +207,7 @@ struct Payloads {
                         "value": params.fileMimeType ?? "application/octet-stream"
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
         return dict
@@ -238,8 +233,7 @@ struct Payloads {
                         "value": params.destinationUrl
                     ]
                 ],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
 
@@ -256,8 +250,7 @@ struct Payloads {
                         "parentFolder_linkId": params.folderLinkId
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -274,8 +267,7 @@ struct Payloads {
                         "passwordOld":updateData.passwordOld
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -290,8 +282,7 @@ struct Payloads {
                         "accountId": accountId
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -311,8 +302,7 @@ struct Payloads {
                         "country": updateUserData.country
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -327,8 +317,7 @@ struct Payloads {
                 "data": [[
                     "ShareVO": shareVODict
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
         return updateDict
@@ -343,8 +332,7 @@ struct Payloads {
                         "archiveId": archiveId
                     ]
                 ]],
-                "apiKey": Constants.API.apiKey,
-                "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!
+                "csrf": Self.csrf
             ]
         ]
     }
@@ -376,8 +364,7 @@ struct Payloads {
         
         return [ "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": Self.csrf,
                         "data": [
                             [
                                 "RecordVO": recordVO
@@ -395,8 +382,7 @@ struct Payloads {
         
         return [ "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": Self.csrf,
                         "data": [
                             [
                                 "LocnVO": locnVO
@@ -411,8 +397,7 @@ struct Payloads {
             [
                 "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": Self.csrf,
                         "data": [
                             [
                                 "SimpleVO": [
@@ -440,8 +425,7 @@ struct Payloads {
         
         return [ "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": Self.csrf,
                         "data": data
                     ]
         ]
@@ -463,8 +447,7 @@ struct Payloads {
         
         return [ "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": Self.csrf,
                         "data": data
                     ]
         ]
@@ -473,8 +456,7 @@ struct Payloads {
     static func getTagsByArchive(params: GetTagsByArchiveParams) -> RequestParameters {
         return [ "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": Self.csrf,
                         "data": [
                             [
                                 "ArchiveVO": [
@@ -489,8 +471,7 @@ struct Payloads {
     static func getArchivesByAccountId(accountId: GetArchivesByAccountId) -> RequestParameters {
         return [ "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": UserDefaults.standard.value(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
                         "data": [
                             [
                                 "AccountVO": [
@@ -506,8 +487,7 @@ struct Payloads {
         return [
             "RequestVO":
                 [
-                    "apiKey": Constants.API.apiKey,
-                    "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                    "csrf": Self.csrf,
                     "data": [
                         [
                             "ArchiveVO": [
@@ -524,8 +504,7 @@ struct Payloads {
         return [
             "RequestVO":
                 [
-                    "apiKey": Constants.API.apiKey,
-                    "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                    "csrf": Self.csrf,
                     "data": [
                         [
                             "ArchiveVO": [
@@ -543,8 +522,7 @@ struct Payloads {
         return [
             "RequestVO":
                 [
-                    "apiKey": Constants.API.apiKey,
-                    "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                    "csrf": Self.csrf,
                     "data": [
                         [
                             "ArchiveVO": [
@@ -600,8 +578,7 @@ struct Payloads {
     static func transferOwnership(archiveNbr: String, primaryEmail: String) -> RequestParameters {
         return [ "RequestVO":
                     [
-                        "apiKey": Constants.API.apiKey,
-                        "csrf": PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.csrfStorageKey)!,
+                        "csrf": Self.csrf,
                         "data": [
                             [
                                 "ArchiveVO": [


### PR DESCRIPTION
- Removed API Key from the Constants file
- Removed API Key from all Payloads
- Improved handling of csrf, as the runtime would sometimes get confused on the type of the saved value