### PR TITLE
VSP-676 [iOS] Account Info: Allow editing of individual fields

### DIFF
--- a/Permanent/Assets/Localization/en.lproj/Localizable.strings
+++ b/Permanent/Assets/Localization/en.lproj/Localizable.strings
@@ -146,7 +146,7 @@
 "PasswordMatchError" = "Passwords must match.";
 "PasswordChangedSuccessfully" = "Password updated.";
 "Security" = "Security";
-"AccountInfo" = "Account Info";
+"AccountInfo" = "Account";
 "UpdatePassword" = "Update Password";
 "CurrentPassword" = "Current Password";
 "ReTypePassword" = "Re-type New Password";

--- a/Permanent/Models/DrawerOption.swift
+++ b/Permanent/Models/DrawerOption.swift
@@ -50,7 +50,7 @@ enum DrawerOption {
         case .publicFiles: return "Public Files".localized()
         case .shares: return "Shared Files".localized()
         case .members: return "Manage Members".localized()
-        case .manageArchives: return "Switch Archives".localized()
+        case .manageArchives: return "Archives".localized()
         case .publicGallery: return "Public Gallery".localized()
         case .invitations: return .invitations
         case .activityFeed: return .activityFeed

--- a/Permanent/ViewControllers/AccountInfoViewController.swift
+++ b/Permanent/ViewControllers/AccountInfoViewController.swift
@@ -139,17 +139,17 @@ extension AccountInfoViewController: UITextFieldDelegate {
     }
     
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        switchBasedNextTextField(textField)
-        return true
-    }
-    
-    private func switchBasedNextTextField(_ textField: UITextField) {
         textField.resignFirstResponder()
         
-        if textField == postalCodeView.textField || textField == countryView.textField {
+        switch textField {
+        case postalCodeView.textField, countryView.textField, cityView.textField, stateView.textField:
             let point = CGPoint.zero
             scrollView.setContentOffset(point, animated: true)
+            
+        default:
+            break
         }
+        return true
     }
 
     func textFieldDidBeginEditing(_ textField: UITextField) {

--- a/Permanent/ViewControllers/AccountInfoViewController.swift
+++ b/Permanent/ViewControllers/AccountInfoViewController.swift
@@ -31,14 +31,14 @@ class AccountInfoViewController: BaseViewController<InfoViewModel> {
         title = .accountInfo
         view.backgroundColor = .white
         
-        accountNameView.configureElementUI(label: .accountName, returnKey: UIReturnKeyType.next)
-        primaryEmailView.configureElementUI(label: .primaryEmail, returnKey: UIReturnKeyType.next)
-        mobilePhoneView.configureElementUI(label: .mobilePhone, returnKey: UIReturnKeyType.next, keyboardType: .numbersAndPunctuation)
-        addressView.configureElementUI(label: "Address Line 1".localized(), returnKey: UIReturnKeyType.next)
-        addressView2.configureElementUI(label: "Address Line 2".localized(), returnKey: UIReturnKeyType.next)
-        cityView.configureElementUI(label: .city, returnKey: UIReturnKeyType.next)
-        stateView.configureElementUI(label: .stateOrRegion, returnKey: UIReturnKeyType.next)
-        postalCodeView.configureElementUI(label: .postalcode, returnKey: UIReturnKeyType.next)
+        accountNameView.configureElementUI(label: .accountName, returnKey: UIReturnKeyType.done)
+        primaryEmailView.configureElementUI(label: .primaryEmail, returnKey: UIReturnKeyType.done)
+        mobilePhoneView.configureElementUI(label: .mobilePhone, returnKey: UIReturnKeyType.done, keyboardType: .numbersAndPunctuation)
+        addressView.configureElementUI(label: "Address Line 1".localized(), returnKey: UIReturnKeyType.done)
+        addressView2.configureElementUI(label: "Address Line 2".localized(), returnKey: UIReturnKeyType.done)
+        cityView.configureElementUI(label: .city, returnKey: UIReturnKeyType.done)
+        stateView.configureElementUI(label: .stateOrRegion, returnKey: UIReturnKeyType.done)
+        postalCodeView.configureElementUI(label: .postalcode, returnKey: UIReturnKeyType.done)
         countryView.configureElementUI(label: .country, returnKey: UIReturnKeyType.done)
         contentUpdateButton.configureActionButtonUI(title: .save)
         deleteAccountButton.configureActionButtonUI(title: "Delete Account".localized(), bgColor: .deepRed)
@@ -144,33 +144,9 @@ extension AccountInfoViewController: UITextFieldDelegate {
     }
     
     private func switchBasedNextTextField(_ textField: UITextField) {
-        switch textField {
-        case accountNameView.textField:
-            primaryEmailView.textField.becomeFirstResponder()
-            
-        case primaryEmailView.textField:
-            mobilePhoneView.textField.becomeFirstResponder()
-            
-        case mobilePhoneView.textField:
-            addressView.textField.becomeFirstResponder()
-            
-        case addressView.textField:
-            addressView2.textField.becomeFirstResponder()
-            
-        case addressView2.textField:
-            cityView.textField.becomeFirstResponder()
-            
-        case cityView.textField:
-            stateView.textField.becomeFirstResponder()
-            
-        case stateView.textField:
-            postalCodeView.textField.becomeFirstResponder()
-            
-        case postalCodeView.textField:
-            countryView.textField.becomeFirstResponder()
-            
-        default:
-            countryView.textField.resignFirstResponder()
+        textField.resignFirstResponder()
+        
+        if textField == postalCodeView.textField || textField == countryView.textField {
             let point = CGPoint.zero
             scrollView.setContentOffset(point, animated: true)
         }

--- a/Permanent/ViewControllers/ArchivesViewController.swift
+++ b/Permanent/ViewControllers/ArchivesViewController.swift
@@ -50,7 +50,7 @@ class ArchivesViewController: BaseViewController<ArchivesViewModel> {
         super.styleNavBar()
         
         if isManaging {
-            title = "Switch Archives".localized()
+            title = "Archives".localized()
         } else {
             title = "Change Archive".localized()
             

--- a/Permanent/ViewControllers/RightSideMenuViewController.swift
+++ b/Permanent/ViewControllers/RightSideMenuViewController.swift
@@ -26,6 +26,7 @@ class RightSideMenuViewController: BaseViewController<AuthViewModel> {
             DrawerOption.addStorage,
             DrawerOption.accountInfo,
             DrawerOption.activityFeed,
+            DrawerOption.manageArchives,
             DrawerOption.invitations,
             DrawerOption.security,
             DrawerOption.contactSupport,
@@ -216,6 +217,10 @@ extension RightSideMenuViewController: UITableViewDataSource, UITableViewDelegat
         switch option {
         case .accountInfo:
             let newRootVC = UIViewController.create(withIdentifier: .accountInfo, from: .settings)
+            AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
+            
+        case .manageArchives:
+            let newRootVC = UIViewController.create(withIdentifier: .archives, from: .archives)
             AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
             
         case .security:

--- a/Permanent/ViewControllers/SideMenuViewController.swift
+++ b/Permanent/ViewControllers/SideMenuViewController.swift
@@ -30,7 +30,6 @@ class SideMenuViewController: BaseViewController<AuthViewModel> {
             DrawerOption.publicFiles
         ],
         LeftDrawerSection.manage: [
-            DrawerOption.manageArchives,
             DrawerOption.members
         ]
     ]
@@ -225,10 +224,6 @@ extension SideMenuViewController: UITableViewDataSource, UITableViewDelegate {
             let newRootVC = UIViewController.create(withIdentifier: .members, from: .members)
             AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
 
-        case .manageArchives:
-            let newRootVC = UIViewController.create(withIdentifier: .archives, from: .archives)
-            AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
-            
         case .archives:
             guard let archive = viewModel?.getCurrentArchive() else { return }
             let newRootVC = UIViewController.create(withIdentifier: .publicArchive, from: .profile) as! PublicArchiveViewController


### PR DESCRIPTION
- Changed "Next" button with "Done" for being able to dismiss the keyboard after the field was modified.
- Changed "Switch Archives" to "Archives"
- Removed "Archives" from left hand menu and added to right side menu, between "Activity Feed" and "Invitations" submenus.
- Changed "Account Info" to "Account"