### PR TITLE
VSP-1485 [iOS] [Mobile] 2FA - Add Email - Send Code

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		5E1CCC27287F055F00913EEA /* UIImageExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCE3C96325388C8D00EC3A66 /* UIImageExtension.swift */; };
 		5E1CCC28287F056C00913EEA /* UIButtonExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC6D3B4425138DFF00390927 /* UIButtonExtension.swift */; };
 		5E1CCC29287F133000913EEA /* ActionDialogView.xib in Resources */ = {isa = PBXBuildFile; fileRef = BCC1E32B254A193C00B71866 /* ActionDialogView.xib */; };
+		5E1DAFFB2D4D023100E13347 /* CustomEmailFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1DAFFA2D4D022B00E13347 /* CustomEmailFieldView.swift */; };
 		5E1DE53C27E1245000FBD7FA /* UpdateNecessaryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1DE53B27E1245000FBD7FA /* UpdateNecessaryViewController.swift */; };
 		5E1E4FA92988897F0062984C /* ManageTagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1E4FA82988897F0062984C /* ManageTagsTests.swift */; };
 		5E202E062981FD660063DDED /* ArchiveSettingsTagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E202E042981FD660063DDED /* ArchiveSettingsTagCollectionViewCell.swift */; };
@@ -326,6 +327,7 @@
 		5E9C8E912CC2A9F8004C058F /* RegisterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9C8E902CC2A9ED004C058F /* RegisterViewModel.swift */; };
 		5E9C8E932CC63D74004C058F /* CustomRegisterFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9C8E922CC63D60004C058F /* CustomRegisterFormView.swift */; };
 		5E9E73D52BA9BB5B007B3EC0 /* GradientArchiveButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9E73D42BA9BB5B007B3EC0 /* GradientArchiveButtonView.swift */; };
+		5E9F5CEF2D53591600F6213E /* CustomPhoneFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9F5CEE2D53591600F6213E /* CustomPhoneFieldView.swift */; };
 		5EA03CA527832D0300CE0320 /* BasicProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA03CA427832D0200CE0320 /* BasicProfileItem.swift */; };
 		5EA04CE826AEE14A00BC00FB /* SignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA04CE726AEE14A00BC00FB /* SignUpTests.swift */; };
 		5EA5B3DA2A71026500C39217 /* BottomButtonsSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA5B3D92A71026500C39217 /* BottomButtonsSectionView.swift */; };
@@ -1066,6 +1068,7 @@
 		5E1C546029B8CA0C00A04B99 /* FileCollectionViewHeaderCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FileCollectionViewHeaderCell.xib; sourceTree = "<group>"; };
 		5E1CCC17287EE4B800913EEA /* ShareExtensionNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShareExtensionNavigationController.swift; sourceTree = "<group>"; };
 		5E1CCC18287EE4B800913EEA /* ShareExtensionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShareExtensionViewModel.swift; sourceTree = "<group>"; };
+		5E1DAFFA2D4D022B00E13347 /* CustomEmailFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEmailFieldView.swift; sourceTree = "<group>"; };
 		5E1DE53B27E1245000FBD7FA /* UpdateNecessaryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateNecessaryViewController.swift; sourceTree = "<group>"; };
 		5E1E4FA82988897F0062984C /* ManageTagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageTagsTests.swift; sourceTree = "<group>"; };
 		5E202E042981FD660063DDED /* ArchiveSettingsTagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveSettingsTagCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -1244,6 +1247,7 @@
 		5E9C8E902CC2A9ED004C058F /* RegisterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterViewModel.swift; sourceTree = "<group>"; };
 		5E9C8E922CC63D60004C058F /* CustomRegisterFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRegisterFormView.swift; sourceTree = "<group>"; };
 		5E9E73D42BA9BB5B007B3EC0 /* GradientArchiveButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientArchiveButtonView.swift; sourceTree = "<group>"; };
+		5E9F5CEE2D53591600F6213E /* CustomPhoneFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPhoneFieldView.swift; sourceTree = "<group>"; };
 		5EA03CA427832D0200CE0320 /* BasicProfileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicProfileItem.swift; sourceTree = "<group>"; };
 		5EA04CE726AEE14A00BC00FB /* SignUpTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpTests.swift; sourceTree = "<group>"; };
 		5EA5B3D92A71026500C39217 /* BottomButtonsSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonsSectionView.swift; sourceTree = "<group>"; };
@@ -2106,6 +2110,8 @@
 				5EF300352D4AC007001FFEE7 /* TwoStepChooseEmailView.swift */,
 				5EF3003B2D4AC772001FFEE7 /* TwoStepChoosePhoneView.swift */,
 				5E3CEA9C2D14A0150029353E /* CustomPasswordFieldView.swift */,
