### PR TITLE
VSP-964 [iOS] File Options Menu: Changing the access role in "Share Management" does not update the access role badge

### DIFF
--- a/Permanent/Models/Data/MinArchiveVO.swift
+++ b/Permanent/Models/Data/MinArchiveVO.swift
@@ -10,7 +10,7 @@ import Foundation
 struct MinArchiveVO: Equatable, Codable {
     let name: String
     let thumbnail: String
-    let shareStatus: String
+    var shareStatus: String
     let shareId: Int
     let archiveID: Int
     let folderLinkID: Int?

--- a/Permanent/ViewControllers/FileMenuViewController.swift
+++ b/Permanent/ViewControllers/FileMenuViewController.swift
@@ -444,7 +444,7 @@ class FileMenuViewController: BaseViewController<ShareLinkViewModel> {
         
         let maxArchivesShown = showAllArchives ? fileViewModel.minArchiveVOS.count : min(fileViewModel.minArchiveVOS.count, 2)
         for (idx, archive) in fileViewModel.minArchiveVOS[0 ..< maxArchivesShown].enumerated() {
-            let accessRole = AccessRole.roleForValue(archive.accessRole).groupName
+            let accessRole = ShareStatus.status(forValue: archive.shareStatus) == .pending  ? "Pending".localized() : AccessRole.roleForValue(archive.accessRole).groupName
             
             let archiveStackView = archiveStackView(withArchiveName: "The \(archive.name) Archive", role: accessRole, imagePath: archive.thumbnail, tag: idx + 1)
             subviews.append(archiveStackView)

--- a/Permanent/ViewControllers/FileMenuViewController.swift
+++ b/Permanent/ViewControllers/FileMenuViewController.swift
@@ -225,6 +225,13 @@ class FileMenuViewController: BaseViewController<ShareLinkViewModel> {
             
             self?.loadSubviews()
         }
+        
+        NotificationCenter.default.addObserver(forName: ShareLinkViewModel.didUpdateSharesNotifName, object: viewModel, queue: nil) { [weak self] notif in
+            guard let fileViewModel = self?.viewModel?.fileViewModel else { return }
+            self?.fileViewModel = fileViewModel
+            
+            self?.loadSubviews()
+        }
     }
     
     func loadSubviews() {

--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -105,6 +105,8 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
             
             self?.viewModel?.viewModels[index].accessRole = shareLinkVM.fileViewModel.accessRole
             self?.viewModel?.viewModels[index].minArchiveVOS = shareLinkVM.fileViewModel.minArchiveVOS
+            
+            self?.collectionView.reloadData()
         }
     }
     

--- a/Permanent/ViewControllers/SharesViewController.swift
+++ b/Permanent/ViewControllers/SharesViewController.swift
@@ -106,6 +106,19 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                 }
             }
         }
