### PR TITLE
VSP-466 [iOS] Copy requires 2 confirmation steps

### DIFF
--- a/Permanent/Constants/Strings.swift
+++ b/Permanent/Constants/Strings.swift
@@ -88,6 +88,7 @@ extension String {
     static var download: String { return "Download".localized() }
     static var copy: String { return "Copy".localized() }
     static var move: String { return "Move".localized() }
+    static var paste: String { return "Paste".localized() }
     static var publish: String { return "Publish".localized() }
     static var publishDescription: String { return "Create a publicly viewable copy of this item in your Public workspace and get a public link to share with anyone.".localized()}
     static var edit: String { return "Edit".localized() }

--- a/Permanent/Managers/FileAction.swift
+++ b/Permanent/Managers/FileAction.swift
@@ -16,11 +16,7 @@ enum FileAction {
     case none
     
     var title: String {
-        switch self {
-        case .copy: return .copy
-        case .move: return .move
-        default: return ""
-        }
+        return .paste
     }
     
     var action: String {

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -707,18 +707,7 @@ extension MainViewController {
     private func didTapRelocate(source: FileViewModel, destination: FileViewModel) {
         guard let fileAction = viewModel?.fileAction else { return }
         
-        let title = String(format: "\(fileAction.title) \"%@\"?", source.name)
-        
-        showActionDialog(
-            styled: .simple,
-            withTitle: title,
-            positiveButtonTitle: fileAction.title,
-            positiveAction: {
-                self.actionDialog?.dismiss()
-                self.relocate(file: source, to: destination)
-            },
-            overlayView: overlayView
-        )
+        self.relocate(file: source, to: destination)
     }
     
     private func download(_ file: FileViewModel) {

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -705,8 +705,6 @@ extension MainViewController {
     }
     
     private func didTapRelocate(source: FileViewModel, destination: FileViewModel) {
-        guard let fileAction = viewModel?.fileAction else { return }
-        
         self.relocate(file: source, to: destination)
     }
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -103,7 +103,7 @@ PODS:
   - nanopb/encode (1.30906.0)
   - ObjectMapper (4.2.0)
   - PromisesObjC (1.2.12)
-  - Protobuf (3.19.1)
+  - Protobuf (3.19.4)
   - SDWebImage (5.10.0):
     - SDWebImage/Core (= 5.10.0)
   - SDWebImage/Core (5.10.0)
@@ -165,7 +165,7 @@ SPEC CHECKSUMS:
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
   ObjectMapper: 1eb41f610210777375fa806bf161dc39fb832b81
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  Protobuf: 3724efa50cb2846d7ccebc8691c574e85fd74471
+  Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
   SDWebImage: 9169792e9eec3e45bba2a0c02f74bf8bd922d1ee
   Sourcery: db66600e8b285c427701821598d07cf3c7e6c476
 


### PR DESCRIPTION
- Removed Copy dialog box
- Changed "Move","Copy" to "Paste" button in the bottom right part of the screen when a file was copied