+				5E1DAFFA2D4D022B00E13347 /* CustomEmailFieldView.swift */,
+				5E9F5CEE2D53591600F6213E /* CustomPhoneFieldView.swift */,
 				5E865D042D3FCF41005B41B7 /* TwoStepBottomNotificationView.swift */,
 			);
 			path = Views;
@@ -4791,6 +4797,7 @@
 				BC3DF865252DDCCC003D3829 /* BiometricsViewController.swift in Sources */,
 				5E991EE72A4AE144006229C0 /* CustomNavigationView.swift in Sources */,
 				F51B331E288AF57900EA15DA /* SessionKeychainHandler.swift in Sources */,
+				5E1DAFFB2D4D023100E13347 /* CustomEmailFieldView.swift in Sources */,
 				5E626CA72A1D6BB400EA9981 /* StewardDetails.swift in Sources */,
 				5EB3EDBF2B04D18600D76B83 /* ResponseGiftingModel.swift in Sources */,
 				5E3ACA532C22EF720031A2A0 /* ArchiveDetailsView.swift in Sources */,
@@ -4928,6 +4935,7 @@
 				F52D2B84292D44D60008D047 /* ShareManagementSharedWithCollectionViewCell.swift in Sources */,
 				F57CE596282BE9D000B06D95 /* DonateViewModel.swift in Sources */,
 				5E7141452AFD25D5003952CD /* GiftingModel.swift in Sources */,
+				5E9F5CEF2D53591600F6213E /* CustomPhoneFieldView.swift in Sources */,
 				BC59BABA25C2B7D6005A45D3 /* ShareDetailsVM.swift in Sources */,
 				F56AA040261F1B930054B6EF /* DeviceEndpoint.swift in Sources */,
 				92430A5E2AF2A1F00098597D /* EmailChipsTextField.swift in Sources */,

--- a/Permanent/Common/Extensions/StringExtension.swift
+++ b/Permanent/Common/Extensions/StringExtension.swift
@@ -41,4 +41,9 @@ extension String {
         let phoneRegex = "^[0-9+]{0,1}+[0-9]{5,16}$"
         return NSPredicate(format: "SELF MATCHES %@", phoneRegex).evaluate(with: self)
     }
+    
+    var isUSPhoneNumber: Bool {
+        let usPhoneRegex = "^\\(?([0-9]{3})\\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$"
+        return NSPredicate(format: "SELF MATCHES %@", usPhoneRegex).evaluate(with: self)
+    }
 }

