### PR TITLE
VSP-673 [iOS] Message on rename is incorrect.

### DIFF
--- a/Permanent/Storyboards/Archives.storyboard
+++ b/Permanent/Storyboards/Archives.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -70,7 +70,7 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="1XR-vW-kpT">
-                                <rect key="frame" x="20" y="139" width="374" height="643"/>
+                                <rect key="frame" x="20" y="139" width="374" height="703"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dataSource" destination="Y6W-OH-hqX" id="lHD-SP-Fca"/>
@@ -97,7 +97,7 @@
                             <constraint firstItem="LiA-iD-9rz" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="15" id="DuO-Tc-P2g"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="1XR-vW-kpT" secondAttribute="trailing" constant="20" id="G86-bx-A67"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Ke2-ZL-CVN" secondAttribute="trailing" constant="20" id="VEo-Yb-xiS"/>
-                            <constraint firstItem="Ke2-ZL-CVN" firstAttribute="top" secondItem="1XR-vW-kpT" secondAttribute="bottom" constant="20" id="ZVL-x5-FVg"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="1XR-vW-kpT" secondAttribute="bottom" constant="20" id="ZVL-x5-FVg"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Ke2-ZL-CVN" secondAttribute="bottom" constant="20" id="dJ9-Aa-F18"/>
                             <constraint firstItem="LiA-iD-9rz" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="hsb-iu-sI3"/>
                             <constraint firstItem="1XR-vW-kpT" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="pzh-QJ-Yt1"/>
@@ -111,6 +111,7 @@
                         <outlet property="currentArhiveImage" destination="f17-Ki-h3h" id="S6l-js-VZ1"/>
                         <outlet property="currentArhiveNameLabel" destination="jxK-VT-fQQ" id="t0C-SH-qG5"/>
                         <outlet property="tableView" destination="1XR-vW-kpT" id="8AT-Ub-nLJ"/>
+                        <outlet property="tableViewBottomConstraint" destination="ZVL-x5-FVg" id="Jsk-aC-Wb3"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Permanent/ViewControllers/ArchivesViewController.swift
+++ b/Permanent/ViewControllers/ArchivesViewController.swift
@@ -19,6 +19,7 @@ class ArchivesViewController: BaseViewController<ArchivesViewModel> {
     @IBOutlet weak var createNewArchiveButton: RoundedButton!
     @IBOutlet weak var currentArchiveRightButton: UIButton!
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var tableViewBottomConstraint: NSLayoutConstraint!
     
     weak var delegate: ArchivesViewControllerDelegate?
     var isManaging = true
@@ -71,6 +72,7 @@ class ArchivesViewController: BaseViewController<ArchivesViewModel> {
         
         createNewArchiveButton.configureActionButtonUI(title: String("Create new archive".localized()))
         createNewArchiveButton.isHidden = !isManaging
+        tableViewBottomConstraint.constant = isManaging ? 80 : 20
         
         view.addSubview(overlayView)
         overlayView.backgroundColor = .overlay
@@ -351,6 +353,9 @@ extension ArchivesViewController: UITableViewDataSource, UITableViewDelegate {
                 switchToArchive(archive)
                 
                 tableView.deselectRow(at: indexPath, animated: true)
+                if !isManaging {
+                    dismiss(animated: true, completion: nil)
+                }
             }
         }
     }

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -482,9 +482,9 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
             case .success:
                 self.pullToRefreshAction()
                 if file.type.isFolder {
-                    self.view.showNotificationBanner(height: Constants.Design.bannerHeight, title: "Folder rename was successfully".localized())
+                    self.view.showNotificationBanner(height: Constants.Design.bannerHeight, title: "Folder rename was successful".localized())
                 } else {
-                    self.view.showNotificationBanner(height: Constants.Design.bannerHeight, title: "File rename was successfully".localized())
+                    self.view.showNotificationBanner(height: Constants.Design.bannerHeight, title: "File rename was successful".localized())
                 }
                 
             case .error( _):
@@ -1059,7 +1059,8 @@ extension MainViewController {
         self.showActionDialog(
             styled: .singleField,
             withTitle: title,
-            prefilledValues: ["Name".localized()],
+            placeholders: ["Name".localized()],
+            prefilledValues: ["\(file.name)"],
             positiveButtonTitle: .rename,
             positiveAction: {
                 guard let inputName = self.actionDialog?.fieldsInput.first?.description else { return }

--- a/Permanent/Views/ActionDialogView/ActionDialogView.swift
+++ b/Permanent/Views/ActionDialogView/ActionDialogView.swift
@@ -165,26 +165,28 @@ class ActionDialogView: UIView {
         button.layer.cornerRadius = Constants.Design.actionButtonRadius
     }
     
-    fileprivate func styleTextField(_ field: TextField, placeholder: String?) {
+    fileprivate func styleTextField(_ field: TextField, placeholder: String?, fieldValue: String? = nil) {
         field.backgroundColor = .galleryGray
         field.layer.borderColor = UIColor.doveGray.cgColor
         field.tintColor = .dustyGray
         field.textColor = .dustyGray
         field.placeholderColor = .dustyGray
         field.placeholder = placeholder
+        field.text = fieldValue
         field.keyboardType = textFieldKeyboardType
         field.delegate = self
     }
     
     fileprivate func styleFields() {
         for (index, field) in fieldsStackView.arrangedSubviews.enumerated() {
-            let fieldValue = prefilledValues?[index] ?? placeholders?[index]
+            let fieldValue = prefilledValues?[index] ?? ""
+            let fieldPlaceholder = placeholders?[index]
             
             if let textField = field as? TextField {
-                styleTextField(textField, placeholder: fieldValue)
+                styleTextField(textField, placeholder: fieldPlaceholder, fieldValue: fieldValue)
             } else {
                 if let dropdownView = field as? DropdownView {
-                    dropdownView.value = fieldValue
+                    dropdownView.value = fieldValue.isEmpty ? fieldPlaceholder : fieldValue
                 }
             }
         }


### PR DESCRIPTION
- Fixed notification message when successful rename file/folder
- Added file/folder name in the edit field when renaming, in case the user just wants to make a small change
- Removed the step when the user had to press the additional done button in changing archive screen for a share link
- Removed bottom white space when changing archives for a share link.