### PR TITLE
Vsp 1049 Managers can't edit public profile photos

### DIFF
--- a/Permanent/ViewControllers/Profile/PublicArchiveViewController.swift
+++ b/Permanent/ViewControllers/Profile/PublicArchiveViewController.swift
@@ -72,7 +72,7 @@ class PublicArchiveViewController: BaseViewController<PublicProfilePicturesViewM
             navigationItem.leftBarButtonItem = UIBarButtonItem(image: leftButtonImage, style: .plain, target: self, action: #selector(closeButtonAction(_:)))
         }
         
-        if !archiveData.permissions().contains(.archiveShare) {
+        if viewModel?.canEditPublicProfilePhoto() == true {
             changeProfilePhotoButton.isHidden = true
             changeProfilePhotoButtonView.alpha = 0
             changeProfileBannerPhotoButtonView.alpha = 0

--- a/Permanent/ViewControllers/Profile/PublicArchiveViewController.swift
+++ b/Permanent/ViewControllers/Profile/PublicArchiveViewController.swift
@@ -72,7 +72,7 @@ class PublicArchiveViewController: BaseViewController<PublicProfilePicturesViewM
             navigationItem.leftBarButtonItem = UIBarButtonItem(image: leftButtonImage, style: .plain, target: self, action: #selector(closeButtonAction(_:)))
         }
         
-        if !archiveData.permissions().contains(.ownership) {
+        if !archiveData.permissions().contains(.archiveShare) {
             changeProfilePhotoButton.isHidden = true
             changeProfilePhotoButtonView.alpha = 0
             changeProfileBannerPhotoButtonView.alpha = 0

--- a/Permanent/ViewModels/PublicProfilePicturesViewModel.swift
+++ b/Permanent/ViewModels/PublicProfilePicturesViewModel.swift
@@ -140,4 +140,8 @@ class PublicProfilePicturesViewModel: ViewModelInterface {
             }
         }
     }
+    
+    func canEditPublicProfilePhoto() -> Bool {
+        return !archiveData.permissions().contains(.archiveShare)
+    }
 }


### PR DESCRIPTION
Moved logic to the viewmodel
Changed the logic to look for "archiveShare" permission, instead of "ownership"