### PR TITLE
VSP-683  iOS: Copy files between Private Files and Public Files workspaces

### DIFF
--- a/Permanent/Constants/Constants.swift
+++ b/Permanent/Constants/Constants.swift
@@ -154,6 +154,8 @@ extension Constants.Keys.StorageKeys {
     static let modelVersion = "modelVersion"
     static let isGridView = "isGridView"
     static let minAppVersion = "minAppVersion"
+    static let selectedFileKey = "selectedFileKey"
+    static let selectedFileActionKey = "selectedFileActionKey"
 }
 
 extension Constants.API.Locations {

--- a/Permanent/Managers/FileAction.swift
+++ b/Permanent/Managers/FileAction.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum FileAction {
+enum FileAction: Codable {
     
     case copy
     

--- a/Permanent/Models/Data/FileType.swift
+++ b/Permanent/Models/Data/FileType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum FileType: String {
+enum FileType: String, Codable {
     case publicFolder = "type.folder.public"
     case privateFolder = "type.folder.private"
     case publicRootFolder = "type.folder.root.public"

--- a/Permanent/Models/Data/MinArchiveVO.swift
+++ b/Permanent/Models/Data/MinArchiveVO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MinArchiveVO: Equatable {
+struct MinArchiveVO: Equatable, Codable {
     let name: String
     let thumbnail: String
     let shareStatus: String

--- a/Permanent/Models/Enums/Permission.swift
+++ b/Permanent/Models/Enums/Permission.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum Permission {
+enum Permission: Codable {
     case read
     case create
     case upload

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -170,6 +170,8 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     }
     
     fileprivate func setupBottomActionSheet() {
+        setupUIForAction(viewModel?.fileAction ?? .none)
+        
         fileActionBottomView.closeAction = {
             self.setupUIForAction(.none)
         }

--- a/Permanent/ViewModels/MyFilesViewModel.swift
+++ b/Permanent/ViewModels/MyFilesViewModel.swift
@@ -17,6 +17,26 @@ class MyFilesViewModel: FilesViewModel {
     
     override var currentFolderIsRoot: Bool { navigationStack.count == 1 }
     
+    override var selectedFile: FileViewModel? {
+        get {
+            return try? PreferencesManager.shared.getCodableObject(forKey: Constants.Keys.StorageKeys.selectedFileKey)
+        }
+        
+        set {
+            try? PreferencesManager.shared.setCodableObject(newValue, forKey: Constants.Keys.StorageKeys.selectedFileKey)
+        }
+    }
+    
+    override var fileAction: FileAction {
+        get {
+            return (try? PreferencesManager.shared.getCodableObject(forKey: Constants.Keys.StorageKeys.selectedFileActionKey)) ?? .none
+        }
+        
+        set {
+            try? PreferencesManager.shared.setCodableObject(newValue, forKey: Constants.Keys.StorageKeys.selectedFileActionKey)
+        }
+    }
+    
     var rootFolderName: String {
         return .myFiles
     }

--- a/Permanent/ViewModels/UI/FileState.swift
+++ b/Permanent/ViewModels/UI/FileState.swift
@@ -7,10 +7,7 @@
 
 import Foundation
 
-enum FileState {
-    
+enum FileState: Codable {
     case enabled
-    
     case disabled
-    
 }

--- a/Permanent/ViewModels/UI/FileStatus.swift
+++ b/Permanent/ViewModels/UI/FileStatus.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum FileStatus {
+enum FileStatus: Codable {
     /// File is synced on the device. It must be displayed on the `FileListType.synced` list.
     case synced
     

--- a/Permanent/ViewModels/UI/FileViewModel.swift
+++ b/Permanent/ViewModels/UI/FileViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct FileViewModel: Equatable {
+struct FileViewModel: Equatable, Codable {
     let thumbnailURL: String?
     let thumbnailURL500: String?
     let thumbnailURL1000: String?


### PR DESCRIPTION
- implemented Codable in FileAction and FileViewModel, and their dependencies 
- created storage keys for selected file action, and selected file
- saved/fetched the selected file and action from the shared preferences