### PR TITLE
VSP-849 [iOS] UI test cases for shared files menu

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		5E62F7C927F79FF40046F6C8 /* PopularArchive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E62F7C827F79FF40046F6C8 /* PopularArchive.swift */; };
 		5E62F7CE27FB10610046F6C8 /* PublicGalleryCellCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E62F7CC27FB10610046F6C8 /* PublicGalleryCellCollectionViewCell.swift */; };
 		5E62F7CF27FB10610046F6C8 /* PublicGalleryCellCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5E62F7CD27FB10610046F6C8 /* PublicGalleryCellCollectionViewCell.xib */; };
+		5E63B3E528A3EC3300067FAF /* SharedFilesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E63B3E428A3EC3300067FAF /* SharedFilesUITests.swift */; };
+		5E63B3E728A43EC400067FAF /* LeftSideMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E63B3E628A43EC400067FAF /* LeftSideMenu.swift */; };
 		5E647334263C22F900E6566D /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E647333263C22F900E6566D /* NotificationName.swift */; };
 		5E66240B27A9740600D533CA /* PublicProfileMilestonesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E66240A27A9740600D533CA /* PublicProfileMilestonesViewController.swift */; };
 		5E66240D27A9745400D533CA /* PublicProfileAddMilestonesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E66240C27A9745400D533CA /* PublicProfileAddMilestonesViewController.swift */; };
@@ -131,6 +133,7 @@
 		5E8B706B283D6E5A004295C6 /* PublicGalleryNoArchiveCellCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8B7069283D6E5A004295C6 /* PublicGalleryNoArchiveCellCollectionViewCell.swift */; };
 		5E8B706C283D6E5A004295C6 /* PublicGalleryNoArchiveCellCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5E8B706A283D6E5A004295C6 /* PublicGalleryNoArchiveCellCollectionViewCell.xib */; };
 		5E8BFEA925DEA02C00454F16 /* FilePreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8BFEA825DEA02C00454F16 /* FilePreviewViewController.swift */; };
+		5E969F7A28A452A3007431BC /* SharedFilesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E969F7928A452A3007431BC /* SharedFilesPage.swift */; };
 		5E96F03F279223D90099C0E7 /* NetworkLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E96F03E279223D90099C0E7 /* NetworkLogger.swift */; };
 		5E980AB72657D3D400ED5764 /* BundleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E980AB62657D3D400ED5764 /* BundleExtension.swift */; };
 		5E9977AC284898C7003E0C46 /* PublicGalleryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9977AB284898C7003E0C46 /* PublicGalleryTests.swift */; };
@@ -644,6 +647,8 @@
 		5E62F7C827F79FF40046F6C8 /* PopularArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularArchive.swift; sourceTree = "<group>"; };
 		5E62F7CC27FB10610046F6C8 /* PublicGalleryCellCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGalleryCellCollectionViewCell.swift; sourceTree = "<group>"; };
 		5E62F7CD27FB10610046F6C8 /* PublicGalleryCellCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PublicGalleryCellCollectionViewCell.xib; sourceTree = "<group>"; };
+		5E63B3E428A3EC3300067FAF /* SharedFilesUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFilesUITests.swift; sourceTree = "<group>"; };
+		5E63B3E628A43EC400067FAF /* LeftSideMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftSideMenu.swift; sourceTree = "<group>"; };
 		5E647333263C22F900E6566D /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		5E66240A27A9740600D533CA /* PublicProfileMilestonesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicProfileMilestonesViewController.swift; sourceTree = "<group>"; };
 		5E66240C27A9745400D533CA /* PublicProfileAddMilestonesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicProfileAddMilestonesViewController.swift; sourceTree = "<group>"; };
@@ -667,6 +672,7 @@
 		5E8B7069283D6E5A004295C6 /* PublicGalleryNoArchiveCellCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGalleryNoArchiveCellCollectionViewCell.swift; sourceTree = "<group>"; };
 		5E8B706A283D6E5A004295C6 /* PublicGalleryNoArchiveCellCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PublicGalleryNoArchiveCellCollectionViewCell.xib; sourceTree = "<group>"; };
 		5E8BFEA825DEA02C00454F16 /* FilePreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewViewController.swift; sourceTree = "<group>"; };
+		5E969F7928A452A3007431BC /* SharedFilesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFilesPage.swift; sourceTree = "<group>"; };
 		5E96F03E279223D90099C0E7 /* NetworkLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkLogger.swift; sourceTree = "<group>"; };
 		5E980AB62657D3D400ED5764 /* BundleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtension.swift; sourceTree = "<group>"; };
 		5E9977AB284898C7003E0C46 /* PublicGalleryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicGalleryTests.swift; sourceTree = "<group>"; };
@@ -1253,9 +1259,11 @@
 			children = (
 				5E07D44B28915C8E008C0A6B /* LoginPage.swift */,
 				5E07D44D28915CE0008C0A6B /* SignUpPage.swift */,
