### PR TITLE
VSP-939[iOS] Edit Files Metadata - File Names: Replace

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -220,7 +220,7 @@
 		5E68F2D926A9A2CD00CC936E /* TestURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E68F2D826A9A2CD00CC936E /* TestURLs.swift */; };
 		5E68F2DB26A9A32400CC936E /* ResponseURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E68F2DA26A9A32400CC936E /* ResponseURLProtocol.swift */; };
 		5E6AD37528A1A85A005ADF7E /* PhotoLibraryPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6AD37428A1A85A005ADF7E /* PhotoLibraryPage.swift */; };
-		5E6FB7582A73E15800984B84 /* MetadataEditFileNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6FB7572A73E15800984B84 /* MetadataEditFileNames.swift */; };
+		5E6FB7582A73E15800984B84 /* MetadataEditFileNamesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6FB7572A73E15800984B84 /* MetadataEditFileNamesView.swift */; };
 		5E6FB75A2A73E18200984B84 /* MetadataEditFileNamesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6FB7592A73E18200984B84 /* MetadataEditFileNamesViewModel.swift */; };
 		5E744F9127E36EAA00A47D27 /* RCValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E744F9027E36EAA00A47D27 /* RCValues.swift */; };
 		5E744F9327E38DB900A47D27 /* LoadingScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E744F9227E38DB900A47D27 /* LoadingScreenViewController.swift */; };
@@ -1014,7 +1014,7 @@
 		5E68F2D826A9A2CD00CC936E /* TestURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLs.swift; sourceTree = "<group>"; };
 		5E68F2DA26A9A32400CC936E /* ResponseURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseURLProtocol.swift; sourceTree = "<group>"; };
 		5E6AD37428A1A85A005ADF7E /* PhotoLibraryPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryPage.swift; sourceTree = "<group>"; };
-		5E6FB7572A73E15800984B84 /* MetadataEditFileNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataEditFileNames.swift; sourceTree = "<group>"; };
+		5E6FB7572A73E15800984B84 /* MetadataEditFileNamesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataEditFileNamesView.swift; sourceTree = "<group>"; };
 		5E6FB7592A73E18200984B84 /* MetadataEditFileNamesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataEditFileNamesViewModel.swift; sourceTree = "<group>"; };
 		5E744F9027E36EAA00A47D27 /* RCValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCValues.swift; sourceTree = "<group>"; };
 		5E744F9227E38DB900A47D27 /* LoadingScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingScreenViewController.swift; sourceTree = "<group>"; };
@@ -2643,7 +2643,7 @@
 			children = (
 				5E991EDE2A48E05C006229C0 /* MetadataEditView.swift */,
 				5E5AB6092A5C414E0030BF61 /* AddNewTagView.swift */,
-				5E6FB7572A73E15800984B84 /* MetadataEditFileNames.swift */,
+				5E6FB7572A73E15800984B84 /* MetadataEditFileNamesView.swift */,
 				5E5AB60E2A6494170030BF61 /* AddTagsView.swift */,
 				5E66730E2A793D9B001C49CC /* ReplaceFilenameView.swift */,
 				5E6673142A7A3A50001C49CC /* AppendFilenameView.swift */,
@@ -4366,7 +4366,7 @@
 				BC59BAB525C2B7D6005A45D3 /* SharePreviewViewModel.swift in Sources */,
 				F5853CFA26DEBB9D0050E377 /* PRMNTActionSheetViewController.swift in Sources */,
 				BC59BAB425C2B7D6005A45D3 /* SharePreviewViewModelDelegate.swift in Sources */,
-				5E6FB7582A73E15800984B84 /* MetadataEditFileNames.swift in Sources */,
+				5E6FB7582A73E15800984B84 /* MetadataEditFileNamesView.swift in Sources */,
 				5ED3B3BC29FAB2BE000CFF48 /* LegacyPlanningSaveButton.swift in Sources */,
 				5E559EC829BF438200F129BF /* IntExtension.swift in Sources */,
 				5EF0B6E927F43D62000CBAF6 /* PublicGalleryViewModel.swift in Sources */,

--- a/Permanent/Common/Base/SwiftUIViews/PullDownButton.swift
+++ b/Permanent/Common/Base/SwiftUIViews/PullDownButton.swift
@@ -6,11 +6,6 @@
 
 import SwiftUI
 
