### PR TITLE
VSP-630 [iOS] Public Files Screen

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -374,6 +374,7 @@
 		F5A2A07926161AE6003AAF36 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A2A07826161AE6003AAF36 /* NotificationService.swift */; };
 		F5B3A253267A3D19009EBC7B /* SerialInputStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B3A252267A3D18009EBC7B /* SerialInputStream.swift */; };
 		F5B3F13326668CAF0040E5C4 /* UploadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B3F13226668CAF0040E5C4 /* UploadManager.swift */; };
+		F5BC105C278D991400595F94 /* PublicFilesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BC105B278D991400595F94 /* PublicFilesViewModel.swift */; };
 		F5C8D247273204CA00707301 /* SearchVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C8D246273204CA00707301 /* SearchVO.swift */; };
 		F5C8D249273205B000707301 /* SearchEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C8D248273205B000707301 /* SearchEndpoint.swift */; };
 		F5D6693C27467F1300DFA75C /* FileSearchTagsCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D6693B27467F1300DFA75C /* FileSearchTagsCollectionViewCell.swift */; };
@@ -801,6 +802,7 @@
 		F5A2A07A26161AE6003AAF36 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F5B3A252267A3D18009EBC7B /* SerialInputStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerialInputStream.swift; sourceTree = "<group>"; };
 		F5B3F13226668CAF0040E5C4 /* UploadManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UploadManager.swift; sourceTree = "<group>"; };
+		F5BC105B278D991400595F94 /* PublicFilesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicFilesViewModel.swift; sourceTree = "<group>"; };
 		F5C8D246273204CA00707301 /* SearchVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchVO.swift; sourceTree = "<group>"; };
 		F5C8D248273205B000707301 /* SearchEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchEndpoint.swift; sourceTree = "<group>"; };
 		F5D6693B27467F1300DFA75C /* FileSearchTagsCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchTagsCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -992,6 +994,7 @@
 				F58EBC2D25DE963800D2D383 /* SharedFilesViewModel.swift */,
 				F509D6FD2742E2FA007E4594 /* SearchFilesViewModel.swift */,
 				F58B8B9F2758100500D43606 /* PublicArchiveViewModel.swift */,
+				F5BC105B278D991400595F94 /* PublicFilesViewModel.swift */,
 				BCD414D6257F74780019548F /* ShareLinkViewModel.swift */,
 				BC6AF9A825933EAF00483BBA /* MembersViewModel.swift */,
 				5E29C1D425AEF22D00C2A230 /* SecurityViewModel.swift */,
@@ -2345,6 +2348,7 @@
 				5E3A6EE9275F610B00AD6DCC /* FieldNameUI.swift in Sources */,
 				5ED581CB25EFC3A100A5A79E /* FileDetailsBottomCollectionViewCell.swift in Sources */,
 				BC59BABC25C2B7D6005A45D3 /* FileLargeCollectionViewCell.swift in Sources */,
+				F5BC105C278D991400595F94 /* PublicFilesViewModel.swift in Sources */,
 				F5379DB9262EF53300E8F06A /* FilePreviewListViewController.swift in Sources */,
 				BCFB0C332582B485001D89E1 /* ManageLinkData.swift in Sources */,
 				BCD414DD257F828E0019548F /* SharebyURLVO.swift in Sources */,

--- a/Permanent/AppDelegate.swift
+++ b/Permanent/AppDelegate.swift
@@ -187,6 +187,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                         mainVC.checkForRequestShareAccess()
                     } else {
                         let rootVC = UIViewController.create(withIdentifier: .main, from: .main) as! MainViewController
+                        rootVC.viewModel = MyFilesViewModel()
                         self.rootViewController.changeDrawerRoot(viewController: rootVC)
                     }
                 }

