### PR TITLE
VSP-1387[iOS]Archive profile photo and banner can't be changed

### DIFF
--- a/Permanent/Modules/PublicProfile/ViewController/PublicArchiveViewController.swift
+++ b/Permanent/Modules/PublicProfile/ViewController/PublicArchiveViewController.swift
@@ -235,6 +235,14 @@ extension PublicArchiveViewController: MyFilesViewModelPickerDelegate {
                         self.dismiss(animated: true, completion: {
                             if status == .success, let thumbURL = URL(string: file.thumbnailURL2000) {
                                 self.profilePhotoImageView.sd_setImage(with: thumbURL)
+                                AuthenticationManager.shared.syncSession { [weak self] status in
+                                    switch status {
+                                    case .success:
+                                        self?.profilePhotoImageView.sd_setImage(with: thumbURL)
+                                    case .error(message: _):
+                                        self?.showErrorAlert(message: .errorMessage)
+                                    }
+                                }
                             } else {
                                 self.showErrorAlert(message: .errorMessage)
                             }


### PR DESCRIPTION
Resolved another bug, where the changed archive thumbnail didn't change in the left and right menus only after a logout