-struct Option: Identifiable, Hashable {
-    let id = UUID()
-    let title: String
-}
-
 struct PullDownButton: View {
     
     @Binding var isSelecting: Bool

--- a/Permanent/Modules/EditMetadata/ViewModels/AppendFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/AppendFilenameViewModel.swift
@@ -5,8 +5,25 @@
 //  Created by Lucian Cerbu on 02.08.2023.
 
 import Foundation
+import SwiftUI
 
-class AppendFilenameViewModel: ObservableObject {
+class AppendFilenameViewModel: ObservableObject, MyProtocol {
+    var fileNamePreview: Binding<String?>
+    
+    @Published var textToAppend: String = ""
+    @Published var positionForText: String = ""
+
+    var selectedFiles: [FileModel]
+    
+    init(selectedFiles: [FileModel], fileNamePreview: Binding<String?>) {
+        self.selectedFiles = selectedFiles
+        self.fileNamePreview = fileNamePreview
+    }
+    
+    func getSelectedFiles() -> [FileModel] {
+        return []
+    }
+
     enum WhereToAppendText: String {
         case beforeFilename
         case afterFilename
@@ -21,7 +38,10 @@ class AppendFilenameViewModel: ObservableObject {
         }
     }
     
-    @Published var textToAppend: String = ""
-    @Published var positionForText: String = ""
+    func updateAppendPreview() {
+        let fileName = selectedFiles.first?.name
+        let result = fileName?.appending(textToAppend)
+        fileNamePreview.wrappedValue = result
+    }
 }
 

--- a/Permanent/Modules/EditMetadata/ViewModels/AppendFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/AppendFilenameViewModel.swift
@@ -7,7 +7,7 @@
 import Foundation
 import SwiftUI
 
-class AppendFilenameViewModel: ObservableObject, MyProtocol {
+class AppendFilenameViewModel: ObservableObject, MetadataEditFilenamesProtocol {
     var fileNamePreview: Binding<String?>
     
     @Published var textToAppend: String = ""

--- a/Permanent/Modules/EditMetadata/ViewModels/AppendFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/AppendFilenameViewModel.swift
@@ -19,7 +19,11 @@ class AppendFilenameViewModel: ObservableObject, MyProtocol {
         PullDownItem(title: "After Name")
     ]
     
-    @Published var selectedOption: PullDownItem?
+    @Published var selectedOption: PullDownItem? {
+        didSet {
+            updateAppendPreview()
+        }
+    }
     
     init(selectedFiles: [FileModel], fileNamePreview: Binding<String?>) {
         self.selectedFiles = selectedFiles
@@ -28,13 +32,30 @@ class AppendFilenameViewModel: ObservableObject, MyProtocol {
     }
     
     func getSelectedFiles() -> [FileModel] {
-        return []
+        let filteredFiles = selectedFiles.map { file in
+            var newFile = file
+            let name = newFile.name
+            if selectedOption?.title == "Before name" {
+                newFile.name = String("\(textToAppend)\(name)")
+            } else {
+                newFile.name = String("\(name)\(textToAppend)")
+            }
+            return newFile
+        }
+        return filteredFiles
     }
     
     func updateAppendPreview() {
-        let fileName = selectedFiles.first?.name
-        let result = fileName?.appending(textToAppend)
-        fileNamePreview.wrappedValue = result
+        var fileName = selectedFiles.first?.name ?? ""
+        
+        if selectedOption?.title == "Before name" {
+            fileName = String("\(textToAppend)\(fileName)")
+        } else {
+            fileName = String("\(fileName)\(textToAppend)")
+        }
+        
+
+        fileNamePreview.wrappedValue = fileName
     }
 }
 

--- a/Permanent/Modules/EditMetadata/ViewModels/MetadataEditFileNamesViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/MetadataEditFileNamesViewModel.swift
@@ -8,8 +8,8 @@ import Foundation
 import SwiftUI
 
 protocol MyProtocol: AnyObject {
-    func getSelectedFiles() -> [FileModel]
     var fileNamePreview: Binding<String?> {get set}
+    func getSelectedFiles() -> [FileModel]
 }
 
 class MetadataEditFileNamesViewModel: ObservableObject {
@@ -20,11 +20,14 @@ class MetadataEditFileNamesViewModel: ObservableObject {
     @Published var fileSizePreview: String?
     @Published var fileNamePreview: String?
     
-    weak var currentViewModel: (any MyProtocol)?
+    @Published var modifiedFiles: [FileModel]
+    
+    var currentViewModel: (any MyProtocol)?
     
     init(tagsRepository: TagsRepository = TagsRepository(), selectedFiles: [FileModel]) {
         self.tagsRepository = tagsRepository
         self.selectedFiles = selectedFiles
+        self.modifiedFiles = selectedFiles
         
         imagePreviewURL = selectedFiles.first?.thumbnailURL500
         fileNamePreview = selectedFiles.first?.name
@@ -33,12 +36,7 @@ class MetadataEditFileNamesViewModel: ObservableObject {
         }
     }
     
-    func update() {
-        let myFiles = currentViewModel?.getSelectedFiles()
-    }
-    
     func applyChanges() {
         let updatedFiles = currentViewModel?.getSelectedFiles()
-        print(updatedFiles?.first?.name)
     }
 }

--- a/Permanent/Modules/EditMetadata/ViewModels/MetadataEditFileNamesViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/MetadataEditFileNamesViewModel.swift
@@ -5,6 +5,12 @@
 //  Created by Lucian Cerbu on 28.07.2023.
 
 import Foundation
+import SwiftUI
+
+protocol MyProtocol: AnyObject {
+    func getSelectedFiles() -> [FileModel]
+    var fileNamePreview: Binding<String?> {get set}
+}
 
 class MetadataEditFileNamesViewModel: ObservableObject {
     @Published var isLoading: Bool = false
@@ -13,6 +19,8 @@ class MetadataEditFileNamesViewModel: ObservableObject {
     @Published var imagePreviewURL: String?
     @Published var fileSizePreview: String?
     @Published var fileNamePreview: String?
+    
+    weak var currentViewModel: (any MyProtocol)?
     
     init(tagsRepository: TagsRepository = TagsRepository(), selectedFiles: [FileModel]) {
         self.tagsRepository = tagsRepository
@@ -23,5 +31,14 @@ class MetadataEditFileNamesViewModel: ObservableObject {
         if let size = selectedFiles.first?.size {
             fileSizePreview = size.bytesToReadableForm(useDecimal: true)
         }
+    }
+    
+    func update() {
+        let myFiles = currentViewModel?.getSelectedFiles()
+    }
+    
+    func applyChanges() {
+        let updatedFiles = currentViewModel?.getSelectedFiles()
+        print(updatedFiles?.first?.name)
     }
 }

--- a/Permanent/Modules/EditMetadata/ViewModels/MetadataEditFileNamesViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/MetadataEditFileNamesViewModel.swift
@@ -7,7 +7,7 @@
 import Foundation
 import SwiftUI
 
-protocol MyProtocol: AnyObject {
+protocol MetadataEditFilenamesProtocol: AnyObject {
     var fileNamePreview: Binding<String?> {get set}
     func getSelectedFiles() -> [FileModel]
 }
@@ -20,14 +20,11 @@ class MetadataEditFileNamesViewModel: ObservableObject {
     @Published var fileSizePreview: String?
     @Published var fileNamePreview: String?
     
-    @Published var modifiedFiles: [FileModel]
-    
-    var currentViewModel: (any MyProtocol)?
+    var currentViewModel: (any MetadataEditFilenamesProtocol)?
     
     init(tagsRepository: TagsRepository = TagsRepository(), selectedFiles: [FileModel]) {
         self.tagsRepository = tagsRepository
         self.selectedFiles = selectedFiles
-        self.modifiedFiles = selectedFiles
         
         imagePreviewURL = selectedFiles.first?.thumbnailURL500
         fileNamePreview = selectedFiles.first?.name

--- a/Permanent/Modules/EditMetadata/ViewModels/ReplaceFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/ReplaceFilenameViewModel.swift
@@ -7,7 +7,7 @@
 import Foundation
 import SwiftUI
 
-class ReplaceFilenameViewModel: ObservableObject, MyProtocol {
+class ReplaceFilenameViewModel: ObservableObject, MetadataEditFilenamesProtocol {
     var fileNamePreview: Binding<String?>
     
     @Published var findText: String = ""

--- a/Permanent/Modules/EditMetadata/ViewModels/ReplaceFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/ReplaceFilenameViewModel.swift
@@ -14,7 +14,6 @@ class ReplaceFilenameViewModel: ObservableObject, MyProtocol {
     @Published var replaceText: String = ""
 
     var selectedFiles: [FileModel]
-    var filteredFiles: [FileModel] = []
     
     init(selectedFiles: [FileModel], fileNamePreview: Binding<String?>) {
         self.selectedFiles = selectedFiles
@@ -22,15 +21,16 @@ class ReplaceFilenameViewModel: ObservableObject, MyProtocol {
     }
 
     func getSelectedFiles() -> [FileModel] {
-        filteredFiles = selectedFiles.map { file in
+        let filteredFiles = selectedFiles.map { file in
             var newFile = file
             let name = newFile.name
             newFile.name = name.replacingOccurrences(of: findText, with: replaceText)
             return newFile
         }
+        
         return filteredFiles
     }
-    
+
     func updateReplacePreview() {
         let fileName = selectedFiles.first?.name
         fileNamePreview.wrappedValue = fileName?.replacingOccurrences(of: findText, with: replaceText)

--- a/Permanent/Modules/EditMetadata/ViewModels/ReplaceFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/ReplaceFilenameViewModel.swift
@@ -5,8 +5,34 @@
 //  Created by Lucian Cerbu on 01.08.2023.
 
 import Foundation
+import SwiftUI
 
-class ReplaceFilenameViewModel: ObservableObject {
+class ReplaceFilenameViewModel: ObservableObject, MyProtocol {
+    var fileNamePreview: Binding<String?>
+    
     @Published var findText: String = ""
     @Published var replaceText: String = ""
+
+    var selectedFiles: [FileModel]
+    var filteredFiles: [FileModel] = []
+    
+    init(selectedFiles: [FileModel], fileNamePreview: Binding<String?>) {
+        self.selectedFiles = selectedFiles
+        self.fileNamePreview = fileNamePreview
+    }
+
+    func getSelectedFiles() -> [FileModel] {
+        filteredFiles = selectedFiles.map { file in
+            var newFile = file
+            let name = newFile.name
+            newFile.name = name.replacingOccurrences(of: findText, with: replaceText)
+            return newFile
+        }
+        return filteredFiles
+    }
+    
+    func updateReplacePreview() {
+        let fileName = selectedFiles.first?.name
+        fileNamePreview.wrappedValue = fileName?.replacingOccurrences(of: findText, with: replaceText)
+    }
 }

--- a/Permanent/Modules/EditMetadata/ViewModels/SequenceFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/SequenceFilenameViewModel.swift
@@ -7,7 +7,7 @@
 import Foundation
 import SwiftUI
 
-class SequenceFilenameViewModel: ObservableObject, MyProtocol {
+class SequenceFilenameViewModel: ObservableObject, MetadataEditFilenamesProtocol {
     var fileNamePreview: Binding<String?>
     
     func getSelectedFiles() -> [FileModel] {

--- a/Permanent/Modules/EditMetadata/ViewModels/SequenceFilenameViewModel.swift
+++ b/Permanent/Modules/EditMetadata/ViewModels/SequenceFilenameViewModel.swift
@@ -5,8 +5,23 @@
 //  Created by Lucian Cerbu on 02.08.2023.
 
 import Foundation
+import SwiftUI
 
-class SequenceFilenameViewModel: ObservableObject {
+class SequenceFilenameViewModel: ObservableObject, MyProtocol {
+    var fileNamePreview: Binding<String?>
+    
+    func getSelectedFiles() -> [FileModel] {
+        return []
+    }
+    
+    var selectedFiles: [FileModel]
+    var filteredFiles: [FileModel] = []
+    
+    init(selectedFiles: [FileModel], fileNamePreview: Binding<String?>) {
+        self.selectedFiles = selectedFiles
+        self.fileNamePreview = fileNamePreview
+    }
+    
     var baseText: String = ""
     @Published var selectedOption: PullDownItem?
 }

--- a/Permanent/Modules/EditMetadata/Views/AppendFilenameView.swift
+++ b/Permanent/Modules/EditMetadata/Views/AppendFilenameView.swift
@@ -7,11 +7,7 @@
 import SwiftUI
 
 struct AppendFilenameView: View {
-    @ObservedObject var viewModel: AppendFilenameViewModel
-    
-    init(viewModel: AppendFilenameViewModel) {
-        self.viewModel = viewModel
-    }
+    @StateObject var viewModel: AppendFilenameViewModel
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -22,7 +18,7 @@ struct AppendFilenameView: View {
                 .modifier(SmallXXRegularTextStyle())
                 .textFieldStyle(CustomTextFieldStyle())
                 .onChange(of: viewModel.textToAppend) { newValue in
-                    print(newValue)
+                    viewModel.updateAppendPreview()
                 }
             Text("Where".uppercased())
                 .textStyle(SmallXXXXXSemiBoldTextStyle())
@@ -30,11 +26,8 @@ struct AppendFilenameView: View {
             Spacer()
         }
         .padding(.top, 15)
-    }
-}
-
-struct AppendFilenameView_Previews: PreviewProvider {
-    static var previews: some View {
-        AppendFilenameView(viewModel: AppendFilenameViewModel())
+        .onDisappear {
+            viewModel.fileNamePreview.wrappedValue = viewModel.selectedFiles.first?.name
+        }
     }
 }

--- a/Permanent/Modules/EditMetadata/Views/AppendFilenameView.swift
+++ b/Permanent/Modules/EditMetadata/Views/AppendFilenameView.swift
@@ -52,6 +52,10 @@ struct AppendFilenameView: View {
                     dismissKeyboard()
                 }
         )
+        .onDisappear {
+            viewModel.textToAppend = ""
+            viewModel.fileNamePreview.wrappedValue = viewModel.selectedFiles.first?.name
+        }
     }
     
     private func dismissKeyboard() {

--- a/Permanent/Modules/EditMetadata/Views/CustomSegmentedControl.swift
+++ b/Permanent/Modules/EditMetadata/Views/CustomSegmentedControl.swift
@@ -49,6 +49,6 @@ struct CustomSegmentedControl: View {
 
 struct CustomSegmentedControl_Previews: PreviewProvider {
     static var previews: some View {
-        MetadataEditFileNames(viewModel: MetadataEditFileNamesViewModel(selectedFiles: []))
+        MetadataEditFileNamesView(viewModel: MetadataEditFileNamesViewModel(selectedFiles: []))
     }
 }

--- a/Permanent/Modules/EditMetadata/Views/MetadataEditFileNames.swift
+++ b/Permanent/Modules/EditMetadata/Views/MetadataEditFileNames.swift
@@ -16,6 +16,10 @@ struct MetadataEditFileNames: View {
     @ObservedObject var viewModel: MetadataEditFileNamesViewModel
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     var showEditFilenames: Binding<Bool>?
+    
+    var replaceViewModel: ReplaceFilenameViewModel!
+    var appendViewModel: AppendFilenameViewModel!
+    var sequenceViewModel: SequenceFilenameViewModel!
 
     @State private var selectedItem: MenuItem? = MenuItem(name: "Replace", image: UIImage(named: "metadataReplace")!)
     private var menuItems: [MenuItem] = [
@@ -26,6 +30,10 @@ struct MetadataEditFileNames: View {
 
     init(viewModel: MetadataEditFileNamesViewModel) {
         self.viewModel = viewModel
+        
+        self.replaceViewModel = ReplaceFilenameViewModel(selectedFiles: self.viewModel.selectedFiles, fileNamePreview: $viewModel.fileNamePreview)
+        self.appendViewModel = AppendFilenameViewModel(selectedFiles: self.viewModel.selectedFiles, fileNamePreview: $viewModel.fileNamePreview)
+        self.sequenceViewModel = SequenceFilenameViewModel(selectedFiles: self.viewModel.selectedFiles, fileNamePreview: $viewModel.fileNamePreview)
     }
     
     var body: some View {
@@ -33,19 +41,29 @@ struct MetadataEditFileNames: View {
             NavigationView {
                 VStack {
                     CustomSegmentedControl(selectedItem: $selectedItem, items: menuItems)
-
+                        .onAppear {
+                            setCurrentViewModel(editViewModel: replaceViewModel)
+                        }
+                        .onChange(of: selectedItem) { newValue in
+                            switch newValue?.name {
+                            case "Replace":
+                                setCurrentViewModel(editViewModel: replaceViewModel)
+                            case "Append":
+                                setCurrentViewModel(editViewModel: appendViewModel)
+                            case "Sequence":
+                                setCurrentViewModel(editViewModel: sequenceViewModel)
+                            default:
+                                break
+                            }
+                        }
                     if selectedItem?.name == "Replace" {
-                        let replaceViewModel = ReplaceFilenameViewModel(selectedFiles: viewModel.selectedFiles, fileNamePreview: $viewModel.fileNamePreview)
-                        let _ = setCurrentViewModel(editViewModel: replaceViewModel)
                         ReplaceFilenameView(viewModel: replaceViewModel)
                     }
                     if selectedItem?.name == "Append" {
-                        let appendViewModel = AppendFilenameViewModel(selectedFiles: viewModel.selectedFiles, fileNamePreview: $viewModel.fileNamePreview)
-                        let _ = setCurrentViewModel(editViewModel: appendViewModel)
                         AppendFilenameView(viewModel: appendViewModel)
                     }
                     if selectedItem?.name == "Sequence" {
-                        SequenceFilenameView(viewModel: SequenceFilenameViewModel())
+                        SequenceFilenameView(viewModel: sequenceViewModel)
                     }
                     Spacer()
                 }
@@ -121,7 +139,6 @@ struct MetadataEditFileNames: View {
             Spacer(minLength: 15)
             Button {
                 viewModel.applyChanges()
-                ///To do add Apply changes button action
             } label: {
                 if viewModel.isLoading {
                     ProgressView()

--- a/Permanent/Modules/EditMetadata/Views/MetadataEditFileNames.swift
+++ b/Permanent/Modules/EditMetadata/Views/MetadataEditFileNames.swift
@@ -35,10 +35,16 @@ struct MetadataEditFileNames: View {
                     CustomSegmentedControl(selectedItem: $selectedItem, items: menuItems)
 
                     if selectedItem?.name == "Replace" {
-                        ReplaceFilenameView(viewModel: ReplaceFilenameViewModel())
-                    }else if selectedItem?.name == "Append" {
-                        AppendFilenameView(viewModel: AppendFilenameViewModel())
-                    }else if selectedItem?.name == "Sequence" {
+                        let replaceViewModel = ReplaceFilenameViewModel(selectedFiles: viewModel.selectedFiles, fileNamePreview: $viewModel.fileNamePreview)
+                        let _ = setCurrentViewModel(editViewModel: replaceViewModel)
+                        ReplaceFilenameView(viewModel: replaceViewModel)
+                    }
+                    if selectedItem?.name == "Append" {
+                        let appendViewModel = AppendFilenameViewModel(selectedFiles: viewModel.selectedFiles, fileNamePreview: $viewModel.fileNamePreview)
+                        let _ = setCurrentViewModel(editViewModel: appendViewModel)
+                        AppendFilenameView(viewModel: appendViewModel)
+                    }
+                    if selectedItem?.name == "Sequence" {
                         SequenceFilenameView(viewModel: SequenceFilenameViewModel())
                     }
                     Spacer()
@@ -60,6 +66,10 @@ struct MetadataEditFileNames: View {
                     .padding(.horizontal, 10)
             }
         }
+    }
+    
+    func setCurrentViewModel(editViewModel: MyProtocol) {
+        viewModel.currentViewModel = editViewModel
     }
     
     var previewSection: some View {
@@ -110,6 +120,7 @@ struct MetadataEditFileNames: View {
             .buttonStyle(CustomButtonStyle(backgroundColor: .galleryGray, foregroundColor: .darkBlue))
             Spacer(minLength: 15)
             Button {
+                viewModel.applyChanges()
                 ///To do add Apply changes button action
             } label: {
                 if viewModel.isLoading {

--- a/Permanent/Modules/EditMetadata/Views/MetadataEditFileNamesView.swift
+++ b/Permanent/Modules/EditMetadata/Views/MetadataEditFileNamesView.swift
@@ -12,7 +12,7 @@ struct MenuItem: Hashable {
     var image: UIImage
 }
 
-struct MetadataEditFileNames: View {
+struct MetadataEditFileNamesView: View {
     @ObservedObject var viewModel: MetadataEditFileNamesViewModel
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
     var showEditFilenames: Binding<Bool>?
@@ -41,21 +41,7 @@ struct MetadataEditFileNames: View {
             NavigationView {
                 VStack {
                     CustomSegmentedControl(selectedItem: $selectedItem, items: menuItems)
-                        .onAppear {
-                            setCurrentViewModel(editViewModel: replaceViewModel)
-                        }
-                        .onChange(of: selectedItem) { newValue in
-                            switch newValue?.name {
-                            case "Replace":
-                                setCurrentViewModel(editViewModel: replaceViewModel)
-                            case "Append":
-                                setCurrentViewModel(editViewModel: appendViewModel)
-                            case "Sequence":
-                                setCurrentViewModel(editViewModel: sequenceViewModel)
-                            default:
-                                break
-                            }
-                        }
+
                     if selectedItem?.name == "Replace" {
                         ReplaceFilenameView(viewModel: replaceViewModel)
                     }
@@ -83,10 +69,25 @@ struct MetadataEditFileNames: View {
                 bottomButtons
                     .padding(.horizontal, 10)
             }
+            .onAppear {
+                setCurrentViewModel(editViewModel: replaceViewModel)
+            }
+            .onChange(of: selectedItem) { newValue in
+                switch newValue?.name {
+                case "Replace":
+                    setCurrentViewModel(editViewModel: replaceViewModel)
+                case "Append":
+                    setCurrentViewModel(editViewModel: appendViewModel)
+                case "Sequence":
+                    setCurrentViewModel(editViewModel: sequenceViewModel)
+                default:
+                    break
+                }
+            }
         }
     }
     
-    func setCurrentViewModel(editViewModel: MyProtocol) {
+    func setCurrentViewModel(editViewModel: MetadataEditFilenamesProtocol) {
         viewModel.currentViewModel = editViewModel
     }
     
@@ -156,6 +157,6 @@ struct MetadataEditFileNames: View {
 struct MetadataEditFileNames_Previews: PreviewProvider {
     static var previews: some View {
         let file = FileModel(model: FolderVOData(folderID: 22, archiveNbr: nil, archiveID: 22, displayName: "TestFile", displayDT: nil, displayEndDT: nil, derivedDT: nil, derivedEndDT: nil, note: nil, voDescription: nil, special: nil, sort: nil, locnID: nil, timeZoneID: nil, view: nil, viewProperty: nil, thumbArchiveNbr: nil, type: nil, thumbStatus: nil, imageRatio: nil, thumbURL200: nil, thumbURL500: "https://img.freepik.com/free-photo/bright-yellow-fire-blazing-against-night-sky-generated-by-ai_188544-11620.jpg?t=st=1690878101~exp=1690881701~hmac=103cd63a2a40c4feeda570cad19c0c3cc8de275d6d6c2731ee33c3310669f67c&w=2000", thumbURL1000: nil, thumbURL2000: nil, thumbDT: nil, status: nil, publicDT: nil, parentFolderID: nil, folderLinkType: nil, folderLinkVOS: nil, accessRole: nil, position: nil, pathAsFolderLinkID: nil, shareDT: nil, pathAsText: nil, folderLinkID: nil, parentFolderLinkID: nil, parentFolderVOS: nil, parentArchiveNbr: nil, parentDisplayName: nil, pathAsArchiveNbr: nil, childFolderVOS: nil, recordVOS: nil, locnVO: nil, timezoneVO: nil, directiveVOS: nil, tagVOS: nil, sharedArchiveVOS: nil, folderSizeVO: nil, attachmentRecordVOS: nil, hasAttachments: nil, childItemVOS: nil, shareVOS: nil, accessVO: nil, returnDataSize: nil, archiveArchiveNbr: nil, accessVOS: nil, posStart: nil, posLimit: nil, searchScore: nil, createdDT: nil, updatedDT: nil))
-        MetadataEditFileNames(viewModel: MetadataEditFileNamesViewModel(selectedFiles: [file]))
+        MetadataEditFileNamesView(viewModel: MetadataEditFileNamesViewModel(selectedFiles: [file]))
     }
 }

--- a/Permanent/Modules/EditMetadata/Views/MetadataEditView.swift
+++ b/Permanent/Modules/EditMetadata/Views/MetadataEditView.swift
@@ -126,7 +126,7 @@ struct MetadataEditView: View {
                 AddNewTagView(viewModel: AddNewTagViewModel(selectionTags: viewModel.allTags, selectedFiles: viewModel.selectedFiles))
             }
             .sheet(isPresented: $showEditFilenames) {
-                MetadataEditFileNames(viewModel: MetadataEditFileNamesViewModel( selectedFiles: viewModel.selectedFiles))
+                MetadataEditFileNames(viewModel: MetadataEditFileNamesViewModel(selectedFiles: viewModel.selectedFiles))
             }
             .onAppear {
                 viewModel.refreshFiles()

--- a/Permanent/Modules/EditMetadata/Views/MetadataEditView.swift
+++ b/Permanent/Modules/EditMetadata/Views/MetadataEditView.swift
@@ -126,7 +126,7 @@ struct MetadataEditView: View {
                 AddNewTagView(viewModel: AddNewTagViewModel(selectionTags: viewModel.allTags, selectedFiles: viewModel.selectedFiles))
             }
             .sheet(isPresented: $showEditFilenames) {
-                MetadataEditFileNames(viewModel: MetadataEditFileNamesViewModel(selectedFiles: viewModel.selectedFiles))
+                MetadataEditFileNamesView(viewModel: MetadataEditFileNamesViewModel(selectedFiles: viewModel.selectedFiles))
             }
             .onAppear {
                 viewModel.refreshFiles()

--- a/Permanent/Modules/EditMetadata/Views/ReplaceFilenameView.swift
+++ b/Permanent/Modules/EditMetadata/Views/ReplaceFilenameView.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 struct ReplaceFilenameView: View {
-    @StateObject var viewModel: ReplaceFilenameViewModel
+   @StateObject var viewModel: ReplaceFilenameViewModel
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -26,7 +26,7 @@ struct ReplaceFilenameView: View {
                 .modifier(SmallXXRegularTextStyle())
                 .textFieldStyle(CustomTextFieldStyle())
                 .onChange(of: viewModel.replaceText) { newValue in
-                    viewModel.updateReplacePreview()
+                   viewModel.updateReplacePreview()
                 }
             Spacer()
         }
@@ -34,6 +34,8 @@ struct ReplaceFilenameView: View {
         .onTapGesture {
             dismissKeyboard()
         }.onDisappear {
+            viewModel.findText = ""
+            viewModel.replaceText = ""
             viewModel.fileNamePreview.wrappedValue = viewModel.selectedFiles.first?.name
         }
     }

--- a/Permanent/Modules/EditMetadata/Views/ReplaceFilenameView.swift
+++ b/Permanent/Modules/EditMetadata/Views/ReplaceFilenameView.swift
@@ -7,11 +7,7 @@
 import SwiftUI
 
 struct ReplaceFilenameView: View {
-    @ObservedObject var viewModel: ReplaceFilenameViewModel
-    
-    init(viewModel: ReplaceFilenameViewModel) {
-        self.viewModel = viewModel
-    }
+    @StateObject var viewModel: ReplaceFilenameViewModel
     
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -22,7 +18,6 @@ struct ReplaceFilenameView: View {
                 .modifier(SmallXXRegularTextStyle())
                 .textFieldStyle(CustomTextFieldStyle())
                 .onChange(of: viewModel.findText) { newValue in
-                    print(newValue)
                 }
             Text("Replace".uppercased())
                 .textStyle(SmallXXXXXSemiBoldTextStyle())
@@ -31,18 +26,19 @@ struct ReplaceFilenameView: View {
                 .modifier(SmallXXRegularTextStyle())
                 .textFieldStyle(CustomTextFieldStyle())
                 .onChange(of: viewModel.replaceText) { newValue in
-                    print(newValue)
+                    viewModel.updateReplacePreview()
                 }
             Spacer()
         }
         .padding(.top, 15)
+        .onTapGesture {
+            dismissKeyboard()
+        }.onDisappear {
+            viewModel.fileNamePreview.wrappedValue = viewModel.selectedFiles.first?.name
+        }
     }
-}
-
-struct ReplaceFilenameView_Previews: PreviewProvider {
-    static var previews: some View {
-        @State var newTag: String = ""
-        
-        ReplaceFilenameView(viewModel: ReplaceFilenameViewModel())
+    
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }

--- a/Permanent/Modules/EditMetadata/Views/SequenceFilenameView.swift
+++ b/Permanent/Modules/EditMetadata/Views/SequenceFilenameView.swift
@@ -87,6 +87,9 @@ struct SequenceFilenameView: View {
                     dismissKeyboard()
                 }
         )
+        .onDisappear {
+            viewModel.fileNamePreview.wrappedValue = viewModel.selectedFiles.first?.name
+        }
     }
     
     private func dismissKeyboard() {

--- a/Permanent/Modules/EditMetadata/Views/SequenceFilenameView.swift
+++ b/Permanent/Modules/EditMetadata/Views/SequenceFilenameView.swift
@@ -29,9 +29,3 @@ struct SequenceFilenameView: View {
         .padding(.top, 15)
     }
 }
-
-struct SequenceFilenameView_Previews: PreviewProvider {
-    static var previews: some View {
-        SequenceFilenameView(viewModel: SequenceFilenameViewModel())
-    }
-}

--- a/Permanent/ViewModels/ViewModel/FileModel.swift
+++ b/Permanent/ViewModels/ViewModel/FileModel.swift
@@ -31,7 +31,7 @@ struct FileModel: Equatable, Codable {
     let thumbnailURL2000: String?
     let thumbStatus: ThumbStatus?
     
-    let name: String
+    var name: String
     let date: String
     let type: FileType
     let description: String


### PR DESCRIPTION
Resolved a memory leak issue that appeared when replace, append, or sequence views were displayed.
Implemented preview filename for append view.
