### PR TITLE
VSP-1050[iOS]Change Access Role screen displays roles as red, instead of black

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ env-vars-staging.sh
 env-vars.sh
 
 .idea/
+*.DS_Store

--- a/Permanent/Views/Cells/ShareManagementCollectionViewCells/ShareManagementAccessRolesCollectionViewCell.swift
+++ b/Permanent/Views/Cells/ShareManagementCollectionViewCells/ShareManagementAccessRolesCollectionViewCell.swift
@@ -51,6 +51,7 @@ class ShareManagementAccessRolesCollectionViewCell: UICollectionViewCell {
             let imageName: String = "accessRole\(ShareManagementAccessRoleCellType.roleToString(cellType) ?? "")"
             leftImageView.image = UIImage(named: imageName)?.withRenderingMode(.alwaysTemplate)
             leftImageView.tintColor = .darkBlue
+            titleLabel.textColor = .darkBlue
         }
         setSelected(isSelected)
     }


### PR DESCRIPTION
Resolved the bug where the "Viewer" text from Share Access Roles sometimes is red.