### PR TITLE
VSP-392 [iOS] Update error message when adding a member that already has access

### DIFF
--- a/Permanent/Network/APIErrors.swift
+++ b/Permanent/Network/APIErrors.swift
@@ -89,6 +89,7 @@ enum PasswordChangeError: String {
 enum MembersOperationsError: String {
     case ownerAccountPending = "error.pr.pending_owner"
     case emailNotValid = "warning.archive.no_email_found"
+    case duplicateAccount = "error.pr.duplicate_share"
     
     var description: String {
         switch self {
@@ -96,6 +97,8 @@ enum MembersOperationsError: String {
             return "There is already a pending owner for this Permanent Archive".localized()
         case .emailNotValid:
             return .emailIsNotValid
+        case .duplicateAccount:
+            return "This account already has access to the Permanent Archive".localized()
         default:
             return .errorMessage
         }

--- a/Permanent/ViewControllers/BaseViewController.swift
+++ b/Permanent/ViewControllers/BaseViewController.swift
@@ -78,6 +78,7 @@ class BaseViewController<T: ViewModelInterface>: UIViewController {
         cancelButtonTitle: String = .cancel,
         positiveButtonColor: UIColor = .primary,
         cancelButtonColor: UIColor = .brightRed,
+        textFieldKeyboardType: UIKeyboardType = .default,
         overlayView: UIView?
     ) {
         
@@ -95,6 +96,7 @@ class BaseViewController<T: ViewModelInterface>: UIViewController {
             placeholders: placeholders,
             prefilledValues: prefilledValues,
             dropdownValues: dropdownValues,
+            textFieldKeyboardType: textFieldKeyboardType,
             onDismiss: {
                 self.view.dismissPopup(
                     self.actionDialog,

--- a/Permanent/ViewControllers/BaseViewController.swift
+++ b/Permanent/ViewControllers/BaseViewController.swift
@@ -81,7 +81,6 @@ class BaseViewController<T: ViewModelInterface>: UIViewController {
         textFieldKeyboardType: UIKeyboardType = .default,
         overlayView: UIView?
     ) {
-        
         guard actionDialog == nil else { return }
         
         actionDialog = ActionDialogView(
@@ -104,7 +103,8 @@ class BaseViewController<T: ViewModelInterface>: UIViewController {
                     completion: { _ in
                         self.actionDialog?.removeFromSuperview()
                         self.actionDialog = nil
-                    })
+                    }
+                )
             }
         )
         

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -729,7 +729,7 @@ extension MainViewController {
             
             onFileDownloaded: { url, error in
                 DispatchQueue.main.async {
-                    self.onFileDownloaded(url: url, error: error)
+                    self.onFileDownloaded(url: url, name: file.name, error: error)
                 }
             },
             
@@ -741,7 +741,7 @@ extension MainViewController {
         )
     }
     
-    fileprivate func onFileDownloaded(url: URL?, error: Error?) {
+    fileprivate func onFileDownloaded(url: URL?, name: String?, error: Error?) {
         refreshCollectionView()
         
         guard url != nil else {
@@ -752,9 +752,10 @@ extension MainViewController {
             } else {
                 showErrorAlert(message: apiError.message)
             }
-
             return
         }
+        let name = name ?? "File" 
+        view.showNotificationBanner(height: Constants.Design.bannerHeight, title: "'\(name)' " + "download completed".localized(), animationDelayInSeconds: Constants.Design.longNotificationBarAnimationDuration)
     }
 }
 

--- a/Permanent/ViewControllers/MembersViewController.swift
+++ b/Permanent/ViewControllers/MembersViewController.swift
@@ -81,13 +81,15 @@ class MembersViewController: BaseViewController<MembersViewModel> {
                 
                 let title = "Switch to The <ARCHIVE_NAME> Archive?".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: requestPAAccess.toArchiveName)
                 let description = "In order to access this content you need to switch to The <ARCHIVE_NAME> Archive.".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: requestPAAccess.toArchiveName)
-                showActionDialog(styled: .simpleWithDescription,
-                                 withTitle: title,
-                                 description: description,
-                                 positiveButtonTitle: "Switch".localized(),
-                                 positiveAction: action,
-                                 cancelButtonTitle: "Cancel".localized(),
-                                 overlayView: overlayView)
+                showActionDialog(
+                    styled: .simpleWithDescription,
+                    withTitle: title,
+                    description: description,
+                    positiveButtonTitle: "Switch".localized(),
+                    positiveAction: action,
+                    cancelButtonTitle: "Cancel".localized(),
+                    overlayView: overlayView
+                )
             } else {
                 getMembers()
             }
@@ -121,11 +123,11 @@ class MembersViewController: BaseViewController<MembersViewModel> {
                 }
             },
             textFieldKeyboardType: .emailAddress,
-            overlayView: self.overlayView)
+            overlayView: self.overlayView
+        )
     }
     
     fileprivate func showTooltip(anchorPoint: CGPoint, text: String) {
-    
         // Check if tooltip view is already presented on screen.
         // If it is visible, we remove it, before presenting it to the new location.
         if tooltipView.isDescendant(of: view) {
@@ -139,7 +141,7 @@ class MembersViewController: BaseViewController<MembersViewModel> {
         NSLayoutConstraint.activate([
             tooltipView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: anchorPoint.x),
             tooltipView.topAnchor.constraint(equalTo: view.topAnchor, constant: anchorPoint.y),
-            tooltipView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            tooltipView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20)
         ])
     }
     