--- a/Permanent/Common/Models/Enums/AuthBannerMessage.swift
+++ b/Permanent/Common/Models/Enums/AuthBannerMessage.swift
@@ -8,13 +8,17 @@ enum AuthBannerMessage {
     case invalidData
     case invalidCredentials
     case invalidPassword
+    case invalidEmail
+    case invalidPhoneNumber
     case emptyPinCode
     case invalidPinCode
     case resentCodeError
     case codeExpiredError
     case successResendCode
+    case successCodeSend
     case successPasswordConfirmed
     case error
+    case generalError
     case none
     
     var text: String {
@@ -25,6 +29,10 @@ enum AuthBannerMessage {
             return "Incorrect email or password."
         case .invalidPassword:
             return "Incorrect password."
+        case .invalidEmail:
+            return "Incorrect email."
+        case .invalidPhoneNumber:
+            return "Incorrect phone number."
         case .emptyPinCode:
             return "The 4-digit code is incorrect."
         case .invalidPinCode:
@@ -33,12 +41,16 @@ enum AuthBannerMessage {
             return "Resent code error"
         case .codeExpiredError:
             return "The code expired."
+        case .successCodeSend:
+            return "The code was sent."
         case .successResendCode:
             return "The code was resent."
         case .successPasswordConfirmed:
             return "Password confirmed"
         case .error:
             return .errorMessage
+        case .generalError:
+            return "Something went wrong."
         case .none:
             return ""
         }

--- a/Permanent/Common/Network/AuthenticationEndpoint.swift
+++ b/Permanent/Common/Network/AuthenticationEndpoint.swift
@@ -16,6 +16,8 @@ enum CodeVerificationType: String {
 // TODO: See if this type is appropiate.
 typealias VerifyCodeCredentials = (email: String, code: String, type: CodeVerificationType)
 typealias CreateCredentials = (name: String, password: String, email: String, phone: String?)
+typealias Send2FAEnableCodeParameters = (method: String, value: String)
+typealias Enable2FAParameters = (method: String, value: String, code: String)
 
 enum AuthenticationEndpoint {
     /// Verifies if user is authenticated.
@@ -30,7 +32,12 @@ enum AuthenticationEndpoint {
     case createCredentials(credentials: CreateCredentials)
     /// Logs out the user.
     case logout
+    /// Gets user two factor authentication methods
     case getIDPUser
+    /// Send code for enable 2FA
+    case send2FAEnableCode(parameters: Send2FAEnableCodeParameters)
+    /// Enable 2FA
+    case enable2FA(parameters: Enable2FAParameters)
 }
 
 extension AuthenticationEndpoint: RequestProtocol {
@@ -46,7 +53,10 @@ extension AuthenticationEndpoint: RequestProtocol {
             return createCredentialsPayload(for: credentials)
         case .verifyAuth:
             return verifyAuth()
-
+//        case .send2FAEnableCode(let parameters):
+//            return send2FAEnableCode(using: parameters)
+//        case .enable2FA(let parameters):
+//            return enable2FA(using: parameters)
         default:
             return nil
         }
@@ -76,6 +86,10 @@ extension AuthenticationEndpoint: RequestProtocol {
             return "/auth/createCredentials"
         case .logout:
             return "/auth/logout"
+        case .send2FAEnableCode:
+            return ""
+        case .enable2FA:
+            return ""
         }
     }
 
@@ -94,13 +108,26 @@ extension AuthenticationEndpoint: RequestProtocol {
         set {}
     }
     
-    var bodyData: Data? { nil }
+    var bodyData: Data? {
+        switch self {
+        case .send2FAEnableCode(let parameters):
+            return try? JSONEncoder().encode(["method": parameters.method, "value": parameters.value])
+        case .enable2FA(let parameters):
+            return try? JSONEncoder().encode(["method": parameters.method, "value": parameters.value, "code": parameters.code])
+        default:
+            return nil
+        }
+    }
     
     var customURL: String? {
         let endpointPath = APIEnvironment.defaultEnv.apiServer
         switch self {
         case .getIDPUser:
             return "\(endpointPath)api/v2/idpuser"
+        case .send2FAEnableCode:
+            return "\(endpointPath)api/v2/idpuser/send-enable-code"
+        case .enable2FA:
+            return "\(endpointPath)api/v2/idpuser/enable-two-factor"
         default:
             return nil
         }
@@ -184,6 +211,26 @@ extension AuthenticationEndpoint {
     }
     
     func verifyAuth() -> RequestParameters {
+        return [
+            "RequestVO": [
+                "data": [
+                    [:]
+                ]
+            ]
+        ]
+    }
+    
+    func send2FAEnableCode(using parameters: Send2FAEnableCodeParameters) -> RequestParameters {
+        return [
+            "RequestVO": [
+                "data": [
+                    [:]
+                ]
+            ]
+        ]
+    }
+    
+    func enable2FA(using parameters: Enable2FAParameters) -> RequestParameters {
         return [
             "RequestVO": [
                 "data": [

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 class TwoStepChooseEmailViewModel: ObservableObject {
     var containerViewModel: TwoStepConfirmationContainerViewModel
+    @Published var textFieldEmail: String = ""
+    @Published var isLoading: Bool = false
     
     init(containerViewModel: TwoStepConfirmationContainerViewModel) {
         self.containerViewModel = containerViewModel

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
@@ -10,8 +10,84 @@ class TwoStepChooseEmailViewModel: ObservableObject {
     var containerViewModel: TwoStepConfirmationContainerViewModel
     @Published var textFieldEmail: String = ""
     @Published var isLoading: Bool = false
+    @Published var emailAlreadyConfirmed: Bool = false
+    @Published var remainingTime: Int = 0
+    @Published var canResend: Bool = true
+    @Published private(set) var sendCodeButtonTitle: String = "Send Code"
+    
+    private var timer: Timer?
     
     init(containerViewModel: TwoStepConfirmationContainerViewModel) {
         self.containerViewModel = containerViewModel
+    }
+    
+    func sendTwoFactorEnableCode() {
+        isLoading = true
+        withAnimation {
+            containerViewModel.showErrorBanner = false
+        }
+        
+        let send2FAParameters: Send2FAEnableCodeParameters = (method: "email", value: textFieldEmail)
+        
+        let send2FAEnableCodeOperation = APIOperation(AuthenticationEndpoint.send2FAEnableCode(parameters: send2FAParameters))
+        send2FAEnableCodeOperation.execute(in: APIRequestDispatcher()) { [weak self] result in
+            self?.isLoading = false
+            
+            switch result {
+            case .json(let response, _):
+                self?.containerViewModel.displayBannerWithAutoClose(.successCodeSend)
+                self?.startResendTimer()
+                self?.emailAlreadyConfirmed = true
+            case .error(let error, _):
+                if let apiError = error as? APIError, apiError == .badRequest {
+                    self?.containerViewModel.displayBanner(bannerErrorMessage: .invalidEmail)
+                } else {
+                    self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
+                }
+            default:
+                self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
+            }
+        }
+    }
+    
+    private func updateButtonTitle() {
+        if canResend {
+            sendCodeButtonTitle = "Send Code"
+        } else {
+            if remainingTime == 0 {
+                sendCodeButtonTitle = "Send Code"
+            } else {
+                let minutes = remainingTime / 60
+                let seconds = remainingTime % 60
+                sendCodeButtonTitle = String(format: "Resend (%02d:%02d)", minutes, seconds)
+            }
+        }
+    }
+    
+    private func startResendTimer() {
+        canResend = false
+        remainingTime = 60
+        updateButtonTitle()
+        
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] timer in
+            guard let self = self else {
+                timer.invalidate()
+                return
+            }
+            
+            if self.remainingTime > 0 {
+                self.remainingTime -= 1
+                self.updateButtonTitle()
+            } else {
+                self.canResend = true
+                self.updateButtonTitle()
+                timer.invalidate()
+            }
+        }
+    }
+    
+    deinit {
+        timer?.invalidate()
     }
 }

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChoosePhoneViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChoosePhoneViewModel.swift
@@ -8,8 +8,15 @@ import SwiftUI
 
 class TwoStepChoosePhoneViewModel: ObservableObject {
     var containerViewModel: TwoStepConfirmationContainerViewModel
+    @Published var formattedPhone: String = ""
+    @Published var rawPhone: String = ""
+    @Published var isLoading: Bool = false
     
     init(containerViewModel: TwoStepConfirmationContainerViewModel) {
         self.containerViewModel = containerViewModel
+    }
+    
+    func attemptSendCode() {
+        let requestPhoneNumber = formattedPhone.replacingOccurrences(of: "+1 ", with: "")
     }
 }

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChoosePhoneViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChoosePhoneViewModel.swift
@@ -11,12 +11,85 @@ class TwoStepChoosePhoneViewModel: ObservableObject {
     @Published var formattedPhone: String = ""
     @Published var rawPhone: String = ""
     @Published var isLoading: Bool = false
+    @Published var phoneAlreadyConfirmed: Bool = false
+    @Published var remainingTime: Int = 0
+    @Published var canResend: Bool = true
+    @Published private(set) var sendCodeButtonTitle: String = "Send Code"
+    
+    private var timer: Timer?
     
     init(containerViewModel: TwoStepConfirmationContainerViewModel) {
         self.containerViewModel = containerViewModel
     }
     
-    func attemptSendCode() {
-        let requestPhoneNumber = formattedPhone.replacingOccurrences(of: "+1 ", with: "")
+    func sendTwoFactorEnableCode() {
+        isLoading = true
+        let phoneNumberForRequest = formattedPhone.replacingOccurrences(of: "+1 ", with: "")
+        withAnimation {
+            containerViewModel.showErrorBanner = false
+        }
+        
+        let send2FAParameters: Send2FAEnableCodeParameters = (method: "sms", value: phoneNumberForRequest)
+        
+        let send2FAEnableCodeOperation = APIOperation(AuthenticationEndpoint.send2FAEnableCode(parameters: send2FAParameters))
+        send2FAEnableCodeOperation.execute(in: APIRequestDispatcher()) { [weak self] result in
+            self?.isLoading = false
+            
+            switch result {
+            case .json(let response, _):
+                self?.containerViewModel.displayBannerWithAutoClose(.successCodeSend)
+                self?.startResendTimer()
+                self?.phoneAlreadyConfirmed = true
+            case .error(let error, _):
+                if let apiError = error as? APIError, apiError == .badRequest {
+                    self?.containerViewModel.displayBanner(bannerErrorMessage: .invalidPhoneNumber)
+                } else {
+                    self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
+                }
+            default:
+                self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
+            }
+        }
+    }
+    
+    private func updateButtonTitle() {
+        if canResend {
+            sendCodeButtonTitle = "Send Code"
+        } else {
+            if remainingTime == 0 {
+                sendCodeButtonTitle = "Send Code"
+            } else {
+                let minutes = remainingTime / 60
+                let seconds = remainingTime % 60
+                sendCodeButtonTitle = String(format: "Resend (%02d:%02d)", minutes, seconds)
+            }
+        }
+    }
+    
+    private func startResendTimer() {
+        canResend = false
+        remainingTime = 60
+        updateButtonTitle()
+        
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] timer in
+            guard let self = self else {
+                timer.invalidate()
+                return
+            }
+            
+            if self.remainingTime > 0 {
+                self.remainingTime -= 1
+                self.updateButtonTitle()
+            } else {
+                self.canResend = true
+                self.updateButtonTitle()
+                timer.invalidate()
+            }
+        }
+    }
+    
+    deinit {
+        timer?.invalidate()
     }
 }

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmPasswordViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmPasswordViewModel.swift
@@ -20,7 +20,7 @@ class TwoStepConfirmPasswordViewModel: ObservableObject {
     func attemptLogin() {
         containerViewModel.showErrorBanner = false
         if !areFieldsValid(emailField: AuthenticationManager.shared.session?.account.primaryEmail, passwordField: textFieldPassword) {
-            containerViewModel.displayErrorBanner(bannerErrorMessage: .invalidPassword)
+            containerViewModel.displayBanner(bannerErrorMessage: .invalidPassword)
             return
         }
         
@@ -31,9 +31,9 @@ class TwoStepConfirmPasswordViewModel: ObservableObject {
             case .success:
                 self?.containerViewModel.setContentType(.chooseVerification)
             case .error(message: _):
-                self?.containerViewModel.displayErrorBanner(bannerErrorMessage: .error)
+                self?.containerViewModel.displayBanner(bannerErrorMessage: .error)
             case .unknown:
-                self?.containerViewModel.displayErrorBanner(bannerErrorMessage: .invalidPassword)
+                self?.containerViewModel.displayBanner(bannerErrorMessage: .invalidPassword)
             default:
                 break
             }

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmationContainerViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmationContainerViewModel.swift
@@ -7,42 +7,6 @@
 import Foundation
 import SwiftUI
 
-class TwoStepConfirmationContainerViewModel: ObservableObject {
-    @Published var phoneNumber: String = ""
-    @Published var isLoading: Bool = false
-    @Published var showErrorBanner: Bool = false
-    @Published var bannerErrorMessage: AuthBannerMessage = .none
-    @Published var showAddVerificationMethod: Bool = false
-    @Published var contentType: TwoStepConfirmationContentType = .confirmPassword
-    @Published var insertionViewTransition: AnyTransition = .opacity
-    
-    func displayErrorBanner(bannerErrorMessage: AuthBannerMessage) {
-        if showErrorBanner {
-            withAnimation {
-                showErrorBanner = false
-            }
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                self.bannerErrorMessage = bannerErrorMessage
-                withAnimation {
-                    self.showErrorBanner = true
-                }
-            }
-        } else {
-            self.bannerErrorMessage = bannerErrorMessage
-            withAnimation {
-                showErrorBanner = true
-            }
-        }
-    }
-    
-    func setContentType(_ newContentType: TwoStepConfirmationContentType) {
-        withAnimation {
-            contentType = newContentType
-        }
-    }
-}
-
 enum TwoStepConfirmationContentType {
     case confirmPassword
     case chooseVerification
@@ -67,6 +31,52 @@ enum TwoStepConfirmationContentType {
             case .none:
                 return ""
             }
+        }
+    }
+}
+
+class TwoStepConfirmationContainerViewModel: ObservableObject {
+    @Published var phoneNumber: String = ""
+    @Published var isLoading: Bool = false
+    @Published var showErrorBanner: Bool = false
+    @Published var bannerErrorMessage: AuthBannerMessage = .none
+    @Published var showAddVerificationMethod: Bool = false
+    @Published var contentType: TwoStepConfirmationContentType = .confirmPassword
+    @Published var insertionViewTransition: AnyTransition = .opacity
+    
+    func displayBanner(bannerErrorMessage: AuthBannerMessage) {
+        if showErrorBanner {
+            withAnimation {
+                showErrorBanner = false
+            }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                self.bannerErrorMessage = bannerErrorMessage
+                withAnimation {
+                    self.showErrorBanner = true
+                }
+            }
+        } else {
+            self.bannerErrorMessage = bannerErrorMessage
+            withAnimation {
+                showErrorBanner = true
+            }
+        }
+    }
+    
+    func displayBannerWithAutoClose(_ bannerErrorMessage: AuthBannerMessage) {
+        displayBanner(bannerErrorMessage: bannerErrorMessage)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+            withAnimation {
+                self?.showErrorBanner = false
+            }
+        }
+    }
+    
+    func setContentType(_ newContentType: TwoStepConfirmationContentType) {
+        withAnimation {
+            contentType = newContentType
         }
     }
 }

--- a/Permanent/Modules/AccountSecurity/Views/CustomEmailFieldView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/CustomEmailFieldView.swift
@@ -1,0 +1,43 @@
+//
+//  CustomEmailFieldView.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 31.01.2025.
+
+import SwiftUI
+
+enum EmailFocusField: Hashable {
+    case isFocused
+}
+
+struct CustomEmailFieldView: View {
+    @Binding var email: String
+    
+    var onSubmit: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            TextField("", text: $email, prompt: Text(verbatim: "example@email.com").foregroundColor(.blue200))
+                .font(.custom("Usual-Regular", size: 14))
+                .foregroundColor(.blue900)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 0)
+                .frame(height: 56, alignment: .leading)
+                .background(.white.opacity(0.04))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .textContentType(.emailAddress)
+                .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .inset(by: 0.5)
+                        .stroke(Color.blue100, lineWidth: 1)
+                )
+                .submitLabel(.done)
+                .onSubmit {
+                    onSubmit()
+                }
+                .clipShape(.rect(cornerRadius: 4))
+        }
+    }
+}

--- a/Permanent/Modules/AccountSecurity/Views/CustomPhoneFieldView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/CustomPhoneFieldView.swift
@@ -1,0 +1,70 @@
+//
+//  CustomPhoneFieldView.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 05.02.2025.
+
+
+struct CustomPhoneFieldView: View {
+    @Binding var phone: String
+    @Binding var rawPhoneNumber: String
+    
+    var onSubmit: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            TextField("", text: $phone, prompt: Text(verbatim: "+1 (123) 456 – 7890").foregroundColor(.blue200))
+                .keyboardType(.numberPad)
+                .onChange(of: phone) { newValue in
+                    // Remove any non-numeric characters and +1 prefix
+                    let filtered = newValue.replacingOccurrences(of: "+1 ", with: "")
+                        .replacingOccurrences(of: "(", with: "")
+                        .replacingOccurrences(of: ")", with: "")
+                        .replacingOccurrences(of: " ", with: "")
+                        .replacingOccurrences(of: "–", with: "")
+                        .filter { "0123456789".contains($0) }
+
+                    let truncated = String(filtered.prefix(10))
+                    
+                    rawPhoneNumber = truncated
+                    
+                    var formatted = truncated
+                    
+                    if formatted.count > 6 {
+                        formatted.insert(contentsOf: " – ", at: formatted.index(formatted.startIndex, offsetBy: 6))
+                    }
+                    if formatted.count > 3 {
+                        formatted.insert(contentsOf: ") ", at: formatted.index(formatted.startIndex, offsetBy: 3))
+                    }
+                    if formatted.count > 0 {
+                        formatted.insert("(", at: formatted.startIndex)
+                        formatted = "+1 " + formatted
+                    }
+
+                    if formatted != phone {
+                        phone = formatted
+                    }
+                }
+                .font(.custom("Usual-Regular", size: 14))
+                .foregroundColor(.blue900)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 0)
+                .frame(height: 56, alignment: .leading)
+                .background(.white.opacity(0.04))
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
+                .textContentType(.emailAddress)
+                .cornerRadius(12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .inset(by: 0.5)
+                        .stroke(Color.blue100, lineWidth: 1)
+                )
+                .submitLabel(.done)
+                .onSubmit {
+                    onSubmit()
+                }
+                .clipShape(.rect(cornerRadius: 4))
+        }
+    }
+}