--- a/Permanent/Models/DrawerOption.swift
+++ b/Permanent/Models/DrawerOption.swift
@@ -11,6 +11,7 @@ enum DrawerOption {
     case archives
     case files
     case shares
+    case publicFiles
     case members
     case addStorage
     case accountInfo
@@ -25,6 +26,7 @@ enum DrawerOption {
     var icon: UIImage? {
         switch self {
         case .files: return .folder
+        case .publicFiles: return .folder
         case .shares: return .share
         case .members: return .group
         case .addStorage: return .storage
@@ -43,6 +45,7 @@ enum DrawerOption {
     var title: String {
         switch self {
         case .files: return .myFiles
+        case .publicFiles: return "Public Files".localized()
         case .shares: return .shares
         case .members: return String.member.pluralized()
         case .invitations: return .invitations

--- a/Permanent/ViewControllers/FilePreviewListViewController.swift
+++ b/Permanent/ViewControllers/FilePreviewListViewController.swift
@@ -8,23 +8,19 @@
 import UIKit
 
 class FilePreviewListViewController: BaseViewController<FilesViewModel> {
-    
     var pageVC: UIPageViewController!
 
     let controllersCache: NSCache<NSNumber, FilePreviewViewController> = NSCache<NSNumber, FilePreviewViewController>()
     
     var filteredFiles: [FileViewModel] {
-        get {
-            viewModel?.viewModels.filter({ $0.type.isFolder == false }) ?? []
-        }
+        viewModel?.viewModels.filter({ $0.type.isFolder == false }) ?? []
     }
 
     var currentFile: FileViewModel!
     
     // Transition Variables
-    var nextFile: FileViewModel? = nil
-    var nextTitle: String? = nil
-    
+    var nextFile: FileViewModel?
+    var nextTitle: String?
     var hasChanges: Bool = false
         
     override func viewDidLoad() {
@@ -87,7 +83,7 @@ class FilePreviewListViewController: BaseViewController<FilesViewModel> {
     @objc private func infoButtonAction(_ sender: Any) {
         let viewModel = (pageVC.viewControllers?.first as! FilePreviewViewController).viewModel
         
-        let fileDetailsVC = UIViewController.create(withIdentifier: .fileDetailsOnTap , from: .main) as! FileDetailsViewController
+        let fileDetailsVC = UIViewController.create(withIdentifier: .fileDetailsOnTap, from: .main) as! FileDetailsViewController
         fileDetailsVC.file = currentFile
         fileDetailsVC.viewModel = viewModel
         fileDetailsVC.delegate = self
@@ -108,7 +104,7 @@ class FilePreviewListViewController: BaseViewController<FilesViewModel> {
     }
 }
 
-//MARK: - UIPageViewControllerDataSource, UIPageViewControllerDelegate
+// MARK: - UIPageViewControllerDataSource, UIPageViewControllerDelegate
 extension FilePreviewListViewController: UIPageViewControllerDataSource, UIPageViewControllerDelegate {
     func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
         let nextVC = pendingViewControllers.first as! FilePreviewViewController
@@ -162,7 +158,7 @@ extension FilePreviewListViewController: UIPageViewControllerDataSource, UIPageV
             
             return fileDetailsVC
         } else if index >= 0 && index < filteredFiles.count {
-            let fileDetailsVC = UIViewController.create(withIdentifier: .filePreview , from: .main) as! FilePreviewViewController
+            let fileDetailsVC = UIViewController.create(withIdentifier: .filePreview, from: .main) as! FilePreviewViewController
             
             // Preload left and right controllers after the current one is loaded
             if preloadLeftRightLevel <= 2 {
@@ -177,6 +173,10 @@ extension FilePreviewListViewController: UIPageViewControllerDataSource, UIPageV
             fileDetailsVC.loadVM()
             
             if let publicArchiveVM = viewModel as? PublicArchiveViewModel {
+                fileDetailsVC.viewModel?.publicURL = publicArchiveVM.publicURL(forFile: file)
+            }
+            
+            if let publicArchiveVM = viewModel as? PublicFilesViewModel {
                 fileDetailsVC.viewModel?.publicURL = publicArchiveVM.publicURL(forFile: file)
             }
             

--- a/Permanent/ViewControllers/RootViewController.swift
+++ b/Permanent/ViewControllers/RootViewController.swift
@@ -89,6 +89,7 @@ class RootViewController: UIViewController {
             mainViewController = sharesVC
         } else {
             mainViewController = UIViewController.create(withIdentifier: .main, from: .main)
+            (mainViewController as! MainViewController).viewModel = MyFilesViewModel()
         }
         let navController = RootNavigationController(viewController: mainViewController)
         return DrawerViewController(rootViewController: navController, leftSideMenuController: leftSideMenuController, rightSideMenuController: rightSideMenuController)

--- a/Permanent/ViewControllers/SideMenuViewController.swift
+++ b/Permanent/ViewControllers/SideMenuViewController.swift
@@ -7,6 +7,12 @@
 
 import UIKit
 
+enum LeftDrawerSection: Int {
+    case header
+    case leftFiles
+    case leftOthers
+}
+
 class SideMenuViewController: BaseViewController<AuthViewModel> {
     @IBOutlet private var tableView: UITableView!
     @IBOutlet private var versionLabel: UILabel!
@@ -20,7 +26,8 @@ class SideMenuViewController: BaseViewController<AuthViewModel> {
         
         LeftDrawerSection.leftFiles: [
             DrawerOption.files,
-            DrawerOption.shares
+            DrawerOption.shares,
+            DrawerOption.publicFiles
         ],
         
         LeftDrawerSection.leftOthers: [
@@ -39,7 +46,7 @@ class SideMenuViewController: BaseViewController<AuthViewModel> {
         
         if viewModel?.getCurrentArchive() == nil {
             viewModel?.refreshCurrentArchive({ [self] archive in
-                tableView.reloadRows(at: [[0,0]], with: .none)
+                tableView.reloadRows(at: [[0, 0]], with: .none)
             })
         }
     }
@@ -56,10 +63,8 @@ class SideMenuViewController: BaseViewController<AuthViewModel> {
     }
     
     fileprivate func setupTableView() {
-        tableView.register(UINib(nibName: String(describing: DrawerTableViewCell.self), bundle: nil),
-                           forCellReuseIdentifier: String(describing: DrawerTableViewCell.self))
-        tableView.register(UINib(nibName: String(describing: LeftSideHeaderTableViewCell.self), bundle: nil),
-                           forCellReuseIdentifier: String(describing: LeftSideHeaderTableViewCell.self))
+        tableView.register(UINib(nibName: String(describing: DrawerTableViewCell.self), bundle: nil), forCellReuseIdentifier: String(describing: DrawerTableViewCell.self))
+        tableView.register(UINib(nibName: String(describing: LeftSideHeaderTableViewCell.self), bundle: nil), forCellReuseIdentifier: String(describing: LeftSideHeaderTableViewCell.self))
         
         tableView.tableFooterView = UIView()
     }
@@ -67,7 +72,7 @@ class SideMenuViewController: BaseViewController<AuthViewModel> {
     func adjustUIForAnimation(isOpening: Bool) {
         tableView.reloadData()
         
-        if (tableView.contentSize.height < tableView.frame.size.height) {
+        if tableView.contentSize.height < tableView.frame.size.height {
             tableView.isScrollEnabled = false
         } else {
             tableView.isScrollEnabled = true
@@ -100,7 +105,6 @@ extension SideMenuViewController: UITableViewDataSource, UITableViewDelegate {
         
         if menuOption == .archives {
             if let tableViewCell = tableView.dequeueReusableCell(withIdentifier: String(describing: LeftSideHeaderTableViewCell.self)) as? LeftSideHeaderTableViewCell {
-                
                 if let archive = viewModel?.getCurrentArchive(),
                    let archiveName: String = archive.fullName {
                     let archiveThumbURL: String = archive.thumbURL500 ?? ""
@@ -114,11 +118,11 @@ extension SideMenuViewController: UITableViewDataSource, UITableViewDelegate {
             }
         } else {
             if let tableViewCell = tableView.dequeueReusableCell(withIdentifier: String(describing: DrawerTableViewCell.self)) as? DrawerTableViewCell {
-            tableViewCell.updateCell(with: menuOption)
-            cell = tableViewCell
+                tableViewCell.updateCell(with: menuOption)
+                cell = tableViewCell
             }
         }
-    
+        
         return cell
     }
     
@@ -224,7 +228,13 @@ extension SideMenuViewController: UITableViewDataSource, UITableViewDelegate {
     fileprivate func handleMenuOptionTap(forOption option: DrawerOption) {
         switch option {
         case .files:
-            let newRootVC = UIViewController.create(withIdentifier: .main, from: .main)
+            let newRootVC = UIViewController.create(withIdentifier: .main, from: .main) as! MainViewController
+            newRootVC.viewModel = MyFilesViewModel()
+            AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
+            
+        case .publicFiles:
+            let newRootVC = UIViewController.create(withIdentifier: .main, from: .main) as! MainViewController
+            newRootVC.viewModel = PublicFilesViewModel()
             AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
             
         case .shares:
@@ -254,10 +264,4 @@ extension SideMenuViewController: UITableViewDataSource, UITableViewDelegate {
         let newRootVC = UIViewController.create(withIdentifier: id, from: storyboard)
         AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
     }
-}
-
-enum LeftDrawerSection: Int {
-    case header
-    case leftFiles
-    case leftOthers
 }


### PR DESCRIPTION
### MainViewController:
 - adapted the mainVC to support both MyFiles and MyPublicFiles
 - it now requires a ViewModel at the time of instantiation, based on this it can either display private or public files
 - added alert when uploading to the public workspace
 - added a new file option to share public files
 - linted the file

### SideMenuViewController:
 - temporarily added a link to the Public Files
 - this whole UI will be refreshed next sprint
 - linted the file

### RootViewController and AppDelegate:
 - instantiated the appropriate ViewModel for the MainVC

### PublicFilesViewModel:
 - overriden methods needed for the public workspace navigation

### FilePreviewListViewController:
 - added handling for the public files when opened from the public files workspace
 - linted the file