@@ -224,38 +226,40 @@ class MembersViewController: BaseViewController<MembersViewModel> {
     }
     
     fileprivate func didTapDelete(forAccount account: Account) {
-        self.showActionDialog(styled: .simple,
-                              withTitle: String.init(format: .removeMember, account.name),
-                              positiveButtonTitle: .remove,
-                              positiveAction: { [weak self] in
-                                self?.modifyMember(account, withOperation: .remove)
-                              },
-                              overlayView: self.overlayView
+        self.showActionDialog(
+            styled: .simple,
+            withTitle: .init(format: .removeMember, account.name),
+            positiveButtonTitle: .remove,
+            positiveAction: { [weak self] in
+                self?.modifyMember(account, withOperation: .remove)
+            },
+            overlayView: self.overlayView
         )
     }
     
     fileprivate func didTapEdit(forAccount account: Account) {
-        self.showActionDialog(styled: .dropdownWithDescription,
-                            withTitle: account.name,
-                            description: account.email,
-                            placeholders: [.accessLevel],
-                            prefilledValues: [account.accessRole.groupName],
-                            dropdownValues: StaticData.allAccessRoles,
-                            positiveButtonTitle: .save,
-                            positiveAction: {
-                                if let newMemberRole = self.actionDialog?.fieldsInput.last,
-                                   newMemberRole == .owner {
-                                        self.transferOwnership(account, withOperation: .transferOwnership)
-                                    } else {
-                                        if account.accessRole != .owner {
-                                            self.modifyMember(account, withOperation: .edit)
-                                        } else {
-                                            self.actionDialog?.dismiss()
-                                            self.view.showNotificationBanner(height: 60, title: "You cannot change the access level of the Permanent Archive owner".localized(), backgroundColor: .deepRed, textColor: .white, animationDelayInSeconds: Constants.Design.longNotificationBarAnimationDuration)
-                                        }
-                                    }
-                            },
-                            overlayView: self.overlayView
+        self.showActionDialog(
+            styled: .dropdownWithDescription,
+            withTitle: account.name,
+            description: account.email,
+            placeholders: [.accessLevel],
+            prefilledValues: [account.accessRole.groupName],
+            dropdownValues: StaticData.allAccessRoles,
+            positiveButtonTitle: .save,
+            positiveAction: {
+                if let newMemberRole = self.actionDialog?.fieldsInput.last,
+                newMemberRole == .owner {
+                    self.transferOwnership(account, withOperation: .transferOwnership)
+                } else {
+                    if account.accessRole != .owner {
+                        self.modifyMember(account, withOperation: .edit)
+                    } else {
+                        self.actionDialog?.dismiss()
+                        self.view.showNotificationBanner(height: 60, title: "You cannot change the access level of the Permanent Archive owner".localized(), backgroundColor: .deepRed, textColor: .white, animationDelayInSeconds: Constants.Design.longNotificationBarAnimationDuration)
+                    }
+                }
+            },
+            overlayView: self.overlayView
         )
     }
     
@@ -267,29 +271,32 @@ class MembersViewController: BaseViewController<MembersViewModel> {
         actionDialog?.dismiss()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.showActionDialog(styled: .simpleWithDescription,
-                                  withTitle: .transferOwnership,
-                                  description: String.transferOwnershipInfo,
-                                  placeholders: [.accessLevel],
-                                  positiveButtonTitle: String.transferButtonText,
-                                  positiveAction: { [self] in
-                                    actionDialog?.dismiss()
-                                    actionDialog = nil
-                                    showSpinner()
-                
-                                    viewModel?.transferOwnership(email: self.parametersActionDialog.email , then: { status in
-                                        hideSpinner()
-                                        switch status {
-                                        case .success:
-                                            self.view.showNotificationBanner(height: Constants.Design.bannerHeight,title: "Ownership transfer request sent".localized())
-                                            self.getMembers()
-                                        case .error(message: let message):
-                                            self.view.showNotificationBanner(title: message ?? .errorMessage, backgroundColor: .deepRed, textColor: .white, animationDelayInSeconds: Constants.Design.longNotificationBarAnimationDuration)
-                                        }
-                                    })
-                                  },
-                                  overlayView: self.overlayView
-            )}
+            self.showActionDialog(
+                styled: .simpleWithDescription,
+                withTitle: .transferOwnership,
+                description: String.transferOwnershipInfo,
+                placeholders: [.accessLevel],
+                positiveButtonTitle: String.transferButtonText,
+                positiveAction: { [self] in
+                    actionDialog?.dismiss()
+                    actionDialog = nil
+                    showSpinner()
+                    
+                    viewModel?.transferOwnership(email: self.parametersActionDialog.email, then: { status in
+                        hideSpinner()
+                        switch status {
+                        case .success:
+                            self.view.showNotificationBanner(height: Constants.Design.bannerHeight, title: "Ownership transfer request sent".localized())
+                            self.getMembers()
+                            
+                        case .error(message: let message):
+                            self.view.showNotificationBanner(title: message ?? .errorMessage, backgroundColor: .deepRed, textColor: .white, animationDelayInSeconds: Constants.Design.longNotificationBarAnimationDuration)
+                        }
+                    })
+                },
+                overlayView: self.overlayView
+            )
+        }
     }
     
     func showEmailWarning(_ message: String) {
@@ -297,9 +304,11 @@ class MembersViewController: BaseViewController<MembersViewModel> {
         
         alert.addAction(UIAlertAction(title: .cancel, style: .cancel, handler: {_ in
             self.actionDialog?.dismiss()
-        }))
+        })
+        )
         alert.addAction(UIAlertAction(title: .retry, style: .default, handler: {_ in
-        }))
+        })
+        )
         
         self.present(alert, animated: true)
     }