-				5E07D44F28915FB7008C0A6B /* RightSideMenuPage.swift */,
 				5E07D4512891600A008C0A6B /* PrivateFilesPage.swift */,
 				5E6AD37428A1A85A005ADF7E /* PhotoLibraryPage.swift */,
+				5E63B3E628A43EC400067FAF /* LeftSideMenu.swift */,
+				5E07D44F28915FB7008C0A6B /* RightSideMenuPage.swift */,
+				5E969F7928A452A3007431BC /* SharedFilesPage.swift */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -1426,6 +1434,7 @@
 				5E07D44A28915C78008C0A6B /* Pages */,
 				5E68830728902DBF0006F434 /* LoginUITests.swift */,
 				5E07D45428917D83008C0A6B /* UploadFilesUITests.swift */,
+				5E63B3E428A3EC3300067FAF /* SharedFilesUITests.swift */,
 			);
 			path = PermanentUITests;
 			sourceTree = "<group>";
@@ -3010,8 +3019,11 @@
 				5E07D4522891600A008C0A6B /* PrivateFilesPage.swift in Sources */,
 				5E07D44E28915CE0008C0A6B /* SignUpPage.swift in Sources */,
 				5E07D44C28915C8E008C0A6B /* LoginPage.swift in Sources */,
+				5E63B3E728A43EC400067FAF /* LeftSideMenu.swift in Sources */,
 				5E07D45028915FB7008C0A6B /* RightSideMenuPage.swift in Sources */,
+				5E63B3E528A3EC3300067FAF /* SharedFilesUITests.swift in Sources */,
 				5E6AD37528A1A85A005ADF7E /* PhotoLibraryPage.swift in Sources */,
+				5E969F7A28A452A3007431BC /* SharedFilesPage.swift in Sources */,
 				5E68830828902DBF0006F434 /* LoginUITests.swift in Sources */,
 				5E07D45528917D83008C0A6B /* UploadFilesUITests.swift in Sources */,
 			);

--- a/Permanent.xcodeproj/xcshareddata/xcschemes/Permanent.xcscheme
+++ b/Permanent.xcodeproj/xcshareddata/xcschemes/Permanent.xcscheme
@@ -53,11 +53,6 @@
                BlueprintName = "PermanentUITests"
                ReferencedContainer = "container:Permanent.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "SharedFilesUITests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Permanent.xcodeproj/xcshareddata/xcschemes/Permanent.xcscheme
+++ b/Permanent.xcodeproj/xcshareddata/xcschemes/Permanent.xcscheme
@@ -53,6 +53,11 @@
                BlueprintName = "PermanentUITests"
                ReferencedContainer = "container:Permanent.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "SharedFilesUITests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/PermanentUITests/LoginUITests.swift
+++ b/PermanentUITests/LoginUITests.swift
@@ -54,6 +54,6 @@ class LoginUITests: XCTestCase {
         
         loginPage.pressCancelButton()
         
-        signUpPage.signUpStaticText
+        signUpPage.waitForExistence()
     }
 }

--- a/PermanentUITests/Pages/LeftSideMenu.swift
+++ b/PermanentUITests/Pages/LeftSideMenu.swift
@@ -1,0 +1,49 @@
+//
+//  LeftSideMenu.swift
+//  PermanentUITests
+//
+//  Created by Lucian Cerbu on 10.08.2022.
+//
+
+import Foundation
+
+import Foundation
+import XCTest
+
+class LeftSideMenuPage {
+    let app: XCUIApplication
+    
+    var menuButton: XCUIElement { app.buttons["hamburger"] }
+    var privateFilesButton: XCUIElement { app.tables.staticTexts["Private Files"] }
+    var sharedFilesButton: XCUIElement { app.tables.staticTexts["Shared Files"] }
+    var privateFilesTitle: XCUIElement {
+        app.navigationBars.staticTexts["Private Files"] }
+    var sharedFilesTitle: XCUIElement {
+        app.navigationBars.staticTexts["Shares"] }
+    
+    init(app: XCUIApplication, testCase: XCTestCase) {
+        self.app = app
+    }
+    
+    func waitForExistence() {
+        XCTAssertTrue(menuButton.waitForExistence(timeout: 5))
+    }
+    
+    func goToSharedFiles() {
+        menuButton.tap()
+        
+        XCTAssertTrue(sharedFilesButton.waitForExistence(timeout: 5))
+        sharedFilesButton.tap()
+        
+        XCTAssertTrue(sharedFilesTitle.waitForExistence(timeout: 5))
+    }
+    
+    func goToPrivateFiles() {
+        menuButton.tap()
+        
+        XCTAssertTrue(privateFilesButton.waitForExistence(timeout: 5))
+        privateFilesButton.tap()
+
+        XCTAssertTrue(privateFilesTitle.waitForExistence(timeout: 5))
+    }
+}