--- a/Permanent/Modules/AccountSecurity/Views/CustomPhoneFieldView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/CustomPhoneFieldView.swift
@@ -3,7 +3,7 @@
 //  Permanent
 //
 //  Created by Lucian Cerbu on 05.02.2025.
-
+import SwiftUI
 
 struct CustomPhoneFieldView: View {
     @Binding var phone: String

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepBottomNotificationView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepBottomNotificationView.swift
@@ -10,7 +10,7 @@ struct TwoStepBottomNotificationView: View {
     let message: AuthBannerMessage
     @Binding var isVisible: Bool
     var isError: Bool {
-        if message == .successResendCode || message == .successPasswordConfirmed {
+        if message == .successResendCode || message == .successPasswordConfirmed || message == .successCodeSend {
             return false
         }
         return true

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
@@ -37,7 +37,6 @@ struct TwoStepChooseEmailView: View {
             .frame(maxWidth: .infinity)
             .padding(32)
         }
-        //.navigationBarTitle("Confirm your password", displayMode: .inline)
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
@@ -10,15 +10,34 @@ struct TwoStepChooseEmailView: View {
     @StateObject var viewModel: TwoStepChooseEmailViewModel
     
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            HStack {
-                Text("Choose Email")
-                    .frame(maxWidth: .infinity, alignment: .center)
+        ZStack(alignment: .top) {
+            VStack(spacing: 32) {
+                Text("Enter your email address and click the button to send a one-time use code.")
+                .font(
+                    .custom(
+                        "Usual-Regular",
+                        fixedSize: 14)
+                )
+                .multilineTextAlignment(.leading)
+                .lineSpacing(5)
+                .foregroundColor(.blue700)
+                VStack(spacing: 16) {
+                    CustomEmailFieldView(email: $viewModel.textFieldEmail) {
+                       // viewModel.attemptLogin()
+                    }
+                    RoundButtonUsualFontView(isDisabled: !viewModel.textFieldEmail.isValidEmail || viewModel.isLoading, isLoading: viewModel.isLoading, text: "Send code") {
+                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                        //viewModel.attemptLogin()
+                    }
+                }
+                Spacer()
             }
-            .padding()
-            Spacer()
+            .frame(maxWidth: .infinity)
+            .padding(32)
         }
-        .padding()
+        .navigationBarTitle("Confirm your password", displayMode: .inline)
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
     }
 }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
@@ -23,11 +23,13 @@ struct TwoStepChooseEmailView: View {
                 .foregroundColor(.blue700)
                 VStack(spacing: 16) {
                     CustomEmailFieldView(email: $viewModel.textFieldEmail) {
-                       // viewModel.attemptLogin()
+                        viewModel.sendTwoFactorEnableCode()
                     }
-                    RoundButtonUsualFontView(isDisabled: !viewModel.textFieldEmail.isValidEmail || viewModel.isLoading, isLoading: viewModel.isLoading, text: "Send code") {
+                    .disabled(viewModel.emailAlreadyConfirmed)
+                    .opacity(viewModel.emailAlreadyConfirmed ? 0.5 : 1)
+                    RoundButtonUsualFontView(isDisabled: !viewModel.textFieldEmail.isValidEmail || viewModel.isLoading || viewModel.remainingTime > 0, isLoading: viewModel.isLoading, text: viewModel.sendCodeButtonTitle) {
                         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                        //viewModel.attemptLogin()
+                        viewModel.sendTwoFactorEnableCode()
                     }
                 }
                 Spacer()
@@ -35,9 +37,13 @@ struct TwoStepChooseEmailView: View {
             .frame(maxWidth: .infinity)
             .padding(32)
         }
-        .navigationBarTitle("Confirm your password", displayMode: .inline)
+        //.navigationBarTitle("Confirm your password", displayMode: .inline)
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
     }
+}
+
+#Preview {
+    TwoStepChooseEmailView(viewModel: TwoStepChooseEmailViewModel(containerViewModel: TwoStepConfirmationContainerViewModel()))
 }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
@@ -12,7 +12,12 @@ struct TwoStepChoosePhoneView: View {
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 32) {
-                Text("Enter your phone number and click the button to send a one-time use code. At this time, we can only accept North American cell phone numbers for SMS.")
+                HStack {
+                    Text("Enter your phone number and click the button to send a one-time use code. At this time, we can only accept ") +
+                    Text("North American")
+                        .bold() +
+                    Text(" cell phone numbers for SMS.")
+                }
                 .font(
                     .custom(
                         "Usual-Regular",
@@ -37,7 +42,6 @@ struct TwoStepChoosePhoneView: View {
             .frame(maxWidth: .infinity)
             .padding(32)
         }
-        //.navigationBarTitle("Confirm your password", displayMode: .inline)
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
@@ -10,15 +10,34 @@ struct TwoStepChoosePhoneView: View {
     @StateObject var viewModel: TwoStepChoosePhoneViewModel
     
     var body: some View {
-        VStack(spacing: 0) {
-            Spacer()
-            HStack {
-                Text("Choose Phone number")
-                    .frame(maxWidth: .infinity, alignment: .center)
+        ZStack(alignment: .top) {
+            VStack(spacing: 32) {
+                Text("Enter your phone number and click the button to send a one-time use code. At this time, we can only accept North American cell phone numbers for SMS.")
+                .font(
+                    .custom(
+                        "Usual-Regular",
+                        fixedSize: 14)
+                )
+                .multilineTextAlignment(.leading)
+                .lineSpacing(5)
+                .foregroundColor(.blue700)
+                VStack(spacing: 16) {
+                    CustomPhoneFieldView(phone: $viewModel.formattedPhone, rawPhoneNumber: $viewModel.rawPhone) {
+                       viewModel.attemptSendCode()
+                    }
+                    RoundButtonUsualFontView(isDisabled: !viewModel.rawPhone.isUSPhoneNumber || viewModel.isLoading, isLoading: viewModel.isLoading, text: "Send code") {
+                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                        viewModel.attemptSendCode()
+                    }
+                }
+                Spacer()
             }
-            .padding()
-            Spacer()
+            .frame(maxWidth: .infinity)
+            .padding(32)
         }
-        .padding()
+        .navigationBarTitle("Confirm your password", displayMode: .inline)
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
     }
 }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
@@ -23,11 +23,13 @@ struct TwoStepChoosePhoneView: View {
                 .foregroundColor(.blue700)
                 VStack(spacing: 16) {
                     CustomPhoneFieldView(phone: $viewModel.formattedPhone, rawPhoneNumber: $viewModel.rawPhone) {
-                       viewModel.attemptSendCode()
+                       viewModel.sendTwoFactorEnableCode()
                     }
-                    RoundButtonUsualFontView(isDisabled: !viewModel.rawPhone.isUSPhoneNumber || viewModel.isLoading, isLoading: viewModel.isLoading, text: "Send code") {
+                    .disabled(viewModel.phoneAlreadyConfirmed)
+                    .opacity(viewModel.phoneAlreadyConfirmed ? 0.5 : 1)
+                    RoundButtonUsualFontView(isDisabled: !viewModel.rawPhone.isUSPhoneNumber || viewModel.isLoading || viewModel.remainingTime > 0, isLoading: viewModel.isLoading, text: viewModel.sendCodeButtonTitle) {
                         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                        viewModel.attemptSendCode()
+                        viewModel.sendTwoFactorEnableCode()
                     }
                 }
                 Spacer()
@@ -35,7 +37,7 @@ struct TwoStepChoosePhoneView: View {
             .frame(maxWidth: .infinity)
             .padding(32)
         }
-        .navigationBarTitle("Confirm your password", displayMode: .inline)
+        //.navigationBarTitle("Confirm your password", displayMode: .inline)
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }

--- a/PermanentTests/AuthenticationManagerTests.swift
+++ b/PermanentTests/AuthenticationManagerTests.swift
@@ -183,7 +183,7 @@ class AuthenticationManagerTests: XCTestCase {
         
         authManager = AuthenticationManager(authRepo: mockAuthRepo, accountRepository: mockAccountRepo)
 
-        let credentials = SignUpCredentials(name: "Test User", loginCredentials: (email: "test@example.com", password: "test1234"))
+        let credentials = SignUpV2Credentials(name: "Test User", email: "test@example.com", password: "test1234", optIn: true)
 
         let expectation = XCTestExpectation(description: "Sign Up Success")
 
@@ -209,7 +209,7 @@ class AuthenticationManagerTests: XCTestCase {
         
         authManager = AuthenticationManager(authRepo: mockAuthRepo, accountRepository: mockAccountRepo)
 
-        let credentials = SignUpCredentials(name: "Test User", loginCredentials: (email: "test@example.com", password: "test1234"))
+        let credentials = SignUpV2Credentials(name: "Test User", email: "test@example.com", password: "test1234", optIn: true)
 
         let expectation = XCTestExpectation(description: "Sign Up Failure")
 


### PR DESCRIPTION
Added screens to add email and phone number methods to add 2FA.
Added send code API request.
Added bottom-screen notifications
Added resend timer.
![Simulator Screen Recording - Staging - add email 2fa](https://github.com/user-attachments/assets/be2db43c-ebf4-451b-980a-4032a0ef67c9)


![Simulator Screen Recording - Staging - add phone 2fa](https://github.com/user-attachments/assets/3f5b653e-843c-49b2-ab28-d36d93daef5e)