@@ -309,11 +318,13 @@ class MembersViewController: BaseViewController<MembersViewModel> {
         
         actions.append(PRMNTAction(title: "Remove".localized(), color: .brightRed, handler: { [self] action in
             modifyMember(account, withOperation: .remove)
-        }))
+        })
+        )
         
         actions.append(PRMNTAction(title: "Edit".localized(), color: .primary, handler: { [self] action in
             didTapEdit(forAccount: account)
-        }))
+        })
+        )
     
         let actionSheet = PRMNTActionSheetViewController(title: account.email, actions: actions)
         present(actionSheet, animated: true, completion: nil)
@@ -342,7 +353,7 @@ extension MembersViewController: UITableViewDelegate, UITableViewDataSource {
         cell.member = member
         
         let hasEditPermission = viewModel?.archivePermissions.contains(.archiveShare) ?? false
-        cell.editButton.isHidden = !((hasEditPermission && member?.accessRole != .owner)||(member?.accessRole == .owner && member?.status == .pending))
+        cell.editButton.isHidden = !((hasEditPermission && member?.accessRole != .owner) || (member?.accessRole == .owner && member?.status == .pending))
         
         cell.editButtonAction = { [weak self] cell in
             guard let viewModel = self?.viewModel,
@@ -351,7 +362,7 @@ extension MembersViewController: UITableViewDelegate, UITableViewDataSource {
                 return
             }
             
-            self?.showFileActionSheet(forAccount:account, atIndexPath: indexPath)
+            self?.showFileActionSheet(forAccount: account, atIndexPath: indexPath)
         }
         
         return cell
@@ -362,7 +373,6 @@ extension MembersViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        
         guard
             let accessRole = AccessRole(rawValue: section),
             let tooltipText = StaticData.rolesTooltipData[accessRole] else {
@@ -378,7 +388,8 @@ extension MembersViewController: UITableViewDelegate, UITableViewDataSource {
             tooltipText: tooltipText,
             action: { point, text in
                 self.showTooltip(anchorPoint: point, text: text)
-            })
+            }
+        )
         
         let numberOfItems = viewModel?.numberOfItemsForRole(accessRole)
         headerView.isSectionEmpty = numberOfItems == 0