+        
+        NotificationCenter.default.addObserver(forName: ShareLinkViewModel.didUpdateSharesNotifName, object: nil, queue: nil) { [weak self] notif in
+            guard let shareLinkVM = notif.object as? ShareLinkViewModel,
+                  let index = self?.viewModel?.viewModels.firstIndex(where: { $0.recordId == shareLinkVM.fileViewModel.recordId })
+            else {
+                return
+            }
+            self?.viewModel?.viewModels[index].fileStatus = shareLinkVM.fileViewModel.fileStatus
+            self?.viewModel?.viewModels[index].accessRole = shareLinkVM.fileViewModel.accessRole
+            self?.viewModel?.viewModels[index].minArchiveVOS = shareLinkVM.fileViewModel.minArchiveVOS
+            
+            self?.collectionView.reloadData()
+        }
     }
     
     override func viewDidLayoutSubviews() {

--- a/Permanent/ViewModels/ShareLinkViewModel.swift
+++ b/Permanent/ViewModels/ShareLinkViewModel.swift
@@ -169,9 +169,9 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
             switch result {
             case .json(let response, _):
                 guard
-                    let model: APIResults<AccountVO> = JSONHelper.decoding(
+                    let model: APIResults<ShareVO> = JSONHelper.decoding(
                         from: response,
-                        with: APIResults<NoDataModel>.decoder
+                        with: APIResults<ShareVO>.decoder
                     )
                 else {
                     handler(.error(message: .errorMessage))
@@ -181,7 +181,8 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
                 if model.isSuccessful {
                     handler(.success)
                     if let idx = self.fileViewModel.minArchiveVOS.firstIndex(where: { $0.archiveID == minArchiveVO.archiveID }) {
-                        self.fileViewModel.minArchiveVOS[idx].accessRole = newShareVO.accessRole
+                        self.fileViewModel.minArchiveVOS[idx].accessRole = model.results.first?.data?.first?.shareVO.accessRole
+                        self.fileViewModel.minArchiveVOS[idx].shareStatus = model.results.first?.data?.first?.shareVO.status ?? ""
                     }
                     NotificationCenter.default.post(name: Self.didUpdateSharesNotifName, object: self, userInfo: nil)
                 } else {
@@ -213,9 +214,9 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
             switch result {
             case .json(let response, _):
                 guard
-                    let model: APIResults<AccountVO> = JSONHelper.decoding(
+                    let model: APIResults<ShareVO> = JSONHelper.decoding(
                         from: response,
-                        with: APIResults<NoDataModel>.decoder
+                        with: APIResults<ShareVO>.decoder
                     )
                 else {
                     handler(.error(message: .errorMessage))
@@ -225,7 +226,8 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
                 if model.isSuccessful {
                     handler(.success)
                     if let idx = self.fileViewModel.minArchiveVOS.firstIndex(where: { $0.archiveID == newShareVO.archiveID }) {
-                        self.fileViewModel.minArchiveVOS[idx].accessRole = newShareVO.accessRole
+                        self.fileViewModel.minArchiveVOS[idx].accessRole = model.results.first?.data?.first?.shareVO.accessRole
+                        self.fileViewModel.minArchiveVOS[idx].shareStatus = model.results.first?.data?.first?.shareVO.status ?? ""
                     }
                     NotificationCenter.default.post(name: Self.didUpdateSharesNotifName, object: self, userInfo: nil)
                 } else {
@@ -260,9 +262,9 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
             switch result {
             case .json(let response, _):
                 guard
-                    let model: APIResults<AccountVO> = JSONHelper.decoding(
+                    let model: APIResults<ShareVO> = JSONHelper.decoding(
                         from: response,
-                        with: APIResults<NoDataModel>.decoder
+                        with: APIResults<ShareVO>.decoder
                     ),
                     model.isSuccessful
                 else {
@@ -270,6 +272,10 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
                     return
                 }
                 handler(.success)
+                if let idx = self.fileViewModel.minArchiveVOS.firstIndex(where: { $0.archiveID == archiveId }) {
+                    self.fileViewModel.minArchiveVOS.remove(at: idx)
+                }
+                
                 NotificationCenter.default.post(name: Self.didUpdateSharesNotifName, object: self, userInfo: nil)
                 return
                 
@@ -294,9 +300,9 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
             switch result {
             case .json(let response, _):
                 guard
-                    let model: APIResults<AccountVO> = JSONHelper.decoding(
+                    let model: APIResults<ShareVO> = JSONHelper.decoding(
                         from: response,
-                        with: APIResults<NoDataModel>.decoder
+                        with: APIResults<ShareVO>.decoder
                     ),
                     model.isSuccessful
                 else {
@@ -304,6 +310,9 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
                     return
                 }
                 handler(.success)
+                if let idx = self.fileViewModel.minArchiveVOS.firstIndex(where: { $0.archiveID == archiveId }) {
+                    self.fileViewModel.minArchiveVOS.remove(at: idx)
+                }
                 NotificationCenter.default.post(name: Self.didUpdateSharesNotifName, object: self, userInfo: nil)
                 return
                 

--- a/Permanent/ViewModels/SharedFilesViewModel.swift
+++ b/Permanent/ViewModels/SharedFilesViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 class SharedFilesViewModel: FilesViewModel {
-    
     override var currentFolderIsRoot: Bool { navigationStack.count == 0 }
     
     var shareListType: ShareListType = .sharedByMe {

--- a/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveTableViewCell.swift
+++ b/Permanent/Views/Cells/ArchiveTableViewCell/ArchiveTableViewCell.swift
@@ -46,7 +46,13 @@ class ArchiveTableViewCell: UITableViewCell {
     func updateCell(model: ShareVOData) {
         archiveImageView.load(urlString: model.archiveVO?.thumbURL200 ?? "")
         archiveNameLabel.text = .init(format: .archiveName, model.archiveVO?.fullName ?? "")
-        relationshipLabel.text = AccessRole.roleForValue(model.accessRole).groupName
+        
+        if ShareStatus.status(forValue: model.status ?? "") != .pending {
+            relationshipLabel.text = AccessRole.roleForValue(model.accessRole).groupName
+        } else {
+            relationshipLabel.text = "Pending".localized()
+        }
+        
         bottomView.isHidden = ShareStatus.status(forValue: model.status ?? "") != .pending
         moreButton.isHidden = ShareStatus.status(forValue: model.status ?? "") == .pending
     }


### PR DESCRIPTION
Fixed the File Options Menu issue that didn't specify pending access with specific badge
Fixed changing the access role in "Share Management" does not update the access role badge
Fixed updating File Options Menu Shared with section after an archive rights were removed for current item.