### PR TITLE
VSP-927 [iOS] Display options menu for multiple files

### DIFF
--- a/Permanent/ViewControllers/MainViewController.swift
+++ b/Permanent/ViewControllers/MainViewController.swift
@@ -1129,7 +1129,7 @@ extension MainViewController: FABActionSheetDelegate {
             menuItems.append(FileMenuViewController.MenuItem(type: .delete, action: { [weak self] in
                 self?.showActionDialog(
                     styled: .simple,
-                    withTitle: "Delete".localized(),
+                    withTitle: "Delete selected items?".localized(),
                     positiveButtonTitle: .delete,
                     positiveAction: { [weak self] in
                         self?.actionDialog?.dismiss()

--- a/Permanent/ViewControllers/SharesViewController.swift
+++ b/Permanent/ViewControllers/SharesViewController.swift
@@ -310,21 +310,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             }),
             FloatingActionImageItem(image: blankImage, action: nil),
             FloatingActionImageItem(image: (UIImage(named: "floatingMore")?.templated!)!, action: { [weak self] _,_  in
-                self?.showActionDialog(
-                    styled: .simple,
-                    withTitle: "Delete".localized(),
-                    positiveButtonTitle: .delete,
-                    positiveAction: { [weak self] in
-                        self?.actionDialog?.dismiss()
-                        self?.deleteFile(self?.viewModel?.selectedFiles)
-                        
-                        self?.dismissFloatingActionIsland()
-                        self?.fabView.isHidden = false
-                        self?.clearButtonWasPressed(UIButton())
-                    }, positiveButtonColor: .brightRed,
-                    cancelButtonColor: .primary,
-                    overlayView: self?.overlayView
-                )
+                self?.showFileActionSheetForSelection()
             })
         ]
         
@@ -724,6 +710,56 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         vc.fileViewModel = file
         vc.menuItems = menuItems
         vc.showsPermission = viewModel?.shareListType == .sharedWithMe
+        present(vc, animated: true)
+    }
+    
+    func showFileActionSheetForSelection() {
+        guard let file = viewModel?.selectedFiles?.first else { return }
+        var menuItems: [FileMenuViewController.MenuItem] = []
+        
+        if file.permissions.contains(.delete) {
+            menuItems.append(FileMenuViewController.MenuItem(type: .delete, action: { [weak self] in
+                self?.showActionDialog(
+                    styled: .simple,
+                    withTitle: "Delete selected items?".localized(),
+                    positiveButtonTitle: .delete,
+                    positiveAction: { [weak self] in
+                        self?.actionDialog?.dismiss()
+                        self?.deleteFile(self?.viewModel?.selectedFiles)
+                        
+                        self?.dismissFloatingActionIsland()
+                        self?.fabView.isHidden = false
+                        self?.clearButtonWasPressed(UIButton())
+                    }, positiveButtonColor: .brightRed,
+                    cancelButtonColor: .primary,
+                    overlayView: self?.overlayView
+                )
+            }))
+        }
+        
+        if file.permissions.contains(.move) {
+            menuItems.append(FileMenuViewController.MenuItem(type: .move, action: { [weak self] in
+                self?.dismissFloatingActionIsland({ [weak self] in
+                    self?.viewModel?.fileAction = FileAction.move
+                    self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .move)
+                    
+                    self?.fabView.isHidden = false
+                    if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
+                        self?.backButton.isUserInteractionEnabled = true
+                        self?.backButton.layer.opacity = 1
+                    }
+                    
+                    self?.viewModel?.isSelecting = false
+                    self?.setupBottomActionSheet()
+                })
+            }))
+        }
+        
+        let vc = FileMenuViewController()
+        vc.fileViewModel = file
+        vc.menuItems = menuItems
+        vc.selectedItemCount = viewModel?.selectedFiles?.count
+        
         present(vc, animated: true)
     }
     


### PR DESCRIPTION
Add an options menu for the selected items with the following options: 
- for private files and public files: copy move and delete
- for shared files: move and delete 