@@ -402,7 +413,6 @@ extension MembersViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        
         guard
             let viewModel = viewModel,
             let accessRole = AccessRole(rawValue: indexPath.section),
@@ -433,5 +443,4 @@ extension MembersViewController: UITableViewDelegate, UITableViewDataSource {
             deleteAction
         ])
     }
-
 }

--- a/Permanent/ViewControllers/MembersViewController.swift
+++ b/Permanent/ViewControllers/MembersViewController.swift
@@ -15,7 +15,7 @@ class MembersViewController: BaseViewController<MembersViewModel> {
     
     lazy var tooltipView = TooltipView(frame: .zero)
     
-    var parametersActionDialog: AddMemberParams = (nil,"","")
+    var parametersActionDialog: AddMemberParams = (nil, "", "")
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -120,6 +120,7 @@ class MembersViewController: BaseViewController<MembersViewModel> {
                     }
                 }
             },
+            textFieldKeyboardType: .emailAddress,
             overlayView: self.overlayView)
     }
     

--- a/Permanent/ViewControllers/SharesViewController.swift
+++ b/Permanent/ViewControllers/SharesViewController.swift
@@ -391,7 +391,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             }
         }, onFileDownloaded: { url, error in
             DispatchQueue.main.async {
-                self.onFileDownloaded(url: url, error: error)
+                self.onFileDownloaded(url: url, name: file.name, error: error)
             }
         }, progressHandler: { progress in
             DispatchQueue.main.async {
@@ -400,10 +400,10 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         })
     }
     
