### PR TITLE
VSP-505 [iOS] Address should have two fields in Account Info

### DIFF
--- a/Permanent/Models/Payloads.swift
+++ b/Permanent/Models/Payloads.swift
@@ -288,19 +288,22 @@ struct Payloads {
     static func updateUserData(accountId: String, updateUserData: UpdateUserData) -> RequestParameters {
         return [
             "RequestVO": [
-                "data": [[
-                    "AccountVO": [
-                        "accountId": accountId,
-                        "fullName": updateUserData.fullName,
-                        "primaryEmail": updateUserData.primaryEmail,
-                        "primaryPhone": updateUserData.primaryPhone,
-                        "address": updateUserData.address,
-                        "city": updateUserData.city,
-                        "state": updateUserData.state,
-                        "zip": updateUserData.zip,
-                        "country": updateUserData.country
+                "data": [
+                    [
+                        "AccountVO": [
+                            "accountId": accountId,
+                            "fullName": updateUserData.fullName,
+                            "primaryEmail": updateUserData.primaryEmail,
+                            "primaryPhone": updateUserData.primaryPhone,
+                            "address": updateUserData.address,
+                            "address2": updateUserData.address2,
+                            "city": updateUserData.city,
+                            "state": updateUserData.state,
+                            "zip": updateUserData.zip,
+                            "country": updateUserData.country
+                        ]
                     ]
-                ]],
+                ],
                 "csrf": Self.csrf
             ]
         ]

--- a/Permanent/Network/AccountEndpoint.swift
+++ b/Permanent/Network/AccountEndpoint.swift
@@ -31,7 +31,7 @@ enum AccountEndpoint {
     /// Update Share request
     case updateShareRequest(shareVO: ShareVOData)
     /// Revoke Share request
-    case deleteShareRequest(shareId: Int,folderLinkId: Int,archiveId: Int)
+    case deleteShareRequest(shareId: Int, folderLinkId: Int, archiveId: Int)
 }
 
 extension AccountEndpoint: RequestProtocol {
@@ -64,24 +64,34 @@ extension AccountEndpoint: RequestProtocol {
         switch self {
         case .signUp(let credentials):
             return Payloads.signUpPayload(for: credentials)
+            
         case .delete(let accountId):
             return Payloads.deleteAccountPayload(accountId: accountId)
+            
         case .updateEmailAndPhone(let accountId, let data):
             return Payloads.updateEmailAndPhone(accountId: accountId, updateData: data)
+            
         case .update(let accountVO):
             return Payloads.update(accountVO: accountVO)
+            
         case .sendVerificationCodeSMS(let id, let email):
             return Payloads.smsVerificationCodePayload(accountId: id, email: email)
+            
         case .changePassword(let id, let passData):
-            return Payloads.updatePassword(accountId: id,updateData: passData)
+            return Payloads.updatePassword(accountId: id, updateData: passData)
+            
         case .getValidCsrf:
             return Payloads.getValidCsrf()
+            
         case .getUserData(let id):
             return Payloads.getUserData(accountId: id)
+            
         case .updateUserData(accountId: let accountId, updateData: let updateData):
-            return Payloads.updateUserData(accountId: accountId,updateUserData: updateData)
+            return Payloads.updateUserData(accountId: accountId, updateUserData: updateData)
+            
         case .updateShareRequest(let shareVO):
             return Payloads.updateShareRequest(shareVO: shareVO)
+            
         case .deleteShareRequest(shareId: let shareId, folderLinkId: let folderLinkId, archiveId: let archiveId):
             return Payloads.deleteShareRequest(shareId: shareId, folderLinkId: folderLinkId, archiveId: archiveId)
         }
@@ -97,7 +107,9 @@ extension AccountEndpoint: RequestProtocol {
     
     var progressHandler: ProgressHandler? {
         get { nil }
-        set {}
+        // swiftlint:disable unused_setter_value
+        set { }
+        // swiftlint:enable unused_setter_value
     }
     
     var bodyData: Data? { nil }

--- a/Permanent/Network/AccountEndpoint.swift
+++ b/Permanent/Network/AccountEndpoint.swift
@@ -107,9 +107,8 @@ extension AccountEndpoint: RequestProtocol {
     
     var progressHandler: ProgressHandler? {
         get { nil }
-        // swiftlint:disable unused_setter_value
+        // swiftlint:disable:next unused_setter_value
         set { }
-        // swiftlint:enable unused_setter_value
     }
     
     var bodyData: Data? { nil }

--- a/Permanent/Storyboards/Settings.storyboard
+++ b/Permanent/Storyboards/Settings.storyboard
@@ -238,33 +238,37 @@
                                                 <rect key="frame" x="0.0" y="0.0" width="394" height="470"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2P9-DV-xhR" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="394" height="60"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="394" height="48.5"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="string" keyPath="value" value="ghjghj"/>
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ogg-ze-DAE" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="82" width="394" height="60"/>
+                                                        <rect key="frame" x="0.0" y="70.5" width="394" height="48"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tvS-OK-oYe" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="164" width="394" height="60"/>
+                                                        <rect key="frame" x="0.0" y="140.5" width="394" height="48.5"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4cx-DB-j2J" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="246" width="394" height="60"/>
+                                                        <rect key="frame" x="0.0" y="211" width="394" height="48"/>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TX9-m2-qMR" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="281" width="394" height="48.5"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     </view>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="eyu-gu-hgn">
-                                                        <rect key="frame" x="0.0" y="328" width="394" height="60"/>
+                                                        <rect key="frame" x="0.0" y="351.5" width="394" height="48"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o1Z-Ao-tzj" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="197" height="60"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="197" height="48"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ekB-PT-q6z" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                                <rect key="frame" x="197" y="0.0" width="197" height="60"/>
+                                                                <rect key="frame" x="197" y="0.0" width="197" height="48"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                             </view>
                                                         </subviews>
@@ -276,14 +280,14 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ZMe-dh-uGc">
-                                                        <rect key="frame" x="0.0" y="410" width="394" height="60"/>
+                                                        <rect key="frame" x="0.0" y="421.5" width="394" height="48.5"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eX1-Fa-Ugn" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="197" height="60"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="197" height="48.5"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZrA-5h-O9O" customClass="InputTextWithLabelElementViewViewController" customModule="Permanent" customModuleProvider="target">
-                                                                <rect key="frame" x="197" y="0.0" width="197" height="60"/>
+                                                                <rect key="frame" x="197" y="0.0" width="197" height="48.5"/>
                                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                             </view>
                                                         </subviews>
@@ -340,6 +344,7 @@
                     <connections>
                         <outlet property="accountNameView" destination="2P9-DV-xhR" id="0VZ-f9-XkZ"/>
                         <outlet property="addressView" destination="4cx-DB-j2J" id="fAh-kf-dbU"/>
+                        <outlet property="addressView2" destination="TX9-m2-qMR" id="ewf-Rh-btj"/>
                         <outlet property="cityView" destination="o1Z-Ao-tzj" id="bXS-g4-vVc"/>
                         <outlet property="contentUpdateButton" destination="68J-lr-Pzv" id="C8a-vd-tmQ"/>
                         <outlet property="countryView" destination="ZrA-5h-O9O" id="8Du-IW-NbV"/>
@@ -457,19 +462,19 @@ The account deletion action will not delete any archives that you own or persona
     </scenes>
     <designables>
         <designable name="68J-lr-Pzv">
-            <size key="intrinsicContentSize" width="46" height="30"/>
+            <size key="intrinsicContentSize" width="70" height="40"/>
         </designable>
         <designable name="ICb-Y6-aLK">
-            <size key="intrinsicContentSize" width="46" height="30"/>
+            <size key="intrinsicContentSize" width="70" height="40"/>
         </designable>
         <designable name="S4H-vw-aNZ">
-            <size key="intrinsicContentSize" width="30" height="30"/>
+            <size key="intrinsicContentSize" width="30" height="40"/>
         </designable>
         <designable name="fUa-8S-g3h">
-            <size key="intrinsicContentSize" width="30" height="30"/>
+            <size key="intrinsicContentSize" width="30" height="40"/>
         </designable>
         <designable name="xJt-MI-I2f">
-            <size key="intrinsicContentSize" width="46" height="30"/>
+            <size key="intrinsicContentSize" width="70" height="40"/>
         </designable>
     </designables>
     <resources>

--- a/Permanent/ViewModels/InfoViewModel.swift
+++ b/Permanent/ViewModels/InfoViewModel.swift
@@ -8,57 +8,39 @@
 import Foundation
 import UIKit
 
-typealias UpdateUserData = (fullName: String?, primaryEmail: String?, primaryPhone: String?, address: String?, city: String?, state: String?, zip: String?, country: String?)
+typealias UpdateUserData = (fullName: String?, primaryEmail: String?, primaryPhone: String?, address: String?, address2: String?, city: String?, state: String?, zip: String?, country: String?)
+
+enum GetUserDataStatus: Equatable {
+    case success(message: String?)
+    case error(message: String?)
+}
+
+enum UpdateUserDataStatus: Equatable {
+    case success(message: String?)
+    case error(message: String?)
+}
 
 class InfoViewModel: ViewModelInterface {
-    weak var delegate: InfoViewModelDelegate?
     var userData: UpdateUserData
-    var accountId: String?
+    var accountId: Int? {
+        PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.accountIdStorageKey)
+    }
     var dataIsNotModified: Bool
     init() {
-        self.userData = (nil, nil, nil, nil, nil, nil, nil, nil)
+        self.userData = (nil, nil, nil, nil, nil, nil, nil, nil, nil)
         self.dataIsNotModified = false
     }
     
     var sessionProtocol: NetworkSessionProtocol = APINetworkSession()
-}
 
-protocol InfoViewModelDelegate: ViewModelDelegateInterface {
-    func getNewCsrf(then handler: @escaping (Bool) -> Void)
-    func getUserData(with accountId: String, then handler: @escaping (GetUserDataStatus) -> Void)
-    func updateUserData(with accountId: String, userData: UpdateUserData, then handler: @escaping (UpdateUserDataStatus) -> Void)
-}
-
-extension InfoViewModel: InfoViewModelDelegate {
-    func getNewCsrf(then handler: @escaping (Bool) -> Void) {
-        let getNewCsrfOperation = APIOperation(AccountEndpoint.getValidCsrf)
-
-        getNewCsrfOperation.execute(in: APIRequestDispatcher()) { result in
-            switch result {
-            case .json(let response, _):
-                guard
-                    let model: APIResults<NoDataModel> = JSONHelper.decoding(
-                        from: response,
-                        with: APIResults<NoDataModel>.decoder
-                    ),
-                    model.isSuccessful
-
-                else {
-                    return
-                }
-                handler(true)
-                return
-            case .error:
-                handler(false)
-                return
-            default:
-                break
-            }
+    func getUserData(then handler: @escaping (GetUserDataStatus) -> Void) {
+        guard let accountId = accountId else {
+            handler(.error(message: .errorMessage))
+            return
         }
-    }
-
-    func getUserData(with accountId: String, then handler: @escaping (GetUserDataStatus) -> Void) {
-        let getUserDataOperation = APIOperation(AccountEndpoint.getUserData(accountId: accountId))
+        let accountIdString = String("\(accountId)")
+        
+        let getUserDataOperation = APIOperation(AccountEndpoint.getUserData(accountId: accountIdString))
         
         let apiDispatch = APIRequestDispatcher(networkSession: sessionProtocol)
         apiDispatch.ignoresMFAWarning = true
@@ -80,23 +62,32 @@ extension InfoViewModel: InfoViewModelDelegate {
                 self.userData.primaryEmail = model.results.first?.data?.first?.accountVO?.primaryEmail
                 self.userData.fullName = model.results.first?.data?.first?.accountVO?.fullName
                 self.userData.address = model.results.first?.data?.first?.accountVO?.address
+                self.userData.address2 = model.results.first?.data?.first?.accountVO?.address2
                 self.userData.city = model.results.first?.data?.first?.accountVO?.city
                 self.userData.state = model.results.first?.data?.first?.accountVO?.state
                 self.userData.zip = model.results.first?.data?.first?.accountVO?.zip
                 self.userData.country = model.results.first?.data?.first?.accountVO?.country
                 self.userData.primaryPhone = model.results.first?.data?.first?.accountVO?.primaryPhone
+                
                 handler(.success(message: .getUserDetailsWasSuccessfully))
                 return
+                
             case .error:
                 handler(.error(message: .errorMessage))
                 return
+                
             default:
                 break
             }
         }
     }
 
-    func updateUserData(with accountId: String, userData: UpdateUserData, then handler: @escaping (UpdateUserDataStatus) -> Void) {
+    func updateUserData(_ userData: UpdateUserData, then handler: @escaping (UpdateUserDataStatus) -> Void) {
+        guard let accountId = accountId else {
+            handler(.error(message: .errorMessage))
+            return
+        }
+        let accountIdString = String("\(accountId)")
         
         let apiDispatch = APIRequestDispatcher(networkSession: sessionProtocol)
         apiDispatch.ignoresMFAWarning = true
@@ -122,7 +113,7 @@ extension InfoViewModel: InfoViewModelDelegate {
             return
         }
 
-        let updateUserDataOperation = APIOperation(AccountEndpoint.updateUserData(accountId: accountId, updateData: userData))
+        let updateUserDataOperation = APIOperation(AccountEndpoint.updateUserData(accountId: accountIdString, updateData: userData))
 
         updateUserDataOperation.execute(in: apiDispatch) { result in
             switch result {
@@ -136,6 +127,7 @@ extension InfoViewModel: InfoViewModelDelegate {
                     handler(.error(message: .errorMessage))
                     return
                 }
+                
                 guard
                     model.isSuccessful
                 else {
@@ -144,6 +136,7 @@ extension InfoViewModel: InfoViewModelDelegate {
                     handler(.error(message: userDetailsFaieldMessage?.description))
                     return
                 }
+                
                 handler(.success(message: .userDetailsChangedSuccessfully))
 
             case .error:
@@ -180,21 +173,11 @@ extension InfoViewModel: InfoViewModelDelegate {
                 result.append(numbers[index])
 
                 index = numbers.index(after: index)
-
             } else {
                 result.append(ch)
             }
         }
+        
         return result
     }
-}
-
-enum GetUserDataStatus: Equatable {
-    case success(message: String?)
-    case error(message: String?)
-}
-
-enum UpdateUserDataStatus: Equatable {
-    case success(message: String?)
-    case error(message: String?)
 }


### PR DESCRIPTION
- added second address line in account info (storyboard, and view controller)
- improved the view model logic:
  - csrf logic was fixed a while ago, so there's no need to do an update to the csrf token
  - the accountId can live in the viewModel, no need to pass it between the controller and the vm
- removed unused view model code
- linted all files that were touched