### PR TITLE
VSP-1089 [iOS] Fix delete tag confirmation dialog bugs

### DIFF
--- a/Permanent/Constants/Colors.swift
+++ b/Permanent/Constants/Colors.swift
@@ -38,6 +38,7 @@ extension UIColor {
     static var primary = UIColor.darkBlue
     static var secondary = UIColor.tangerine
     static var overlay = UIColor.black.withAlphaComponent(0.25)
+    static var bgOverlay = UIColor.black.withAlphaComponent(0.6)
     static var destructive = UIColor.brightRed
     static var textPrimary = UIColor.middleGray
     static var iconTintPrimary = UIColor.middleGray

--- a/Permanent/Extensions/UIViewExtension.swift
+++ b/Permanent/Extensions/UIViewExtension.swift
@@ -162,12 +162,23 @@ extension UIView {
         self.endEditing(true)
     }
     
-    func shadowToBorder(showShadow: Bool = true) {
-        layer.shadowColor = UIColor.black.cgColor
+    func shadowToBorder(showShadow: Bool = true, onlyBottomShadow: Bool = false) {
         layer.shadowOpacity = showShadow ? 1 : 0
-        layer.shadowOffset = .zero
-        layer.shadowRadius = 10
-        layer.shouldRasterize = true
-        layer.rasterizationScale = UIScreen.main.scale
+        if onlyBottomShadow {
+            let height = frame.height
+              let width = frame.width
+
+              let shadowSize: CGFloat = 15
+            let contactRect = CGRect(x: -shadowSize, y: height - shadowSize * 3, width: width, height: shadowSize/3)
+              layer.shadowPath = UIBezierPath(ovalIn: contactRect).cgPath
+             layer.shadowRadius = 5
+             layer.shadowOpacity = 0.6
+        } else {
+            layer.shadowColor = UIColor.black.cgColor
+            layer.shadowOffset = .zero
+            layer.shadowRadius = 10
+            layer.shouldRasterize = true
+            layer.rasterizationScale = UIScreen.main.scale
+        }
     }
 }

--- a/Permanent/ViewControllers/TagManagementViewController.swift
+++ b/Permanent/ViewControllers/TagManagementViewController.swift
@@ -50,7 +50,7 @@ class TagManagementViewController: BaseViewController<ManageTagsViewModel> {
         
         overlayView.frame = view.bounds
         view.addSubview(overlayView)
-        overlayView.backgroundColor = .overlay
+        overlayView.backgroundColor = .bgOverlay
         overlayView.alpha = 0
         
         archiveTitleNameLabel.font = Text.style35.font
@@ -143,8 +143,9 @@ extension TagManagementViewController: UICollectionViewDataSource {
             
             cell.rightSideButtonAction = {
                 self.showActionDialog(styled: .updatedSimpleWithDescription, withTitle: "Delete Tags".localized(), description: "Are you sure you want to delete the tags from all items in the current archive?".localized(), positiveButtonTitle: "Delete", positiveAction: { [weak self] in
-                    self?.viewModel?.deleteTag(index: indexPath.item, completion: { result in
-                        if let _ = result {
+                    self?.actionDialog?.dismiss()
+                    self?.viewModel?.deleteTag(index: indexPath.item, completion: { error in
+                        if let _ = error {
                             self?.showErrorAlert(message: .errorMessage)
                         }
                     })

--- a/Permanent/ViewModels/ManageTagsViewModel.swift
+++ b/Permanent/ViewModels/ManageTagsViewModel.swift
@@ -84,9 +84,8 @@ class ManageTagsViewModel: ViewModelInterface {
         if let newTagName = text,
            newTagName.isNotEmpty {
             let filteredTags = tags.filter { tag in
-                tag.tagVO.name?.contains(newTagName) ?? false
+                tag.tagVO.name == newTagName
             }
-            
             return filteredTags.count == 0
         } else {
             return false

--- a/Permanent/Views/ActionDialogView/ActionDialogView.swift
+++ b/Permanent/Views/ActionDialogView/ActionDialogView.swift
@@ -210,6 +210,8 @@ class ActionDialogView: UIView {
     fileprivate func updateUI(forStyle style: ActionDialogStyle) {
         switch style {
         case .updatedSimpleWithDescription:
+            dialogView.shadowToBorder(showShadow: true, onlyBottomShadow: true)
+            
             titleLabel.textColor = .paleRed
             titleLabel.font = Text.style32.font
             


### PR DESCRIPTION
- Added bottom shadow to the confirmation dialog
- Fixed the bug where the delete dialog doesn’t disappear when delete was pressed
- Fixed a bug where an error alert appears if you already have the “test222“ tag and want to add the “test“ tag