### PR TITLE
VSP-1387[IOS] Archive profile photo and banner can't be changed

### DIFF
--- a/Permanent/Common/Files/ViewModel/MyFilesViewModel.swift
+++ b/Permanent/Common/Files/ViewModel/MyFilesViewModel.swift
@@ -14,7 +14,6 @@ protocol MyFilesViewModelPickerDelegate: AnyObject {
 class MyFilesViewModel: FilesViewModel {
     static let didSelectFilesNotifName = NSNotification.Name("MyFilesViewModel.didSelectFilesNotifName")
     var isPickingImage: Bool = false
-    var isPickingProfilePicture: Bool = false
     weak var pickerDelegate: MyFilesViewModelPickerDelegate?
     
     override var currentFolderIsRoot: Bool { navigationStack.count == 1 }

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -167,7 +167,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         overlayView.backgroundColor = .overlay
         overlayView.alpha = 0
         
-        fabView.isHidden = viewModel!.archivePermissions.contains(.create) == false || viewModel!.archivePermissions.contains(.upload) == false || viewModel!.isPickingImage || viewModel!.isPickingProfilePicture
+        fabView.isHidden = viewModel!.archivePermissions.contains(.create) == false || viewModel!.archivePermissions.contains(.upload) == false || viewModel!.isPickingImage
     }
     
     fileprivate func setupCollectionView() {
@@ -888,7 +888,7 @@ extension MainViewController: UICollectionViewDelegateFlowLayout, UICollectionVi
             
             let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: FileCollectionViewHeaderCell.identifier, for: indexPath) as! FileCollectionViewHeaderCell
             headerView.leftButtonTitle = viewModel?.title(forSection: section)
-            headerView.configure(with: viewModel, isPickingProfilePicture: viewModel!.isPickingProfilePicture)
+            headerView.configure(with: viewModel, isPickingProfilePicture: viewModel!.isPickingImage)
             if viewModel?.shouldPerformAction(forSection: section) == true {
                 headerView.leftButtonAction = { [weak self] header in self?.headerButtonAction(UIButton()) }
             } else {

--- a/Permanent/Modules/PublicProfile/ViewController/PublicArchiveViewController.swift
+++ b/Permanent/Modules/PublicProfile/ViewController/PublicArchiveViewController.swift
@@ -178,7 +178,7 @@ class PublicArchiveViewController: BaseViewController<PublicProfilePicturesViewM
         
         let myFilesVC = UIViewController.create(withIdentifier: .main, from: .main) as! MainViewController
         let myFilesVM = MyFilesViewModel()
-        myFilesVM.isPickingProfilePicture = true
+        myFilesVM.isPickingImage = true
         myFilesVM.pickerDelegate = self
         myFilesVC.viewModel = myFilesVM
         
@@ -192,7 +192,7 @@ class PublicArchiveViewController: BaseViewController<PublicProfilePicturesViewM
         
         let myFilesVC = UIViewController.create(withIdentifier: .main, from: .main) as! MainViewController
         let myFilesVM = MyFilesViewModel()
-        myFilesVM.isPickingProfilePicture = true
+        myFilesVM.isPickingImage = true
         myFilesVM.pickerDelegate = self
         myFilesVC.viewModel = myFilesVM
         


### PR DESCRIPTION
Resolved another bug where you can't select a photo for a thumbnail, only view the file.