-    fileprivate func onFileDownloaded(url: URL?, error: Error?) {
+    fileprivate func onFileDownloaded(url: URL?, name: String?, error: Error?) {
         self.refreshCollectionView()
         
-        guard let _ = url else {
+        guard url != nil else {
             let apiError = (error as? APIError) ?? .unknown
             
             if apiError == .cancelled {
@@ -411,9 +411,10 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             } else {
                 showErrorAlert(message: apiError.message)
             }
-
             return
         }
+        let name = name ?? "File"
+        view.showNotificationBanner(height: Constants.Design.bannerHeight, title: "'\(name)' " + "download completed".localized(), animationDelayInSeconds: Constants.Design.longNotificationBarAnimationDuration)
     }
     
     private func handleCellRightButtonAction(for file: FileViewModel, atIndexPath indexPath: IndexPath) {

--- a/Permanent/ViewControllers/SharesViewController.swift
+++ b/Permanent/ViewControllers/SharesViewController.swift
@@ -52,8 +52,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         navigationItem.title = .shares
         view.backgroundColor = .backgroundPrimary
         
-        segmentedControl.setTitleTextAttributes([.foregroundColor: UIColor.white,
-                                                 .font: Text.style11.font], for: .selected)
+        segmentedControl.setTitleTextAttributes([.foregroundColor: UIColor.white, .font: Text.style11.font], for: .selected)
         segmentedControl.setTitleTextAttributes([.font: Text.style8.font], for: .normal)
         segmentedControl.setTitle(.sharedByMe, forSegmentAt: 0)
         segmentedControl.setTitle(.sharedWithMe, forSegmentAt: 1)
@@ -146,7 +145,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     
                     self?.viewModel?.changeArchive(withArchiveId: sharedFile.toArchiveId, archiveNbr: sharedFile.toArchiveNbr, completion: { success in
                         if success {
-                            self?.getShares() {
+                            self?.getShares {
                                 _presentFileDetails()
                             }
                         }
@@ -155,15 +154,17 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                 
                 let title = "Switch to The <ARCHIVE_NAME> Archive?".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: sharedFile.toArchiveName)
                 let description = "In order to access this content you need to switch to The <ARCHIVE_NAME> Archive.".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: sharedFile.toArchiveName)
-                showActionDialog(styled: .simpleWithDescription,
-                                 withTitle: title,
-                                 description: description,
-                                 positiveButtonTitle: "Switch".localized(),
-                                 positiveAction: action,
-                                 cancelButtonTitle: "Cancel".localized(),
-                                 overlayView: overlayView)
+                showActionDialog(
+                    styled: .simpleWithDescription,
+                    withTitle: title,
+                    description: description,
+                    positiveButtonTitle: "Switch".localized(),
+                    positiveAction: action,
+                    cancelButtonTitle: "Cancel".localized(),
+                    overlayView: overlayView
+                )
             } else {
-                getShares() {
+                getShares {
                     _presentFileDetails()
                 }
             }
@@ -189,7 +190,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     
                     self?.viewModel?.changeArchive(withArchiveId: sharedFolder.toArchiveId, archiveNbr: sharedFolder.toArchiveNbr, completion: { success in
                         if success {
-                            self?.getShares() {
+                            self?.getShares {
                                 self?.navigateToFolder(withParams: navigationParams, backNavigation: false) {
                                     self?.backButton.isHidden = false
                                     self?.directoryLabel.text = navigationParams.folderName
@@ -203,15 +204,17 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                 
                 let title = "Switch to The <ARCHIVE_NAME> Archive?".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: sharedFolder.toArchiveName)
                 let description = "In order to access this content you need to switch to The <ARCHIVE_NAME> Archive.".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: sharedFolder.toArchiveName)
-                showActionDialog(styled: .simpleWithDescription,
-                                 withTitle: title,
-                                 description: description,
-                                 positiveButtonTitle: "Switch".localized(),
-                                 positiveAction: action,
-                                 cancelButtonTitle: "Cancel".localized(),
-                                 overlayView: overlayView)
+                showActionDialog(
+                    styled: .simpleWithDescription,
+                    withTitle: title,
+                    description: description,
+                    positiveButtonTitle: "Switch".localized(),
+                    positiveAction: action,
+                    cancelButtonTitle: "Cancel".localized(),
+                    overlayView: overlayView
+                )
             } else {
-                getShares() { [self] in
+                getShares { [self] in
                     navigateToFolder(withParams: navigationParams, backNavigation: false) {
                         backButton.isHidden = false
                         directoryLabel.text = navigationParams.folderName
@@ -374,6 +377,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self.directoryLabel.text = "Shares".localized()
                     self.backButton.isHidden = true
                 }
+                
             case .error(let message):
                 self.showErrorAlert(message: message)
             }
@@ -439,7 +443,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
     
     private func handleProgress(forFile file: FileViewModel, withValue value: Float) {
         guard let index = viewModel?.viewModels.firstIndex(where: { $0.recordId == file.recordId }),
-              let downloadingCell = collectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? FileCollectionViewCell
+            let downloadingCell = collectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? FileCollectionViewCell
         else {
             return
         }
@@ -555,7 +559,7 @@ extension SharesViewController: UICollectionViewDelegateFlowLayout, UICollection
         let section = indexPath.section
         let title = viewModel?.title(forSection: section) ?? ""
         
-        if kind == UICollectionView.elementKindSectionHeader && title.count > 0 {
+        if kind == UICollectionView.elementKindSectionHeader && title.isNotEmpty {
             let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: "HeaderView", for: indexPath) as! FileCollectionViewHeader
             headerView.leftButtonTitle = title
             if viewModel?.shouldPerformAction(forSection: section) == true {
@@ -574,10 +578,9 @@ extension SharesViewController: UICollectionViewDelegateFlowLayout, UICollection
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
-        let height: CGFloat = viewModel?.numberOfRowsInSection(section) != 0 && (viewModel?.title(forSection: section) ?? "").count > 0 ? 40 : 0
+        let height: CGFloat = viewModel?.numberOfRowsInSection(section) != 0 && (viewModel?.title(forSection: section) ?? "").isNotEmpty ? 40 : 0
         return CGSize(width: UIScreen.main.bounds.width, height: height)
     }
-    
 }
 
 // MARK: - CollectionView Related
@@ -611,7 +614,6 @@ extension SharesViewController: FilePreviewNavigationControllerDelegate {
     }
     
     func filePreviewNavigationControllerDidChange(_ filePreviewNavigationVC: UIViewController, hasChanges: Bool) {
-        
     }
 }
 

--- a/Permanent/ViewModels/MembersViewModel.swift
+++ b/Permanent/ViewModels/MembersViewModel.swift
@@ -77,10 +77,15 @@ class MembersViewModel: ViewModelInterface {
                     let model: APIResults<AccountVO> = JSONHelper.decoding(
                         from: response,
                         with: APIResults<AccountVO>.decoder
-                    ), model.isSuccessful else {
+                    ) else {
                     return handler(.error(message: .errorMessage))
                 }
-                                
+                guard model.isSuccessful  else {
+                    let message = model.results.first?.message.first
+                    let memberOperationFailedMessage = MembersOperationsError(rawValue: message ?? .errorUnknown)
+                    handler(.error(message: memberOperationFailedMessage?.description))
+                    return
+                }
                 handler(.success)
                 
             case .error(let error, _):

--- a/Permanent/ViewModels/UI/FileListType.swift
+++ b/Permanent/ViewModels/UI/FileListType.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 enum FileListType: Int {
-    
     case downloading = 0
     
     case uploading

--- a/Permanent/Views/ActionDialogView/ActionDialogStyle.swift
+++ b/Permanent/Views/ActionDialogView/ActionDialogStyle.swift
@@ -26,5 +26,4 @@ enum ActionDialogStyle {
     
     /// Dialog with title, an input field and a dropdown (UIPickerView).
     case inputWithDropdown
-    
 }

--- a/Permanent/Views/ActionDialogView/ActionDialogView.swift
+++ b/Permanent/Views/ActionDialogView/ActionDialogView.swift
@@ -26,6 +26,7 @@ class ActionDialogView: UIView {
     private var prefilledValues: [String]?
     private var dropdownValues: [String]?
     private var dialogStyle: ActionDialogStyle = .simple
+    private var textFieldKeyboardType: UIKeyboardType = .default
     
     var positiveAction: ButtonAction?
     var removeAction: ButtonAction? {
@@ -56,7 +57,7 @@ class ActionDialogView: UIView {
         return inputArray
     }
     
-    convenience init(frame: CGRect, style: ActionDialogStyle, title: String?, description: String? = nil, positiveButtonTitle: String?, cancelButtonTitle:String? ,positiveButtonColor: UIColor?, cancelButtonColor: UIColor?, placeholders: [String]? = nil, prefilledValues: [String]? = nil, dropdownValues: [String]? = nil, onDismiss: @escaping ButtonAction) {
+    convenience init(frame: CGRect, style: ActionDialogStyle, title: String?, description: String? = nil, positiveButtonTitle: String?, cancelButtonTitle: String?, positiveButtonColor: UIColor?, cancelButtonColor: UIColor?, placeholders: [String]? = nil, prefilledValues: [String]? = nil, dropdownValues: [String]? = nil, textFieldKeyboardType: UIKeyboardType = .default, onDismiss: @escaping ButtonAction) {
         self.init(frame: frame)
         
         self.onDismiss = onDismiss
@@ -64,6 +65,7 @@ class ActionDialogView: UIView {
         self.placeholders = placeholders
         self.prefilledValues = prefilledValues
         self.dropdownValues = dropdownValues
+        self.textFieldKeyboardType = textFieldKeyboardType
         
         commonInit()
         
@@ -170,6 +172,7 @@ class ActionDialogView: UIView {
         field.textColor = .dustyGray
         field.placeholderColor = .dustyGray
         field.placeholder = placeholder
+        field.keyboardType = textFieldKeyboardType
         field.delegate = self
     }
     

--- a/Permanent/Views/ActionDialogView/ActionDialogView.swift
+++ b/Permanent/Views/ActionDialogView/ActionDialogView.swift
@@ -178,7 +178,6 @@ class ActionDialogView: UIView {
     
     fileprivate func styleFields() {
         for (index, field) in fieldsStackView.arrangedSubviews.enumerated() {
-
             let fieldValue = prefilledValues?[index] ?? placeholders?[index]
             
             if let textField = field as? TextField {
@@ -253,5 +252,4 @@ extension ActionDialogView: UIPickerViewDelegate, UIPickerViewDataSource {
         let dropdownView = fieldsStackView.arrangedSubviews.last as? DropdownView
         dropdownView?.value = dropdownValues?[row]
     }
-    
 }

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsBaseCollectionViewCell.swift
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsBaseCollectionViewCell.swift
@@ -16,6 +16,7 @@ class FileDetailsBaseCollectionViewCell: UICollectionViewCell {
         switch cellType {
         case .name:
             return "Name".localized()
+            
         case .description:
             return "Description".localized()
         case .date:

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsBaseCollectionViewCell.swift
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsBaseCollectionViewCell.swift
@@ -19,28 +19,39 @@ class FileDetailsBaseCollectionViewCell: UICollectionViewCell {
             
         case .description:
             return "Description".localized()
+            
         case .date:
             return "Date".localized()
+            
         case .location:
             return "Location".localized()
+            
         case .tags:
             return "Tags".localized()
+            
         case .uploaded:
             return "Uploaded".localized()
         case .lastModified:
             return "Last Modified".localized()
+            
         case .created:
             return "Created".localized()
+            
         case .fileCreated:
             return "File Created".localized()
+            
         case .size:
             return "Size".localized()
+            
         case .fileType:
             return "File Type".localized()
+            
         case .originalFileName:
             return "Original File Name".localized()
+            
         case .originalFileType:
             return "Original File Type".localized()
+            
         default: return ""
         }
     }
@@ -58,5 +69,4 @@ class FileDetailsBaseCollectionViewCell: UICollectionViewCell {
         self.viewModel = viewModel
         self.cellType = type
     }
-    
 }

--- a/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsBottomCollectionViewCell.xib
+++ b/Permanent/Views/Cells/FileDetailsCollectionViewCells/FileDetailsBottomCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,7 +20,7 @@
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="aGj-jI-7Xc">
                         <rect key="frame" x="20" y="26" width="226" height="34"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                        <textInputTraits key="textInputTraits" returnKeyType="done"/>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done"/>
                     </textField>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2xc-Ku-yLp">
                         <rect key="frame" x="20" y="0.0" width="226" height="21"/>

--- a/Permanent/Views/Share Link/InputSettingsView.swift
+++ b/Permanent/Views/Share Link/InputSettingsView.swift
@@ -99,7 +99,7 @@ class InputSettingsView: UIView {
         let spaceButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: nil, action: nil)
         let cancelButton = UIBarButtonItem(title: .cancel, style: .plain, target: self, action: #selector(cancel))
         
-        toolbar.setItems([doneButton,spaceButton,cancelButton], animated: false)
+        toolbar.setItems([cancelButton,spaceButton,doneButton], animated: false)
         
         textField.inputView = datePicker
         textField.inputAccessoryView = toolbar

--- a/Permanent/Views/Share Link/InputSettingsView.swift
+++ b/Permanent/Views/Share Link/InputSettingsView.swift
@@ -86,7 +86,7 @@ class InputSettingsView: UIView {
     func configureNumericUI() {
         let toolbar = UIToolbar()
         toolbar.sizeToFit()
-        let doneButton = UIBarButtonItem(title: .done, style: .plain, target: self, action: #selector(cancel));
+        let doneButton = UIBarButtonItem(title: .done, style: .plain, target: self, action: #selector(cancel))
         
         toolbar.setItems([doneButton], animated: false)
         textField.inputAccessoryView = toolbar
@@ -95,7 +95,7 @@ class InputSettingsView: UIView {
     func configureDatePickerUI() {
         let toolbar = UIToolbar()
         toolbar.sizeToFit()
-        let doneButton = UIBarButtonItem(title: .done, style: .plain, target: self, action: #selector(doneDatePicker));
+        let doneButton = UIBarButtonItem(title: .done, style: .plain, target: self, action: #selector(doneDatePicker))
         let spaceButton = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.flexibleSpace, target: nil, action: nil)
         let cancelButton = UIBarButtonItem(title: .cancel, style: .plain, target: self, action: #selector(cancel))
         
@@ -106,7 +106,7 @@ class InputSettingsView: UIView {
     }
     
     @objc
-    private func doneDatePicker(){
+    private func doneDatePicker() {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         textField.text = formatter.string(from: datePicker.date)
@@ -114,7 +114,7 @@ class InputSettingsView: UIView {
     }
 
     @objc
-    private func cancel(){
+    private func cancel() {
         self.endEditing(true)
     }
 }


### PR DESCRIPTION
- Update error message when adding a member that already has access [VSP-392]
- Description field defaults to lowercase [VSP-472]
- Adding a member should pop up the email keyboard [VSP-500]
- When editing settings for a share link, the expiration date has "cancel" and "done" reversed from where I expected them to be. Done is on the left and Cancel is on the right [VSP-671]
- When downloading an image, you tap download and then it does happen, but there's no confirmation on the Permanent app that anything happened. It'd be nice if there was confirmation that it downloaded [VSP-672]
- Resolved SwiftLint warnings for modified files