### PR TITLE
VSP-615 [iOS] Video has no sound

### DIFF
--- a/Permanent/ViewControllers/FilePreviewViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewViewController.swift
@@ -44,6 +44,13 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     override func viewDidLoad() {
         super.viewDidLoad()
         initUI()
+        
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            print("Setting category to AVAudioSessionCategoryPlayback failed.")
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -202,7 +209,7 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     }
     
     func loadVideo(withURL url: URL, contentType: String) {
-        let asset = AVURLAsset(url: url, options: ["AVURLAssetOutOfBandMIMETypeKey": contentType])
+        let asset = AVURLAsset(url: url)
         let playerItem = AVPlayerItem(asset: asset)
         
         let player = AVPlayer(playerItem: playerItem)

--- a/Permanent/ViewModels/FilePreviewViewModel.swift
+++ b/Permanent/ViewModels/FilePreviewViewModel.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import WebKit
+import AVKit
 
 class FilePreviewViewModel: ViewModelInterface {
     let file: FileViewModel
@@ -61,13 +62,20 @@ class FilePreviewViewModel: ViewModelInterface {
     }
     
     func fileVO() -> FileVO? {
-        if file.type == .video,
-           let fileVO = recordVO?.recordVO?.fileVOS?.first(where: {$0.format == "file.format.converted"}) {
-            return fileVO
-        } else {
-            return recordVO?.recordVO?.fileVOS?.first
+        var fileVO: FileVO? = recordVO?.recordVO?.fileVOS?.first
+
+        if file.type == .video {
+            if let uwFileVO = recordVO?.recordVO?.fileVOS?.first,
+               let url = URL(string: uwFileVO.downloadURL),
+               AVAsset(url: url).isPlayable {
+                fileVO = uwFileVO
+            } else if let uwFileVO = recordVO?.recordVO?.fileVOS?.first(where: {$0.format == "file.format.converted"}) {
+                fileVO = uwFileVO
+            }
         }
-    }
+        
+        return fileVO
+}
     
     func fileName() -> String? {
         guard let fileVO = self.fileVO(),


### PR DESCRIPTION
- Added configuration for the AVAudioSession when the File Preview screen loads
- Removed private option from the AVURLAsset
- Refactored code in the ViewModel so that it asks the Apple SDK for playback ability. It will switch to the converted file only if the SDK says that the default file is not playable