### PR TITLE
VSP-471 [iOS] Files which have finished processing are stuck with a spinner until manual refresh

### DIFF
--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -264,6 +264,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
                 self.refreshControl.endRefreshing()
             }
         )
+        viewModel?.invalidateTimer()
     }
     
     private func handleProgress(withValue value: Float, listSection section: FileListType) {

--- a/Permanent/ViewModels/FilesViewModel.swift
+++ b/Permanent/ViewModels/FilesViewModel.swift
@@ -169,7 +169,14 @@ class FilesViewModel: NSObject, ViewModelInterface {
         timerRunCount += 1
         if timerRunCount == 1 {
             timerRunCount = 0
+            invalidateTimer()
+        }
+    }
+    
+    func invalidateTimer() {
+        if timer != nil {
             timer?.invalidate()
+            timerRunCount = 0
         }
     }
 }


### PR DESCRIPTION
Fixed pull to refresh issue that refresh timer was not cancelled when user refreshed the folder manually.