--- a/PermanentUITests/Pages/LeftSideMenu.swift
+++ b/PermanentUITests/Pages/LeftSideMenu.swift
@@ -13,13 +13,21 @@ import XCTest
 class LeftSideMenuPage {
     let app: XCUIApplication
     
-    var menuButton: XCUIElement { app.buttons["hamburger"] }
-    var privateFilesButton: XCUIElement { app.tables.staticTexts["Private Files"] }
-    var sharedFilesButton: XCUIElement { app.tables.staticTexts["Shared Files"] }
+    var menuButton: XCUIElement {
+        app.buttons["hamburger"]
+    }
+    var privateFilesButton: XCUIElement {
+        app.tables.staticTexts["Private Files"]
+    }
+    var sharedFilesButton: XCUIElement {
+        app.tables.staticTexts["Shared Files"]
+    }
     var privateFilesTitle: XCUIElement {
-        app.navigationBars.staticTexts["Private Files"] }
+        app.navigationBars.staticTexts["Private Files"]
+    }
     var sharedFilesTitle: XCUIElement {
-        app.navigationBars.staticTexts["Shares"] }
+        app.navigationBars.staticTexts["Shares"]
+    }
     
     init(app: XCUIApplication, testCase: XCTestCase) {
         self.app = app

--- a/PermanentUITests/Pages/LoginPage.swift
+++ b/PermanentUITests/Pages/LoginPage.swift
@@ -11,11 +11,21 @@ import XCTest
 class LoginPage {
     let app: XCUIApplication
     
-    var emailField: XCUIElement { app.webViews.textFields["Email"] }
-    var passwordField: XCUIElement { app.webViews.secureTextFields["Password (min. 8 chars)"] }
-    var rememberSignInSwitch: XCUIElement { app.webViews.switches.firstMatch }
-    var submitButton: XCUIElement { app.webViews.buttons["Submit"] }
-    var cancelButton: XCUIElement { app.buttons["Cancel"] }
+    var emailField: XCUIElement {
+        app.webViews.textFields["Email"]
+    }
+    var passwordField: XCUIElement {
+        app.webViews.secureTextFields["Password (min. 8 chars)"]
+    }
+    var rememberSignInSwitch: XCUIElement {
+        app.webViews.switches.firstMatch
+    }
+    var submitButton: XCUIElement {
+        app.webViews.buttons["Submit"]
+    }
+    var cancelButton: XCUIElement {
+        app.buttons["Cancel"]
+    }
     
     init(app: XCUIApplication, testCase: XCTestCase) {
         self.app = app

--- a/PermanentUITests/Pages/PhotoLibraryPage.swift
+++ b/PermanentUITests/Pages/PhotoLibraryPage.swift
@@ -10,15 +10,14 @@ import XCTest
 
 class PhotoLibraryPage {
     let app: XCUIApplication
+    
     var navigationBar: XCUIElement {
         app.navigationBars["Recents"]
     }
-    
     var firstPhotoFromCollectionView: XCUIElement {
         app.collectionViews.children(matching: .cell).element(boundBy: 5).children(matching: .other).element
     }
-    
-    var uploadOneElement:XCUIElement {
+    var uploadOneElement: XCUIElement {
         app.toolbars["Toolbar"].buttons["Upload 1 items"]
     }
     

--- a/PermanentUITests/Pages/PrivateFilesPage.swift
+++ b/PermanentUITests/Pages/PrivateFilesPage.swift
@@ -42,8 +42,8 @@ class PrivateFilesPage {
         app.buttons["Cancel"]
     }
     
-    var uploadsFolderButton: XCUIElement {
-        app.collectionViews.staticTexts["uploads"].firstMatch
+    var currentTestFolderButton: XCUIElement {
+        app.collectionViews.staticTexts["current test"].firstMatch
     }
     
     var photoLibraryButton: XCUIElement {
@@ -67,7 +67,7 @@ class PrivateFilesPage {
     }
     
     var firstElementMoreButton: XCUIElement {
-        firstElementFromFolder.children(matching: .button).element
+        app.collectionViews.children(matching: .cell).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .button).element
     }
     
     var deleteButtonFromMoreList: XCUIElement {
@@ -113,11 +113,12 @@ class PrivateFilesPage {
         
         sleep(3)
         
-        XCTAssertTrue(uploadsFolderButton.waitForExistence(timeout: 5))
-        uploadsFolderButton.tap()
+        XCTAssertTrue(currentTestFolderButton.waitForExistence(timeout: 5))
+        currentTestFolderButton.tap()
     }
     
     func enterPhotoLibrary() {
+        sleep(2)
         addButton.tap()
         sleep(2)
         

--- a/PermanentUITests/Pages/PrivateFilesPage.swift
+++ b/PermanentUITests/Pages/PrivateFilesPage.swift
@@ -10,6 +10,7 @@ import XCTest
 
 class PrivateFilesPage {
     let app: XCUIApplication
+    
     var navigationBar: XCUIElement {
         app.navigationBars["Private Files"]
     }
@@ -25,47 +26,36 @@ class PrivateFilesPage {
     var uploadButton: XCUIElement {
         app.buttons["Upload"]
     }
-    
     var createNewFolderStaticText: XCUIElement {
         app.staticTexts["Create New Folder"]
     }
-    
     var folderNameTextField: XCUIElement {
         app.textFields["Folder Name"]
     }
-    
     var createNewFolderButton: XCUIElement {
         app.buttons["Create"]
     }
-    
     var cancelCreateNewFolderButton: XCUIElement {
         app.buttons["Cancel"]
     }
-    
     var currentTestFolderButton: XCUIElement {
         app.collectionViews.staticTexts["current test"].firstMatch
     }
-    
     var photoLibraryButton: XCUIElement {
         app.sheets.scrollViews.otherElements.buttons["Photo Library"]
     }
-    
     var photoLibraryElementLoading: XCUIElement {
         app.collectionViews.activityIndicators["In progress"]
     }
-    
     var uploadInProgress: XCUIElement {
         app.collectionViews.buttons["Uploads"]
     }
-    
     var uploadFinishedButton: XCUIElement {
         app.collectionViews.buttons["Name (A-Z)"]
     }
-    
     var firstElementFromFolder: XCUIElement {
         app.collectionViews.cells.children(matching: .other).element.children(matching: .other).element
     }
-    
     var firstElementMoreButton: XCUIElement {
         app.collectionViews.children(matching: .cell).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .button).element
     }
@@ -73,15 +63,12 @@ class PrivateFilesPage {
     var deleteButtonFromMoreList: XCUIElement {
         app.buttons["Delete"]
     }
-    
     var deleteButtonFromConfirmation: XCUIElement {
         app.scrollViews.otherElements.staticTexts["Delete"]
     }
-    
     var backButton: XCUIElement {
         app.buttons["chevron"]
     }
-    
     var emptyFolder: XCUIElement {
         app.collectionViews.staticTexts["This folder is empty"]
     }

--- a/PermanentUITests/Pages/RightSideMenuPage.swift
+++ b/PermanentUITests/Pages/RightSideMenuPage.swift
@@ -12,8 +12,12 @@ class RightSideMenuPage {
     let app: XCUIApplication
     let accountEmail: String
     
-    var emailStaticText: XCUIElement { app.staticTexts[accountEmail] }
-    var logoutButton: XCUIElement { app.tables.staticTexts["Log Out"] }
+    var emailStaticText: XCUIElement {
+        app.staticTexts[accountEmail]
+    }
+    var logoutButton: XCUIElement {
+        app.tables.staticTexts["Log Out"]
+    }
     
     init(app: XCUIApplication, testCase: XCTestCase, accountEmail: String) {
         self.app = app

--- a/PermanentUITests/Pages/SharedFilesPage.swift
+++ b/PermanentUITests/Pages/SharedFilesPage.swift
@@ -10,47 +10,106 @@ import XCTest
 
 class SharedFilesPage {
     let app: XCUIApplication
+    
     var navigationBar: XCUIElement {
         app.navigationBars["Shares"]
     }
-    
-    var sharedByMeButton: XCUIElement { app.buttons["Shared By Me"] }
-    var sharedWithMeButton: XCUIElement { app.buttons["Shared With Me"] }
-    var settingsButton: XCUIElement { navigationBar.buttons["settings"] }
+    var sharedByMeButton: XCUIElement {
+        app.buttons["Shared By Me"]
+    }
+    var sharedWithMeButton: XCUIElement {
+        app.buttons["Shared With Me"]
+    }
+    var settingsButton: XCUIElement {
+        navigationBar.buttons["settings"]
+    }
     var addButton: XCUIElement {
         app.windows.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 1)
     }
-    var firstItemFromFolderButton: XCUIElement {         app.windows.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 0) }
-    
-    var moreForFirstItemFromFolderButton: XCUIElement { app.collectionViews.children(matching: .cell).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .button).element }
-    
+    var firstItemFromFolderButton: XCUIElement {
+        app.windows.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 0)
+    }
+    var moreForFirstItemFromFolderButton: XCUIElement {
+        app.collectionViews.children(matching: .cell).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .button).element
+    }
     var uploadButton: XCUIElement {
-        app.buttons["Upload"] }
+        app.buttons["Upload"]
+    }
     var newFolderButton: XCUIElement {
         app.buttons["New Folder"]
     }
     var downloadButton: XCUIElement {
-        app.buttons["Download"] }
+        app.buttons["Download"]
+    }
     var renameButton: XCUIElement {
-        app.buttons["Rename"] }
+        app.buttons["Rename"]
+    }
     var deleteButton: XCUIElement {
-        app.buttons["Delete"] }
+        app.buttons["Delete"]
+    }
     var backButton: XCUIElement {
-        app.buttons["Back"] }
+        app.buttons["Back"]
+    }
     var filesWithOwnerAccessFolderButton: XCUIElement {
-        app.collectionViews.staticTexts["files with owner access"].firstMatch }
+        app.collectionViews.staticTexts["files with owner access"].firstMatch
+    }
     var filesWithViewerFolderButton: XCUIElement {
-        app.collectionViews.staticTexts["files with viewer access"].firstMatch }
+        app.collectionViews.staticTexts["files with viewer access "].firstMatch
+    }
     var createNewFolderStaticText: XCUIElement {
-        app.staticTexts["Create New Folder"] }
+        app.staticTexts["Create New Folder"]
+    }
     var folderNameTextField: XCUIElement {
-        app.textFields["Folder Name"] }
+        app.textFields["Folder Name"]
+    }
     var createNewFolderButton: XCUIElement {
-        app.buttons["Create"] }
+        app.buttons["Create"]
+    }
     var cancelCreateNewFolderButton: XCUIElement {
-        app.buttons["Cancel"] }
+        app.buttons["Cancel"]
+    }
     var currentTestFolderButton: XCUIElement {
-        app.collectionViews.staticTexts["a test folder"].firstMatch }
+        app.collectionViews.staticTexts["a test folder"].firstMatch
+    }
+    var photoLibraryButton: XCUIElement {
+        app.sheets.scrollViews.otherElements.buttons["Photo Library"]
+    }
+    var uploadInProgress: XCUIElement {
+        app.collectionViews.buttons["Uploads"]
+    }
+    var uploadFinishedButton: XCUIElement {
+        app.collectionViews.buttons["Name (A-Z)"]
+    }
+    var firstElementFromFolder: XCUIElement {
+        app.collectionViews.cells.children(matching: .other).element.children(matching: .other).element
+    }
+    var firstElementMoreButton: XCUIElement {
+        app.collectionViews.children(matching: .cell).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .button).element
+    }
+    var photoLibraryElementLoading: XCUIElement {
+        app.collectionViews.activityIndicators["In progress"]
+    }
+    var deleteButtonFromMoreList: XCUIElement {
+        app.buttons["Delete"]
+    }
+    var deleteButtonFromConfirmation: XCUIElement {
+        app.scrollViews.otherElements.staticTexts["Delete"]
+    }
+    var renameButtonFromMoreList: XCUIElement {
+        app.buttons["Rename"]
+    }
+    var renameButtonFromConfirmation: XCUIElement {
+        app.scrollViews.otherElements.staticTexts["Rename"]
+    }
+    var folderRenameTextField: XCUIElement {
+        app.textFields["a test"]
+    }
+    var emptyFolder: XCUIElement {
+        app.collectionViews.staticTexts["You haven’t shared any content with anyone. Choose an item from My Files and share it with someone!"]
+    }
+    var notificationCompletedDownload: XCUIElement {
+        app.staticTexts["'uploaded file' download completed"]
+    }
     
     init(app: XCUIApplication, testCase: XCTestCase) {
         self.app = app
@@ -66,8 +125,16 @@ class SharedFilesPage {
     }
     
     func enterFolderWithOwnerAccess() {
+        sleep(1)
         XCTAssertTrue(filesWithOwnerAccessFolderButton.waitForExistence(timeout: 5))
         filesWithOwnerAccessFolderButton.tap()
+        
+        sleep(3)
+    }
+    
+    func enterFolderWithViewerAccess() {
+        XCTAssertTrue(filesWithViewerFolderButton.waitForExistence(timeout: 5))
+        filesWithViewerFolderButton.tap()
         
         sleep(3)
     }
@@ -92,6 +159,51 @@ class SharedFilesPage {
         XCTAssertEqual(addButton.isHittable, false)
     }
     
+    func testMoreFileOptionsForSharedByMe() {
+        XCTAssertTrue(firstElementMoreButton.waitForExistence(timeout: 10))
+        firstElementMoreButton.tap()
+        
+        XCTAssertEqual(downloadButton.exists, false)
+        
+        XCTAssertEqual(renameButton.exists, true)
+        
+        XCTAssertEqual(deleteButton.exists, true)
+        
+        sleep(1)
+        
+        app.tap()
+    }
+    
+    func testMoreFileOptionsMenuOwnerAccess() {
+        XCTAssertTrue(firstElementMoreButton.waitForExistence(timeout: 10))
+        firstElementMoreButton.tap()
+        
+        XCTAssertEqual(downloadButton.exists, true)
+        
+        XCTAssertEqual(renameButton.exists, true)
+        
+        XCTAssertEqual(deleteButton.exists, true)
+        
+        sleep(1)
+        
+        app.tap()
+    }
+    
+    func testMoreFileOptionsMenuViewerAccess() {
+        XCTAssertTrue(firstElementMoreButton.waitForExistence(timeout: 10))
+        firstElementMoreButton.tap()
+        
+        XCTAssertEqual(downloadButton.exists, true)
+        
+        XCTAssertEqual(renameButton.exists, false)
+        
+        XCTAssertEqual(deleteButton.exists, false)
+        
+        sleep(1)
+        
+        app.tap()
+    }
+    
     func createNewFolder(name: String) {
         addButton.tap()
         XCTAssertTrue(newFolderButton.waitForExistence(timeout: 5))
@@ -106,7 +218,89 @@ class SharedFilesPage {
         
         sleep(3)
         
+        XCTAssertTrue(app.collectionViews.staticTexts[name].firstMatch.waitForExistence(timeout: 5))
+    }
+    
+    func enterCreatedFolder() {
         XCTAssertTrue(currentTestFolderButton.waitForExistence(timeout: 5))
         currentTestFolderButton.tap()
+        
+        sleep(3)
+    }
+    
+    func enterPhotoLibrary() {
+        sleep(2)
+        addButton.tap()
+        sleep(2)
+        
+        XCTAssertTrue(uploadButton.waitForExistence(timeout: 10))
+        uploadButton.tap()
+        
+        XCTAssertTrue(photoLibraryButton.waitForExistence(timeout: 5))
+        photoLibraryButton.tap()
+    }
+    
+    func processUpload() {
+        XCTAssertTrue(uploadInProgress.waitForExistence(timeout: 10))
+        
+        XCTAssertTrue(uploadFinishedButton.waitForExistence(timeout: 40))
+        
+        XCTAssertTrue(photoLibraryElementLoading.waitForExistence(timeout: 20))
+        
+        XCTAssertTrue(firstElementFromFolder.waitForExistence(timeout: 20))
+        
+        XCTAssertFalse(firstElementFromFolder.staticTexts.element(boundBy: 0).label.isEmpty)
+    }
+    
+    func deleteFirstElementFromFolder() {
+        XCTAssertTrue(firstElementMoreButton.waitForExistence(timeout: 10))
+        firstElementMoreButton.tap()
+        
+        XCTAssertTrue(deleteButtonFromMoreList.waitForExistence(timeout: 10))
+        deleteButtonFromMoreList.tap()
+        
+        XCTAssertTrue(deleteButtonFromConfirmation.waitForExistence(timeout: 10))
+        deleteButtonFromConfirmation.tap()
+        
+        sleep(3)
+    }
+    
+    func renameFirstElementFromFolder(name: String) {
+        let firstElementName: String = app.collectionViews.staticTexts.element(boundBy: 2).label
+        let renameTextFieldName: XCUIElement = app.textFields[firstElementName]
+        
+        XCTAssertTrue(firstElementMoreButton.waitForExistence(timeout: 10))
+        firstElementMoreButton.tap()
+        
+        XCTAssertTrue(renameButtonFromMoreList.waitForExistence(timeout: 10))
+        renameButtonFromMoreList.tap()
+        
+        XCTAssertTrue(renameTextFieldName.waitForExistence(timeout: 5))
+        renameTextFieldName.press(forDuration: 2)
+        app.menuItems["Select All"].tap()
+        renameTextFieldName.typeText(name)
+        
+        XCTAssertTrue(renameButtonFromConfirmation.waitForExistence(timeout: 10))
+        renameButtonFromConfirmation.tap()
+        
+        sleep(3)
+    }
+    
+    func downloadFirstElementFromFolder() {
+        XCTAssertTrue(firstElementMoreButton.waitForExistence(timeout: 10))
+        firstElementMoreButton.tap()
+        
+        XCTAssertTrue(downloadButton.waitForExistence(timeout: 10))
+        downloadButton.tap()
+    }
+    
+    func processDownload() {
+        XCTAssertTrue(notificationCompletedDownload.waitForExistence(timeout: 40))
+        
+        XCTAssertTrue(uploadFinishedButton.waitForExistence(timeout: 40))
+    }
+    
+    func emptyFolderTest() {
+        XCTAssertTrue(emptyFolder.waitForExistence(timeout: 10))
     }
 }

--- a/PermanentUITests/Pages/SharedFilesPage.swift
+++ b/PermanentUITests/Pages/SharedFilesPage.swift
@@ -1,0 +1,112 @@
+//
+//  SharedFilesPage.swift
+//  PermanentUITests
+//
+//  Created by Lucian Cerbu on 10.08.2022.
+//
+
+import Foundation
+import XCTest
+
+class SharedFilesPage {
+    let app: XCUIApplication
+    var navigationBar: XCUIElement {
+        app.navigationBars["Shares"]
+    }
+    
+    var sharedByMeButton: XCUIElement { app.buttons["Shared By Me"] }
+    var sharedWithMeButton: XCUIElement { app.buttons["Shared With Me"] }
+    var settingsButton: XCUIElement { navigationBar.buttons["settings"] }
+    var addButton: XCUIElement {
+        app.windows.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 1)
+    }
+    var firstItemFromFolderButton: XCUIElement {         app.windows.children(matching: .other).element.children(matching: .other).element.children(matching: .other).element(boundBy: 0) }
+    
+    var moreForFirstItemFromFolderButton: XCUIElement { app.collectionViews.children(matching: .cell).element(boundBy: 0).children(matching: .other).element.children(matching: .other).element.children(matching: .button).element }
+    
+    var uploadButton: XCUIElement {
+        app.buttons["Upload"] }
+    var newFolderButton: XCUIElement {
+        app.buttons["New Folder"]
+    }
+    var downloadButton: XCUIElement {
+        app.buttons["Download"] }
+    var renameButton: XCUIElement {
+        app.buttons["Rename"] }
+    var deleteButton: XCUIElement {
+        app.buttons["Delete"] }
+    var backButton: XCUIElement {
+        app.buttons["Back"] }
+    var filesWithOwnerAccessFolderButton: XCUIElement {
+        app.collectionViews.staticTexts["files with owner access"].firstMatch }
+    var filesWithViewerFolderButton: XCUIElement {
+        app.collectionViews.staticTexts["files with viewer access"].firstMatch }
+    var createNewFolderStaticText: XCUIElement {
+        app.staticTexts["Create New Folder"] }
+    var folderNameTextField: XCUIElement {
+        app.textFields["Folder Name"] }
+    var createNewFolderButton: XCUIElement {
+        app.buttons["Create"] }
+    var cancelCreateNewFolderButton: XCUIElement {
+        app.buttons["Cancel"] }
+    var currentTestFolderButton: XCUIElement {
+        app.collectionViews.staticTexts["a test folder"].firstMatch }
+    
+    init(app: XCUIApplication, testCase: XCTestCase) {
+        self.app = app
+    }
+    
+    func waitForExistence() {
+        XCTAssertTrue(navigationBar.waitForExistence(timeout: 5))
+    }
+    
+    func goToSharedWithMeTab() {
+        XCTAssertTrue(sharedWithMeButton.waitForExistence(timeout: 5))
+        sharedWithMeButton.tap()
+    }
+    
+    func enterFolderWithOwnerAccess() {
+        XCTAssertTrue(filesWithOwnerAccessFolderButton.waitForExistence(timeout: 5))
+        filesWithOwnerAccessFolderButton.tap()
+        
+        sleep(3)
+    }
+    
+    func goBack() {
+        XCTAssertTrue(backButton.waitForExistence(timeout: 10))
+        backButton.tap()
+    }
+    
+    func toggleRightSideMenu() {
+        XCTAssertTrue(settingsButton.waitForExistence(timeout: 5))
+        settingsButton.tap()
+    }
+    
+    func testAddButtonIsPresent() {
+        XCTAssertEqual(addButton.exists, true)
+        XCTAssertEqual(addButton.isHittable, true)
+    }
+    
+    func testAddButtonIsNotPresent() {
+        XCTAssertEqual(addButton.exists, false)
+        XCTAssertEqual(addButton.isHittable, false)
+    }
+    
+    func createNewFolder(name: String) {
+        addButton.tap()
+        XCTAssertTrue(newFolderButton.waitForExistence(timeout: 5))
+        newFolderButton.tap()
+        
+        XCTAssertTrue(createNewFolderStaticText.waitForExistence(timeout: 5))
+        XCTAssertTrue(folderNameTextField.waitForExistence(timeout: 5))
+        folderNameTextField.typeText(name)
+        
+        XCTAssertTrue(createNewFolderButton.waitForExistence(timeout: 5))
+        createNewFolderButton.tap()
+        
+        sleep(3)
+        
+        XCTAssertTrue(currentTestFolderButton.waitForExistence(timeout: 5))
+        currentTestFolderButton.tap()
+    }
+}

