### PR TITLE
VSP-553 [iOS] When opening an invalid share preview link, hide all controls except navigation button

### DIFF
--- a/Permanent/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
+++ b/Permanent/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
@@ -221,6 +221,7 @@ extension SharePreviewViewController: SharePreviewViewModelViewDelegate {
         case .error:
             headerViewCollectionConstrain.constant = .zero
             actionButton.isHidden = true
+            currentArchiveContainer.isHidden = true
             actionButton.configureActionButtonUI(title: .ok)
             actionButton.addTarget(self, action: #selector(dismissScreen), for: .touchUpInside)
             

--- a/Permanent/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
+++ b/Permanent/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
@@ -24,6 +24,8 @@ class SharePreviewViewController: UIViewController {
     @IBOutlet weak var currentArchiveDefaultButton: UIButton!
     @IBOutlet weak var selectArchiveLabel: UILabel!
     
+    @IBOutlet weak var headerViewCollectionConstrain: NSLayoutConstraint!
+    
     var viewModel: SharePreviewViewModelDelegate! {
         didSet {
             viewModel.viewDelegate = self
@@ -93,7 +95,7 @@ class SharePreviewViewController: UIViewController {
         
         viewModel.updateAccountArchives { [self] in
             if let accountArchives = viewModel.accountArchives,
-               accountArchives.count == 1 {
+                accountArchives.count == 1 {
                 currentArchiveContainer.isHidden = true
             }
         }
@@ -217,7 +219,8 @@ extension SharePreviewViewController: SharePreviewViewModelViewDelegate {
             }
             
         case .error:
-            actionButton.isHidden = false
+            headerViewCollectionConstrain.constant = .zero
+            actionButton.isHidden = true
             actionButton.configureActionButtonUI(title: .ok)
             actionButton.addTarget(self, action: #selector(dismissScreen), for: .touchUpInside)
             

--- a/Permanent/Storyboards/Share.storyboard
+++ b/Permanent/Storyboards/Share.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -762,6 +762,7 @@
                         <outlet property="currentArchiveImageView" destination="yZ1-PS-0bL" id="sDN-9e-vBN"/>
                         <outlet property="currentArchiveName" destination="VNw-45-876" id="ixR-kL-uXA"/>
                         <outlet property="headerView" destination="IIX-dP-AYX" id="7sb-px-9yk"/>
+                        <outlet property="headerViewCollectionConstrain" destination="t0b-Jw-UGT" id="mgE-nH-7ZQ"/>
                         <outlet property="selectArchiveLabel" destination="Pcx-W8-D5n" id="z1X-n3-6jH"/>
                         <outlet property="shareNameLabel" destination="P9R-bv-rnQ" id="Ahw-Rq-KV2"/>
                         <outlet property="sharedByLabel" destination="pIA-zP-Z7N" id="a7Y-gR-xh1"/>

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -113,7 +113,7 @@ PODS:
   - nanopb/encode (1.30906.0)
   - ObjectMapper (4.2.0)
   - PromisesObjC (1.2.12)
-  - Protobuf (3.19.4)
+  - Protobuf (3.20.1)
   - SDWebImage (5.10.0):
     - SDWebImage/Core (= 5.10.0)
   - SDWebImage/Core (5.10.0)
@@ -180,7 +180,7 @@ SPEC CHECKSUMS:
   nanopb: 59317e09cf1f1a0af72f12af412d54edf52603fc
   ObjectMapper: 1eb41f610210777375fa806bf161dc39fb832b81
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  Protobuf: 235750e4696ff59fb07d949a9dbbc92b3c0700fe
+  Protobuf: b60ec2f51ad74765f44d0c09d2e0579d7de21745
   SDWebImage: 9169792e9eec3e45bba2a0c02f74bf8bd922d1ee
   Sourcery: db66600e8b285c427701821598d07cf3c7e6c476
 


### PR DESCRIPTION
Removed all controls except navigation button when link is no longer available.