### PR TITLE
VSP-1411 [IOS] Clicking on the View in archive from the Share Preview crashes the app

### DIFF
--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -1236,7 +1236,14 @@ extension SharesViewController {
             return
         }
         
+        guard index >= 0 && index < collectionView.numberOfItems(inSection: 0) else {
+            // Handle the case where the index is out of bounds
+            print("Index out of bounds")
+            return
+        }
+        
         let indexPath = IndexPath(row: index, section: 0)
+        
         collectionView.selectItem(at: indexPath, animated: true, scrollPosition: [])
     }
 }

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -1238,7 +1238,6 @@ extension SharesViewController {
         
         guard index >= 0 && index < collectionView.numberOfItems(inSection: 0) else {
             // Handle the case where the index is out of bounds
-            print("Index out of bounds")
             return
         }
         


### PR DESCRIPTION
Resolved an issue where the app tries to scroll to a null position in the collection view.