--- a/PermanentUITests/Pages/SignUpPage.swift
+++ b/PermanentUITests/Pages/SignUpPage.swift
@@ -10,6 +10,7 @@ import XCTest
 
 class SignUpPage {
     let app: XCUIApplication
+    
     var enterLoginScreenButton: XCUIElement {
         app.staticTexts["Already have an account?"]
     }

--- a/PermanentUITests/SharedFilesUITests.swift
+++ b/PermanentUITests/SharedFilesUITests.swift
@@ -22,30 +22,79 @@ class SharedFilesUITests: XCTestCase {
     
     func testSharedFilesMenu() throws {
         let accountEmail = uiTestCredentials.username
-//        let accountPassword = uiTestCredentials.password
-//
-//        let signUpPage = SignUpPage(app: app, testCase: self)
-//        signUpPage.navigateToLogin()
-//
-//        let loginPage = LoginPage(app: app, testCase: self)
-//        loginPage.login(username: accountEmail, password: accountPassword)
+        let accountPassword = uiTestCredentials.password
+    
+        let signUpPage = SignUpPage(app: app, testCase: self)
+        signUpPage.navigateToLogin()
+
+        let loginPage = LoginPage(app: app, testCase: self)
+        loginPage.login(username: accountEmail, password: accountPassword)
  
         let leftMenu = LeftSideMenuPage(app: app, testCase: self)
         leftMenu.goToSharedFiles()
         
         let sharedFilesPage = SharedFilesPage(app: app, testCase: self)
+        
+        sharedFilesPage.testMoreFileOptionsForSharedByMe()
+        
         sharedFilesPage.goToSharedWithMeTab()
         sharedFilesPage.enterFolderWithOwnerAccess()
         sharedFilesPage.testAddButtonIsPresent()
         
-        sharedFilesPage.createNewFolder(name: "a test folder")
+        sharedFilesPage.createNewFolder(name: "a test")
+        ///TO DO -redesign test case, after this bug is resolved : when you are creating a new folder in shared with me section, reload the shared files menu is needed.
+        leftMenu.goToSharedFiles()
+        
+        sharedFilesPage.goToSharedWithMeTab()
+        sharedFilesPage.enterFolderWithOwnerAccess()
+        
+        sharedFilesPage.renameFirstElementFromFolder(name: "a test folder")
+        leftMenu.goToSharedFiles()
+        
+        sharedFilesPage.goToSharedWithMeTab()
+        sharedFilesPage.enterFolderWithOwnerAccess()
+        
+        sharedFilesPage.enterCreatedFolder()
+        sharedFilesPage.enterPhotoLibrary()
+        
+        let photoLibraryPage = PhotoLibraryPage(app: app, testCase: self)
+        photoLibraryPage.waitForExistence()
+        
+        photoLibraryPage.uploadFirstPhoto()
+        
+        sharedFilesPage.processUpload()
+        
+        sharedFilesPage.renameFirstElementFromFolder(name: "uploaded file")
+        
+        sharedFilesPage.downloadFirstElementFromFolder()
+                        
+        sharedFilesPage.processDownload()
+        
+        sharedFilesPage.deleteFirstElementFromFolder()
+        
+        sharedFilesPage.emptyFolderTest()
         
         sharedFilesPage.goBack()
+        
+        sharedFilesPage.deleteFirstElementFromFolder()
+        
+        sharedFilesPage.testMoreFileOptionsMenuOwnerAccess()
+        
+        leftMenu.goToSharedFiles()
+        
+        sharedFilesPage.goToSharedWithMeTab()
+        
+        sharedFilesPage.enterFolderWithViewerAccess()
+        
+        sharedFilesPage.testMoreFileOptionsMenuViewerAccess()
         
         sharedFilesPage.toggleRightSideMenu()
         
         let rightSideMenu = RightSideMenuPage(app: app, testCase: self, accountEmail: accountEmail)
         rightSideMenu.waitForExistence()
         rightSideMenu.logOut()
+        sleep(2)
+        
+        XCTAssertTrue(signUpPage.signUpStaticText.waitForExistence(timeout: 10))
     }
 }

--- a/PermanentUITests/SharedFilesUITests.swift
+++ b/PermanentUITests/SharedFilesUITests.swift
@@ -1,0 +1,51 @@
+//
+//  SharedFilesUITests.swift
+//  PermanentUITests
+//
+//  Created by Lucian Cerbu on 10.08.2022.
+//
+
+import XCTest
+
+class SharedFilesUITests: XCTestCase {
+    let app = XCUIApplication()
+    
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        
+        app.launch()
+        sleep(5)
+    }
+
+    override func tearDownWithError() throws {
+    }
+    
+    func testSharedFilesMenu() throws {
+        let accountEmail = uiTestCredentials.username
+//        let accountPassword = uiTestCredentials.password
+//
+//        let signUpPage = SignUpPage(app: app, testCase: self)
+//        signUpPage.navigateToLogin()
+//
+//        let loginPage = LoginPage(app: app, testCase: self)
+//        loginPage.login(username: accountEmail, password: accountPassword)
+ 
+        let leftMenu = LeftSideMenuPage(app: app, testCase: self)
+        leftMenu.goToSharedFiles()
+        
+        let sharedFilesPage = SharedFilesPage(app: app, testCase: self)
+        sharedFilesPage.goToSharedWithMeTab()
+        sharedFilesPage.enterFolderWithOwnerAccess()
+        sharedFilesPage.testAddButtonIsPresent()
+        
+        sharedFilesPage.createNewFolder(name: "a test folder")
+        
+        sharedFilesPage.goBack()
+        
+        sharedFilesPage.toggleRightSideMenu()
+        
+        let rightSideMenu = RightSideMenuPage(app: app, testCase: self, accountEmail: accountEmail)
+        rightSideMenu.waitForExistence()
+        rightSideMenu.logOut()
+    }
+}

