### PR TITLE
VSP-1364[iOS]Redeem code deep link and demo remarks implementations

### DIFF
--- a/Permanent/App/AppDelegate.swift
+++ b/Permanent/App/AppDelegate.swift
@@ -49,30 +49,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         switch url.pathComponents[1] {
         case "share":
-            if let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-               let redeemCode = components.queryItems?.first(where: { $0.name == "promoCode" })?.value {
-                if let authData = KeychainSwift().getData(SessionKeychainHandler.keychainAuthDataKey),
-                   let session = try? JSONDecoder().decode(PermSession.self, from: authData),
-                   let archiveId = session.selectedArchive?.archiveID,
-                   archiveId != .zero {
-                    let storageViewModel = StateObject(wrappedValue: StorageViewModel(reddemCode: redeemCode))
-                    let storageView = StorageView(viewModel: storageViewModel)
-                    
-                    let host = UIHostingController(rootView: storageView)
-                    self.window?.rootViewController?.present(host, animated: true, completion: nil)
-                    
-                    return true
-                } else {
-                    
-                    return false
-                }
+            if rootViewController.isDrawerRootActive {
+                return navigateFromUniversalLink(url: url)
             } else {
-                if rootViewController.isDrawerRootActive {
-                    return navigateFromUniversalLink(url: url)
-                } else {
-                    saveUnivesalLinkToken(url.lastPathComponent)
-                    return false
-                }
+                saveUnivesalLinkToken(url.lastPathComponent)
+                return false
             }
             
         case "p":
@@ -105,15 +86,33 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             
         case "app":
-            if url.pathComponents.count >= 3, url.pathComponents[2] == "pr" && url.pathComponents[3] == "manage" {
-                if rootViewController.isDrawerRootActive {
-                    return navigateFromSharedArchive()
+            if let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+               let redeemCode = components.queryItems?.first(where: { $0.name == "promoCode" })?.value {
+                if let authData = KeychainSwift().getData(SessionKeychainHandler.keychainAuthDataKey),
+                   let session = try? JSONDecoder().decode(PermSession.self, from: authData),
+                   let archiveId = session.selectedArchive?.archiveID,
+                   archiveId != .zero {
+                    let storageViewModel = StateObject(wrappedValue: StorageViewModel(reddemCode: redeemCode))
+                    let storageView = StorageView(viewModel: storageViewModel)
+                    
+                    let host = UIHostingController(rootView: storageView)
+                    self.window?.rootViewController?.present(host, animated: true, completion: nil)
+                    
+                    return true
                 } else {
-                    saveSharedArchiveToken()
                     return false
                 }
+            } else {
+                if url.pathComponents.count >= 3, url.pathComponents[2] == "pr" && url.pathComponents[3] == "manage" {
+                    if rootViewController.isDrawerRootActive {
+                        return navigateFromSharedArchive()
+                    } else {
+                        saveSharedArchiveToken()
+                        return false
+                    }
+                }
+                return false
             }
-            return false
             
         default: return false
         }

--- a/Permanent/App/AppDelegate.swift
+++ b/Permanent/App/AppDelegate.swift
@@ -86,24 +86,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             
         case "app":
-            if let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
-               let redeemCode = components.queryItems?.first(where: { $0.name == "promoCode" })?.value {
-                if let authData = KeychainSwift().getData(SessionKeychainHandler.keychainAuthDataKey),
-                   let session = try? JSONDecoder().decode(PermSession.self, from: authData),
-                   let archiveId = session.selectedArchive?.archiveID,
-                   archiveId != .zero {
-                    let storageViewModel = StateObject(wrappedValue: StorageViewModel(reddemCode: redeemCode))
-                    let storageView = StorageView(viewModel: storageViewModel)
-                    
-                    let host = UIHostingController(rootView: storageView)
-                    self.window?.rootViewController?.present(host, animated: true, completion: nil)
-                    
-                    return true
-                } else {
-                    return false
+            if let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+            {
+                if let redeemCode = components.queryItems?.first(where: { $0.name == "promoCode" })?.value {
+                    if let authData = KeychainSwift().getData(SessionKeychainHandler.keychainAuthDataKey),
+                       let session = try? JSONDecoder().decode(PermSession.self, from: authData),
+                       let archiveId = session.selectedArchive?.archiveID,
+                       archiveId != .zero {
+                        let storageViewModel = StateObject(wrappedValue: StorageViewModel(reddemCode: redeemCode))
+                        let storageView = StorageView(viewModel: storageViewModel)
+                        
+                        let host = UIHostingController(rootView: storageView)
+                        self.window?.rootViewController?.present(host, animated: true, completion: nil)
+                        
+                        return true
+                    }
                 }
-            } else {
-                if url.pathComponents.count >= 3, url.pathComponents[2] == "pr" && url.pathComponents[3] == "manage" {
+                if components.path == "/app/pr/manage" {
                     if rootViewController.isDrawerRootActive {
                         return navigateFromSharedArchive()
                     } else {
@@ -111,8 +110,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                         return false
                     }
                 }
-                return false
             }
+            return false
             
         default: return false
         }

--- a/Permanent/Common/Base/SwiftUIViews/GradientCustomBarView.swift
+++ b/Permanent/Common/Base/SwiftUIViews/GradientCustomBarView.swift
@@ -18,9 +18,11 @@ struct GradientProgressBarView: View {
                     Text("\(value) ")
                         .textStyle(SmallXXXSemiBoldTextStyle())
                         .foregroundColor(.white)
-                    Text("used")
-                        .textStyle(SmallXXXRegularTextStyle())
-                        .foregroundColor(.white)
+                    if value.isNotEmpty {
+                        Text("used")
+                            .textStyle(SmallXXXRegularTextStyle())
+                            .foregroundColor(.white)
+                    }
                 }
                 Spacer()
                 Text("\(maxValue)")
@@ -29,7 +31,7 @@ struct GradientProgressBarView: View {
             }
             .padding(.horizontal)
             
-            ProgressView(value: sizeRatio)
+            ProgressView(value: sizeRatio, total: 1.0)
                 .progressViewStyle(CustomBarProgressStyle(color: .white, height: 8, cornerRadius: 3))
                 .frame(height: 12)
                 .padding(.horizontal)

--- a/Permanent/Common/Base/SwiftUIViews/GradientCustomBarView.swift
+++ b/Permanent/Common/Base/SwiftUIViews/GradientCustomBarView.swift
@@ -7,12 +7,13 @@
 import SwiftUI
 
 struct GradientProgressBarView: View {
-    @Binding var value: String
-    @Binding var maxValue: String
-    @Binding var sizeRatio: Double
+    var value: String
+    var maxValue: String
+    var sizeRatio: Double
+    @State private var redraw = UUID()
     
     var body: some View {
-        VStack(spacing: 16) {
+        LazyVStack(spacing: 16) {
             HStack {
                 HStack(spacing: 0) {
                     Text("\(value) ")
@@ -30,22 +31,22 @@ struct GradientProgressBarView: View {
                     .foregroundColor(.white)
             }
             .padding(.horizontal)
-            
-            if sizeRatio != .zero {
-                ProgressView(value: sizeRatio)
-                    .progressViewStyle(CustomBarProgressStyle(color: .white, height: 8, cornerRadius: 3))
-                    .frame(height: 12)
-                    .padding(.horizontal)
-            } else {
-                ProgressView(value: 0.0)
-                    .progressViewStyle(CustomBarProgressStyle(color: .white, height: 8, cornerRadius: 3))
-                    .frame(height: 12)
-                    .padding(.horizontal)
-            }
+            ProgressView(value: sizeRatio)
+                .progressViewStyle(CustomBarProgressStyle(color: .white, height: 8, cornerRadius: 3))
+                .frame(height: 12)
+                .padding(.horizontal)
+                .id(redraw)
         }
+        .onChange(of: sizeRatio, perform: { newValue in
+            updateRedraw()
+        })
         .frame(maxHeight: 72)
         .background(Gradient.purpleYellowGradient)
         .cornerRadius(12)
         .padding(16)
+    }
+    
+    func updateRedraw() {
+        redraw = UUID()
     }
 }

--- a/Permanent/Modules/SideMenus/ViewController/RightSideMenuViewController.swift
+++ b/Permanent/Modules/SideMenus/ViewController/RightSideMenuViewController.swift
@@ -248,7 +248,7 @@ extension RightSideMenuViewController: UITableViewDataSource, UITableViewDelegat
             AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
             
         case .storage:
-            let hostingController = UIHostingController(rootView: StorageView(viewModel: StateObject(wrappedValue: StorageViewModel.init(accountData: self.viewModel?.accountData))))
+            let hostingController = UIHostingController(rootView: StorageView(viewModel: StateObject(wrappedValue: StorageViewModel.init())))
             hostingController.modalPresentationStyle = .fullScreen
             
             self.present(hostingController, animated: true, completion: nil)

--- a/Permanent/Modules/SideMenus/ViewController/RightSideMenuViewController.swift
+++ b/Permanent/Modules/SideMenus/ViewController/RightSideMenuViewController.swift
@@ -248,13 +248,12 @@ extension RightSideMenuViewController: UITableViewDataSource, UITableViewDelegat
             AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: newRootVC)
             
         case .storage:
-            var storageView = StorageView(viewModel: StateObject(wrappedValue: StorageViewModel.init()))
-            let hostingController = UIHostingController(rootView: storageView)
+            let hostingController = UIHostingController(rootView: StorageView(viewModel: StateObject(wrappedValue: StorageViewModel.init())))
             hostingController.modalPresentationStyle = .fullScreen
             
             self.present(hostingController, animated: true, completion: nil)
             
-            storageView.dismissAction = { [weak self] hasUpdates in
+            hostingController.rootView.dismissAction = { [weak self] hasUpdates in
                 hostingController.dismiss(animated: true, completion: { [weak self] in
                     self?.updateAccountInfo()
                     self?.selectedMenuOption = .none
@@ -262,6 +261,7 @@ extension RightSideMenuViewController: UITableViewDataSource, UITableViewDelegat
                     self?.adjustUIForAnimation(isOpening: false)
                 })
             }
+            
             
         case .activityFeed:
             let newRootVC = ActivityFeedViewController()

--- a/Permanent/Modules/Storage/ViewModels/RedeemCodeViewModel.swift
+++ b/Permanent/Modules/Storage/ViewModels/RedeemCodeViewModel.swift
@@ -36,9 +36,16 @@ class RedeemCodeViewModel: ObservableObject {
     @Published var storageRedeemedResponse: String = ""
     var firstTextFieldInput: Bool = true
     
-    init(accountData: AccountVOData? = nil) {
+    init(accountData: AccountVOData? = nil, redeemCode: String? = nil) {
+        if let redeemCode = redeemCode {
+            self.redeemCode = redeemCode
+            isConfirmButtonDisabled = false
+            invalidDataInserted = false
+        } else {
+            self.redeemCode = ""
+        }
+
         self.accountData = accountData
-        self.redeemCode = ""
     }
     
     func redeemCodeRequest() {

--- a/Permanent/Modules/Storage/ViewModels/StorageViewModel.swift
+++ b/Permanent/Modules/Storage/ViewModels/StorageViewModel.swift
@@ -30,7 +30,7 @@ class StorageViewModel: ObservableObject {
         didSet {
             let ammountAdded = redeemAmmountInt * 1024 * 1024
             if redeemAmmountInt > 0 {
-                redeemAmmountConverted = ammountAdded.bytesToReadableForm(useDecimal: false)
+                redeemAmmountConverted = ammountAdded.bytesToReadableForm(useDecimal: true)
                 addInTotalSpace(spaceToAdd: ammountAdded)
                 showRedeemNotif = true
             }
@@ -101,6 +101,7 @@ class StorageViewModel: ObservableObject {
     
     func addInTotalSpace(spaceToAdd: Int) {
         spaceTotal = spaceTotal + spaceToAdd
+        spaceRatio = Double(spaceUsed) / Double(spaceTotal)
         spaceTotalReadable = spaceTotal.bytesToReadableForm(useDecimal: false)
     }
 }

--- a/Permanent/Modules/Storage/ViewModels/StorageViewModel.swift
+++ b/Permanent/Modules/Storage/ViewModels/StorageViewModel.swift
@@ -69,12 +69,11 @@ class StorageViewModel: ObservableObject {
                     completionBlock(APIError.invalidResponse)
                     return
                 }
-                self.accountData = model.results[0].data?[0].accountVO
-                completionBlock(nil)
-               
-                return
-                
-            case .error:
+                if let accountDataVO = model.results[0].data?[0].accountVO {
+                    self.accountData = accountDataVO
+                    completionBlock(nil)
+                    return
+                }
                 completionBlock(APIError.invalidResponse)
                 return
                 

--- a/Permanent/Modules/Storage/Views/RedeemCodeView.swift
+++ b/Permanent/Modules/Storage/Views/RedeemCodeView.swift
@@ -51,17 +51,17 @@ struct RedeemCodeView: View {
     var contentView: some View {
         ZStack(alignment: .bottom) {
             if showInvalidAlertView {
-                BottomInvalidAlertMessageView(alertTextTitle: "The code is invalid!", alertTextDescription: "Enter a new code.") {
+                BottomInvalidAlertMessageView(alertTextTitle: "The code is invalid.", alertTextDescription: "Enter a new code.") {
                     viewModel.showAlert = false
                 }
                 .transition(.asymmetric(insertion: .move(edge: .bottom), removal: .opacity))
                 .padding(.bottom, keyboard.currentHeight == .zero ? 16 : keyboard.currentHeight - 10)
             }
             VStack(alignment: .leading, spacing: 8) {
-                Text("Redeem gift code for free storage")
+                Text("Redeem gift code for storage")
                     .textStyle(RegularSemiBoldTextStyle())
                     .foregroundColor(.blue900)
-                Text("If you have a gift code, redeem it for complimentary storage below.")
+                Text("If you have a gift code, redeem it for storage below.")
                     .textStyle(SmallXRegularTextStyle())
                     .foregroundColor(.blue700)
                     .lineLimit(2)

--- a/Permanent/Modules/Storage/Views/StorageView.swift
+++ b/Permanent/Modules/Storage/Views/StorageView.swift
@@ -9,10 +9,6 @@ import SwiftUI
 struct StorageView: View {
     @Environment(\.presentationMode) var presentationMode
     @StateObject var viewModel: StorageViewModel
-    @State var addStorageIsPresented: Bool = false
-    @State var giftStorageIsPresented: Bool = false
-    @State var redeemStorageIspresented: Bool = false
-    @State private var showRedeemNotifView = false
     
     init(viewModel: StateObject<StorageViewModel>) {
         self._viewModel = viewModel
@@ -36,21 +32,22 @@ struct StorageView: View {
         }
         .onChange(of: viewModel.showRedeemNotif) { showNotif in
             withAnimation {
-                showRedeemNotifView = showNotif
+                viewModel.showRedeemNotifView = showNotif
             }
         }
-        .sheet(isPresented: $addStorageIsPresented) {
+        .sheet(isPresented: $viewModel.addStorageIsPresented) {
         } content: {
             AddStorageView()
         }
-        .sheet(isPresented: $giftStorageIsPresented) {
+        .sheet(isPresented: $viewModel.giftStorageIsPresented) {
         } content: {
             GiftStorageView(viewModel: StateObject(wrappedValue: GiftStorageViewModel(accountData: viewModel.accountData)))
         }
-        .sheet(isPresented: $redeemStorageIspresented) {
+        .sheet(isPresented: $viewModel.redeemStorageIspresented) {
         } content: {
-            RedeemCodeView(viewModel: RedeemCodeViewModel(accountData: viewModel.accountData)) { ammount in
+            RedeemCodeView(viewModel: RedeemCodeViewModel(accountData: viewModel.accountData, redeemCode: viewModel.redeemCodeFromUrl)) { ammount in
                 viewModel.redeemAmmountString = ammount
+                viewModel.redeemCodeFromUrl = nil
             }
         }
     }
@@ -63,7 +60,7 @@ struct StorageView: View {
     
     var contentView: some View {
         ZStack(alignment: .bottom) {
-            if showRedeemNotifView {
+            if viewModel.showRedeemNotifView {
                 BottomInfoMessageView(alertTextTitle: "Gift code redeemed!", alertTextDescription: "\(viewModel.reddemAmmountConverted) of storage") {
                     viewModel.showRedeemNotif = false
                 }
@@ -74,19 +71,19 @@ struct StorageView: View {
             VStack {
                 GradientProgressBarView(value: viewModel.spaceUsedReadable, maxValue: viewModel.spaceTotalReadable, sizeRatio: viewModel.spaceRatio)
                 Button {
-                    addStorageIsPresented = true
+                    viewModel.addStorageIsPresented = true
                 } label: {
                     CustomListItemView(image: Image(.storagePlus), titleText: "Add storage", descText: "Increase your space easily by adding more storage.")
                 }
                 Divider()
                 Button {
-                    giftStorageIsPresented = true
+                    viewModel.giftStorageIsPresented = true
                 } label: {
                     CustomListItemView(image: Image(.storageGift), titleText: "Gift storage", descText: "Share storage with others by gifting it to friends or collaborators.")
                 }
                 Divider()
                 Button {
-                    redeemStorageIspresented = true
+                    viewModel.redeemStorageIspresented = true
                 } label: {
                     CustomListItemView(image: Image(.storageRedeem), titleText: "Redeem code", descText: "Enter codes to unlock special storage benefits just for you.")
                 }

--- a/Permanent/Modules/Storage/Views/StorageView.swift
+++ b/Permanent/Modules/Storage/Views/StorageView.swift
@@ -61,7 +61,7 @@ struct StorageView: View {
     var contentView: some View {
         ZStack(alignment: .bottom) {
             if viewModel.showRedeemNotifView {
-                BottomInfoMessageView(alertTextTitle: "Gift code redeemed!", alertTextDescription: "\(viewModel.redeemAmmountConverted) of storage") {
+                BottomInfoMessageView(alertTextTitle: "Gift code redeemed.", alertTextDescription: "\(viewModel.redeemAmmountConverted) of storage") {
                     viewModel.showRedeemNotif = false
                 }
                 .transition(.asymmetric(insertion: .move(edge: .bottom), removal: .opacity))
@@ -69,7 +69,7 @@ struct StorageView: View {
                 .padding(.horizontal)
             }
             VStack {
-                GradientProgressBarView(value: $viewModel.spaceUsedReadable, maxValue: $viewModel.spaceTotalReadable, sizeRatio: $viewModel.spaceRatio)
+                GradientProgressBarView(value: viewModel.spaceUsedReadable, maxValue: viewModel.spaceTotalReadable, sizeRatio: viewModel.spaceRatio)
                 Button {
                     viewModel.addStorageIsPresented = true
                 } label: {


### PR DESCRIPTION
[Implemented remarks from the demo :
 - Removed "free" and "complimentary" from redeem screen
 - Round the amount of storage added by one decimal point(in GB)
Resolved a bug where the storage progress bar view would not update after a successful redeem code was added.
Also changed the path for the deep link to correspond with the real one.