--- a/PermanentUITests/UploadFilesUITests.swift
+++ b/PermanentUITests/UploadFilesUITests.swift
@@ -33,7 +33,7 @@ class UploadFilesUITests: XCTestCase {
         let privateFilesPage = PrivateFilesPage(app: app, testCase: self)
         privateFilesPage.waitForExistence()
         
-        privateFilesPage.createNewFolder(name: "uploads")
+        privateFilesPage.createNewFolder(name: "current test")
         
         privateFilesPage.enterPhotoLibrary()
         
@@ -52,12 +52,13 @@ class UploadFilesUITests: XCTestCase {
         
         privateFilesPage.deleteFirstElementFromFolder()
         
-        privateFilesPage.emptyFolderTest()
-        
         privateFilesPage.toggleRightSideMenu()
         
         let rightSideMenu = RightSideMenuPage(app: app, testCase: self, accountEmail: accountEmail)
         rightSideMenu.waitForExistence()
         rightSideMenu.logOut()
+        sleep(2)
+        
+        XCTAssertTrue(signUpPage.signUpStaticText.waitForExistence(timeout: 10))
     }
 }


### PR DESCRIPTION
Shared files menu test case should contain :

- login and navigate to private files screen
- navigate to Shared with me
- enter a folder with viewer permissions and test “+“ menu options
- enter a folder with owner permissions and test “+“ menu options
- log out from settings menu