### PR TITLE
VSP-1487 [IOS][Mobile] 2FA - Add Email - Enter Digits

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		5E31B630292FA9BC00934408 /* ShareManagementAccessRolesCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5E31B62E292FA9BC00934408 /* ShareManagementAccessRolesCollectionViewCell.xib */; };
 		5E31B633292FA9EA00934408 /* ShareManagementAccessRolesHeaderCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E31B631292FA9EA00934408 /* ShareManagementAccessRolesHeaderCollectionReusableView.swift */; };
 		5E31B634292FA9EA00934408 /* ShareManagementAccessRolesHeaderCollectionReusableView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5E31B632292FA9EA00934408 /* ShareManagementAccessRolesHeaderCollectionReusableView.xib */; };
+		5E328DEB2D59FF0F00EE2307 /* Add2FAFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E328DEA2D59FF0F00EE2307 /* Add2FAFieldView.swift */; };
 		5E37F2D52AA75248004F00E8 /* CustomDialogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E37F2D42AA75248004F00E8 /* CustomDialogView.swift */; };
 		5E381F0B27AB0B7100F7E277 /* MilestonesTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E381F0A27AB0B7100F7E277 /* MilestonesTableViewCell.swift */; };
 		5E3A060029E44D7900A6C531 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E3A05FF29E44D7900A6C531 /* Workspace.swift */; };
@@ -1103,6 +1104,7 @@
 		5E31B62E292FA9BC00934408 /* ShareManagementAccessRolesCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShareManagementAccessRolesCollectionViewCell.xib; sourceTree = "<group>"; };
 		5E31B631292FA9EA00934408 /* ShareManagementAccessRolesHeaderCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareManagementAccessRolesHeaderCollectionReusableView.swift; sourceTree = "<group>"; };
 		5E31B632292FA9EA00934408 /* ShareManagementAccessRolesHeaderCollectionReusableView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ShareManagementAccessRolesHeaderCollectionReusableView.xib; sourceTree = "<group>"; };
+		5E328DEA2D59FF0F00EE2307 /* Add2FAFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Add2FAFieldView.swift; sourceTree = "<group>"; };
 		5E37F2D42AA75248004F00E8 /* CustomDialogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDialogView.swift; sourceTree = "<group>"; };
 		5E381F0A27AB0B7100F7E277 /* MilestonesTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestonesTableViewCell.swift; sourceTree = "<group>"; };
 		5E3A05FF29E44D7900A6C531 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
@@ -2113,6 +2115,7 @@
 				5E1DAFFA2D4D022B00E13347 /* CustomEmailFieldView.swift */,
 				5E9F5CEE2D53591600F6213E /* CustomPhoneFieldView.swift */,
 				5E865D042D3FCF41005B41B7 /* TwoStepBottomNotificationView.swift */,
+				5E328DEA2D59FF0F00EE2307 /* Add2FAFieldView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -5041,6 +5044,7 @@
 				BCCC76EB255E8BF800903D3C /* URLExtension.swift in Sources */,
 				F50E135728F43368003DF4CC /* FilesRemoteDataSource.swift in Sources */,
 				BC6D3B5A2514F62400390927 /* AuthenticationEndpoint.swift in Sources */,
+				5E328DEB2D59FF0F00EE2307 /* Add2FAFieldView.swift in Sources */,
 				5EBAFCE42A154606005DB527 /* LegacyPlanningLoadingViewController.swift in Sources */,
 				5E548E8A2B2AF3EF00DD2C59 /* DonateStorageView.swift in Sources */,
 				5E7AE8B3291E97DA00F2A41D /* ShareManagementLinkAndShowSettingsCollectionViewCell.swift in Sources */,

--- a/Permanent/Modules/AccountSecurity/ViewModel/LoginSecurityViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/LoginSecurityViewModel.swift
@@ -30,7 +30,7 @@ class LoginSecurityViewModel: ObservableObject {
     /// Checks the current status of two-factor authentication by fetching
     /// the user's IDP methods from the server.
     /// Updates the UI state based on the server response.
-    private func checkTwoFactorStatus() {
+    func checkTwoFactorStatus() {
         let operation = APIOperation(AuthenticationEndpoint.getIDPUser)
         
         operation.execute(in: APIRequestDispatcher()) { [weak self] result in
@@ -41,16 +41,16 @@ class LoginSecurityViewModel: ObservableObject {
                         self?.updateTwoFactorStatus(enabled: false)
                         return
                     }
-                    
                     // Convert IDPUserMethodModel to TwoFactorMethod
-                    self?.twoFactorMethods = methods.map { method in
-                        TwoFactorMethod(methodId: method.methodId, 
-                                      method: method.method,
-                                      value: method.value)
+                    withAnimation {
+                        self?.twoFactorMethods = methods.map { method in
+                            TwoFactorMethod(methodId: method.methodId,
+                                            method: method.method,
+                                            value: method.value)
+                        }
+                        // If we have any methods, 2FA is enabled
+                        self?.updateTwoFactorStatus(enabled: !methods.isEmpty)
                     }
-                    
-                    // If we have any methods, 2FA is enabled
-                    self?.updateTwoFactorStatus(enabled: !methods.isEmpty)
                     
                 case .error:
                     self?.updateTwoFactorStatus(enabled: false)

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
@@ -69,6 +69,7 @@ class TwoStepChooseEmailViewModel: ObservableObject {
             
             switch result {
             case .json(let response, _):
+                self?.containerViewModel.refreshSecurityView = true
                 self?.containerViewModel.dismissContainer = true
                 
             case .error(let error, _):
@@ -80,14 +81,6 @@ class TwoStepChooseEmailViewModel: ObservableObject {
             default:
                 self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
             }
-        }
-    }
-    
-    func testEnableCode() {
-        isLoadingCodeVerification = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 7.5) { [weak self] in
-            self?.isLoadingCodeVerification = false
-            self?.containerViewModel.dismissContainer = true
         }
     }
     

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChooseEmailViewModel.swift
@@ -9,11 +9,14 @@ import SwiftUI
 class TwoStepChooseEmailViewModel: ObservableObject {
     var containerViewModel: TwoStepConfirmationContainerViewModel
     @Published var textFieldEmail: String = ""
-    @Published var isLoading: Bool = false
+    @Published var isLoadingEmailValidation: Bool = false
+    @Published var isLoadingCodeVerification: Bool = false
     @Published var emailAlreadyConfirmed: Bool = false
     @Published var remainingTime: Int = 0
     @Published var canResend: Bool = true
     @Published private(set) var sendCodeButtonTitle: String = "Send Code"
+    
+    @Published var pinCode: String = ""
     
     private var timer: Timer?
     
@@ -22,7 +25,8 @@ class TwoStepChooseEmailViewModel: ObservableObject {
     }
     
     func sendTwoFactorEnableCode() {
-        isLoading = true
+        isLoadingEmailValidation = true
+        
         withAnimation {
             containerViewModel.showErrorBanner = false
         }
@@ -31,13 +35,15 @@ class TwoStepChooseEmailViewModel: ObservableObject {
         
         let send2FAEnableCodeOperation = APIOperation(AuthenticationEndpoint.send2FAEnableCode(parameters: send2FAParameters))
         send2FAEnableCodeOperation.execute(in: APIRequestDispatcher()) { [weak self] result in
-            self?.isLoading = false
+            self?.isLoadingEmailValidation = false
             
             switch result {
             case .json(let response, _):
                 self?.containerViewModel.displayBannerWithAutoClose(.successCodeSend)
                 self?.startResendTimer()
-                self?.emailAlreadyConfirmed = true
+                withAnimation {
+                    self?.emailAlreadyConfirmed = true
+                }
             case .error(let error, _):
                 if let apiError = error as? APIError, apiError == .badRequest {
                     self?.containerViewModel.displayBanner(bannerErrorMessage: .invalidEmail)
@@ -47,6 +53,41 @@ class TwoStepChooseEmailViewModel: ObservableObject {
             default:
                 self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
             }
+        }
+    }
+    
+    func verifyAndEnableReceivedTwoFactorEnableCode() {
+        isLoadingCodeVerification = true
+        withAnimation {
+            containerViewModel.showErrorBanner = false
+        }
+        let enable2FAParameters: Enable2FAParameters = (method: "email", value: textFieldEmail, code: pinCode)
+
+        let enable2FACodeOperation = APIOperation(AuthenticationEndpoint.enable2FA(parameters: enable2FAParameters))
+        enable2FACodeOperation.execute(in: APIRequestDispatcher()) { [weak self] result in
+            self?.isLoadingCodeVerification = false
+            
+            switch result {
+            case .json(let response, _):
+                self?.containerViewModel.dismissContainer = true
+                
+            case .error(let error, _):
+                if let apiError = error as? APIError, apiError == .badRequest {
+                    self?.containerViewModel.displayBanner(bannerErrorMessage: .invalidPinCode)
+                } else {
+                    self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
+                }
+            default:
+                self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
+            }
+        }
+    }
+    
+    func testEnableCode() {
+        isLoadingCodeVerification = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 7.5) { [weak self] in
+            self?.isLoadingCodeVerification = false
+            self?.containerViewModel.dismissContainer = true
         }
     }
     

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChoosePhoneViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepChoosePhoneViewModel.swift
@@ -69,6 +69,7 @@ class TwoStepChoosePhoneViewModel: ObservableObject {
             
             switch result {
             case .json(let response, _):
+                self?.containerViewModel.refreshSecurityView = true
                 self?.containerViewModel.dismissContainer = true
                 
             case .error(let error, _):
@@ -80,14 +81,6 @@ class TwoStepChoosePhoneViewModel: ObservableObject {
             default:
                 self?.containerViewModel.displayBanner(bannerErrorMessage: .generalError)
             }
-        }
-    }
-    
-    func testEnableCode() {
-        isLoadingCodeVerification = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 7.5) { [weak self] in
-            self?.isLoadingCodeVerification = false
-            self?.containerViewModel.dismissContainer = true
         }
     }
     

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmationContainerViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmationContainerViewModel.swift
@@ -44,6 +44,11 @@ class TwoStepConfirmationContainerViewModel: ObservableObject {
     @Published var contentType: TwoStepConfirmationContentType = .confirmPassword
     @Published var insertionViewTransition: AnyTransition = .opacity
     @Published var dismissContainer: Bool = false
+    @Binding var refreshSecurityView: Bool
+    
+    init(refreshSecurityView: Binding<Bool>) {
+        self._refreshSecurityView = refreshSecurityView
+    }
     
     func displayBanner(bannerErrorMessage: AuthBannerMessage) {
         if showErrorBanner {

--- a/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmationContainerViewModel.swift
+++ b/Permanent/Modules/AccountSecurity/ViewModel/TwoStepConfirmationContainerViewModel.swift
@@ -43,6 +43,7 @@ class TwoStepConfirmationContainerViewModel: ObservableObject {
     @Published var showAddVerificationMethod: Bool = false
     @Published var contentType: TwoStepConfirmationContentType = .confirmPassword
     @Published var insertionViewTransition: AnyTransition = .opacity
+    @Published var dismissContainer: Bool = false
     
     func displayBanner(bannerErrorMessage: AuthBannerMessage) {
         if showErrorBanner {

--- a/Permanent/Modules/AccountSecurity/Views/Add2FAFieldView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/Add2FAFieldView.swift
@@ -1,0 +1,114 @@
+//
+//  Add2FAFieldView.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 10.02.2025.
+import SwiftUI
+import Combine
+
+struct Add2FAFieldView: View {
+    var numberOfFields: Int
+    @Binding private var code: String
+    @State private var pins: [String]
+    @FocusState var pinFocusState: FocusPinType?
+    @Binding var digitsDisabled: Bool
+
+    init(numberOfFields: Int, code: Binding<String>, digitsDisabled: Binding<Bool>) {
+        self.numberOfFields = numberOfFields
+        self._code = code
+        self._pins = State(initialValue: Array(repeating: "", count: numberOfFields))
+        self._digitsDisabled = digitsDisabled
+    }
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            ForEach(0..<numberOfFields, id: \.self) { index in
+                TextField("", text: $pins[index])
+                    .modifier(Add2FAFieldViewCodeModifier(pin: $pins[index]))
+                    .onChange(of: pins[index]) { newVal in
+                        if newVal.count == 1 {
+                            if index < numberOfFields - 1 {
+                                pinFocusState = FocusPinType.pin(index + 1)
+                            } else {
+                                pinFocusState = nil
+                            }
+                        }
+                        else if newVal.count == numberOfFields, let intValue = Int(newVal) {
+                            code = newVal
+                            updatePinsFromOTP()
+                            pinFocusState = FocusPinType.pin(numberOfFields - 1)
+                        }
+                        else if newVal.isEmpty {
+                            if index > 0 {
+                                pinFocusState = FocusPinType.pin(index - 1)
+                            }
+                        }
+                        updateOTPString()
+                    }
+                    .keyboardType(.numberPad)
+                    .focused($pinFocusState, equals: FocusPinType.pin(index))
+                    .disabled(digitsDisabled)
+                    .onTapGesture {
+                        pinFocusState = FocusPinType.pin(index)
+                    }
+            }
+        }
+        .onAppear {
+            updatePinsFromOTP()
+        }
+    }
+    
+    private func updatePinsFromOTP() {
+        let otpArray = Array(code.prefix(numberOfFields))
+        for (index, char) in otpArray.enumerated() {
+            pins[index] = String(char)
+        }
+    }
+    
+    private func updateOTPString() {
+        code = pins.joined()
+    }
+}
+
+struct Add2FAFieldViewCodeModifier: ViewModifier {
+    @Binding var pin: String
+    
+    var textLimit = 1
+    
+    func limitText(_ upper: Int) {
+        if pin.count > upper {
+            self.pin = String(pin.prefix(upper))
+        }
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .frame(height: 36)
+            .multilineTextAlignment(.center)
+            .keyboardType(.numberPad)
+            .onReceive(Just(pin)) { _ in limitText(textLimit) }
+            .font(.custom("Usual-Regular", size: 24))
+            .foregroundColor(.blue900)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 12)
+            .background(.white)
+            .cornerRadius(12)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .inset(by: 0.5)
+                    .stroke(Color.blue100, lineWidth: 1)
+            )
+    }
+}
+
+struct Add2FAFieldView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color.blue25
+            Add2FAFieldView(numberOfFields: 4, code: .constant("4321"), digitsDisabled: .constant(false))
+        }
+        .ignoresSafeArea()
+    }
+}
+
+

--- a/Permanent/Modules/AccountSecurity/Views/LoginSecurityView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/LoginSecurityView.swift
@@ -79,6 +79,9 @@ struct LoginSecurityView: View {
                 )
                 Spacer()
             }
+            .onAppear() {
+                viewModel.checkTwoFactorStatus()
+            }
         }
         .navigationBarTitle("Login & Security", displayMode: .inline)
         .padding(.top, 10)

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
@@ -67,7 +67,6 @@ struct TwoStepChooseEmailView: View {
                                         RoundButtonUsualFontView(isDisabled: viewModel.pinCode.count != 4, isLoading: viewModel.isLoadingCodeVerification, text: "Enable") {
                                             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                                             viewModel.verifyAndEnableReceivedTwoFactorEnableCode()
-//                                            viewModel.testEnableCode()
                                         }
                                     }
                                     .padding(.horizontal, 32)
@@ -122,5 +121,5 @@ struct TwoStepChooseEmailView: View {
 }
 
 #Preview {
-    TwoStepChooseEmailView(viewModel: TwoStepChooseEmailViewModel(containerViewModel: TwoStepConfirmationContainerViewModel()))
+    TwoStepChooseEmailView(viewModel: TwoStepChooseEmailViewModel(containerViewModel: TwoStepConfirmationContainerViewModel(refreshSecurityView: .constant(false))))
 }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChooseEmailView.swift
@@ -8,34 +8,112 @@ import SwiftUI
 
 struct TwoStepChooseEmailView: View {
     @StateObject var viewModel: TwoStepChooseEmailViewModel
+    @State var keyboardHeight: CGFloat = 0
+    @FocusState var codeInputIsFocused: Bool
+    let bottomButtonId = UUID()
+    let topTextId = UUID()
     
     var body: some View {
         ZStack(alignment: .top) {
-            VStack(spacing: 32) {
-                Text("Enter your email address and click the button to send a one-time use code.")
-                .font(
-                    .custom(
-                        "Usual-Regular",
-                        fixedSize: 14)
-                )
-                .multilineTextAlignment(.leading)
-                .lineSpacing(5)
-                .foregroundColor(.blue700)
-                VStack(spacing: 16) {
-                    CustomEmailFieldView(email: $viewModel.textFieldEmail) {
-                        viewModel.sendTwoFactorEnableCode()
+            GeometryReader { geometry in
+                ScrollViewReader { scrollView in
+                    ScrollView(showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: 32) {
+                            Text("Enter your email address and click the button to send a one-time use code.")
+                                .font(
+                                    .custom(
+                                        "Usual-Regular",
+                                        fixedSize: 14)
+                                )
+                                .multilineTextAlignment(.leading)
+                                .lineSpacing(5)
+                                .foregroundColor(.blue700)
+                                .padding(.horizontal, 32)
+                                .padding(.top, 32)
+                                .id(topTextId)
+                            VStack(spacing: 16) {
+                                CustomEmailFieldView(email: $viewModel.textFieldEmail) {
+                                    viewModel.sendTwoFactorEnableCode()
+                                }
+                                .disabled(viewModel.emailAlreadyConfirmed)
+                                .opacity(viewModel.emailAlreadyConfirmed ? 0.5 : 1)
+                                RoundButtonUsualFontView(isDisabled: !viewModel.textFieldEmail.isValidEmail || viewModel.isLoadingEmailValidation || viewModel.remainingTime > 0, isLoading: viewModel.isLoadingEmailValidation, text: viewModel.sendCodeButtonTitle) {
+                                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                    viewModel.sendTwoFactorEnableCode()
+                                }
+                            }
+                            .padding(.horizontal, 32)
+                            .padding(.bottom, 32)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .safeAreaInset(edge: .bottom) {
+                            if viewModel.emailAlreadyConfirmed {
+                                VStack(alignment: .leading, spacing: 32) {
+                                    Text("Enter the 4-digit code you received.")
+                                        .font(
+                                            .custom(
+                                                "Usual-Regular",
+                                                fixedSize: 14)
+                                        )
+                                        .multilineTextAlignment(.leading)
+                                        .lineSpacing(5)
+                                        .foregroundColor(.blue700)
+                                        .padding(.top, 32)
+                                        .padding(.horizontal, 32)
+                                    VStack(spacing: 16) {
+                                        Add2FAFieldView(numberOfFields: 4, code: $viewModel.pinCode, digitsDisabled: $viewModel.isLoadingCodeVerification)
+                                            .focused($codeInputIsFocused)
+                                            .opacity(viewModel.isLoadingCodeVerification ? 0.5 : 1)
+                                        RoundButtonUsualFontView(isDisabled: viewModel.pinCode.count != 4, isLoading: viewModel.isLoadingCodeVerification, text: "Enable") {
+                                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                            viewModel.verifyAndEnableReceivedTwoFactorEnableCode()
+//                                            viewModel.testEnableCode()
+                                        }
+                                    }
+                                    .padding(.horizontal, 32)
+                                    Spacer()
+                                }
+                                .safeAreaInset(edge: .bottom, content: {
+                                    Color.blue25
+                                        .frame(height: 300)
+                                        .id(bottomButtonId)
+                                })
+                                .background(Color.blue25)
+                            } else {
+                                Spacer()
+                            }
+                        }
                     }
-                    .disabled(viewModel.emailAlreadyConfirmed)
-                    .opacity(viewModel.emailAlreadyConfirmed ? 0.5 : 1)
-                    RoundButtonUsualFontView(isDisabled: !viewModel.textFieldEmail.isValidEmail || viewModel.isLoading || viewModel.remainingTime > 0, isLoading: viewModel.isLoading, text: viewModel.sendCodeButtonTitle) {
-                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                        viewModel.sendTwoFactorEnableCode()
+                    .frame(minHeight: geometry.size.height)
+                    .frame(maxWidth: .infinity)
+                    .onAppear {
+                        UIScrollView.appearance().bounces = false
+                    }
+                    .onDisappear {
+                        UIScrollView.appearance().bounces = true
+                        
+                    }
+                    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { event in
+                        if let keyboardSize = event.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                            if codeInputIsFocused {
+                                withAnimation {
+                                    scrollView.scrollTo(bottomButtonId, anchor: .bottom)
+                                }
+                            }
+                        }
+                    }
+                    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) { event in
+                        if let keyboardSize = event.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                            if !codeInputIsFocused {
+                                withAnimation {
+                                    scrollView.scrollTo(topTextId, anchor: .top)
+                                }
+                            }
+                        }
                     }
                 }
-                Spacer()
             }
-            .frame(maxWidth: .infinity)
-            .padding(32)
+            .ignoresSafeArea(.all, edges: .bottom)
         }
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
@@ -72,7 +72,6 @@ struct TwoStepChoosePhoneView: View {
                                         RoundButtonUsualFontView(isDisabled: viewModel.pinCode.count != 4, isLoading: viewModel.isLoadingCodeVerification, text: "Enable") {
                                             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                                             viewModel.verifyAndEnableReceivedTwoFactorEnableCode()
-                                            //viewModel.testEnableCode()
                                         }
                                     }
                                     .padding(.horizontal, 32)
@@ -127,5 +126,5 @@ struct TwoStepChoosePhoneView: View {
 }
 
 #Preview {
-    TwoStepChoosePhoneView(viewModel: TwoStepChoosePhoneViewModel(containerViewModel: TwoStepConfirmationContainerViewModel()))
+    TwoStepChoosePhoneView(viewModel: TwoStepChoosePhoneViewModel(containerViewModel: TwoStepConfirmationContainerViewModel(refreshSecurityView: .constant(false))))
 }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepChoosePhoneView.swift
@@ -8,42 +8,124 @@ import SwiftUI
 
 struct TwoStepChoosePhoneView: View {
     @StateObject var viewModel: TwoStepChoosePhoneViewModel
+    @State var keyboardHeight: CGFloat = 0
+    @FocusState var codeInputIsFocused: Bool
+    let bottomButtonId = UUID()
+    let topTextId = UUID()
     
     var body: some View {
         ZStack(alignment: .top) {
-            VStack(spacing: 32) {
-                HStack {
-                    Text("Enter your phone number and click the button to send a one-time use code. At this time, we can only accept ") +
-                    Text("North American")
-                        .bold() +
-                    Text(" cell phone numbers for SMS.")
-                }
-                .font(
-                    .custom(
-                        "Usual-Regular",
-                        fixedSize: 14)
-                )
-                .multilineTextAlignment(.leading)
-                .lineSpacing(5)
-                .foregroundColor(.blue700)
-                VStack(spacing: 16) {
-                    CustomPhoneFieldView(phone: $viewModel.formattedPhone, rawPhoneNumber: $viewModel.rawPhone) {
-                       viewModel.sendTwoFactorEnableCode()
+            GeometryReader { geometry in
+                ScrollViewReader { scrollView in
+                    ScrollView(showsIndicators: false) {
+                        VStack(spacing: 32) {
+                            HStack {
+                                Text("Enter your phone number and click the button to send a one-time use code. At this time, we can only accept ") +
+                                Text("North American")
+                                    .bold() +
+                                Text(" cell phone numbers for SMS.")
+                            }
+                            .font(
+                                .custom(
+                                    "Usual-Regular",
+                                    fixedSize: 14)
+                            )
+                            .multilineTextAlignment(.leading)
+                            .lineSpacing(5)
+                            .foregroundColor(.blue700)
+                            .padding(.horizontal, 32)
+                            .padding(.top, 32)
+                            .id(topTextId)
+                            VStack(spacing: 16) {
+                                CustomPhoneFieldView(phone: $viewModel.formattedPhone, rawPhoneNumber: $viewModel.rawPhone) {
+                                    viewModel.sendTwoFactorEnableCode()
+                                }
+                                .disabled(viewModel.phoneAlreadyConfirmed)
+                                .opacity(viewModel.phoneAlreadyConfirmed ? 0.5 : 1)
+                                RoundButtonUsualFontView(isDisabled: !viewModel.rawPhone.isUSPhoneNumber || viewModel.isLoadingPhoneValidation || viewModel.remainingTime > 0, isLoading: viewModel.isLoadingPhoneValidation, text: viewModel.sendCodeButtonTitle) {
+                                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                    viewModel.sendTwoFactorEnableCode()
+                                }
+                            }
+                            .padding(.horizontal, 32)
+                            .padding(.bottom, 32)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .safeAreaInset(edge: .bottom) {
+                            if viewModel.phoneAlreadyConfirmed {
+                                VStack(alignment: .leading, spacing: 32) {
+                                    Text("Enter the 4-digit code you received.")
+                                        .font(
+                                            .custom(
+                                                "Usual-Regular",
+                                                fixedSize: 14)
+                                        )
+                                        .multilineTextAlignment(.leading)
+                                        .lineSpacing(5)
+                                        .foregroundColor(.blue700)
+                                        .padding(.top, 32)
+                                        .padding(.horizontal, 32)
+                                    VStack(spacing: 16) {
+                                        Add2FAFieldView(numberOfFields: 4, code: $viewModel.pinCode, digitsDisabled: $viewModel.isLoadingCodeVerification)
+                                            .focused($codeInputIsFocused)
+                                            .opacity(viewModel.isLoadingCodeVerification ? 0.5 : 1)
+                                        RoundButtonUsualFontView(isDisabled: viewModel.pinCode.count != 4, isLoading: viewModel.isLoadingCodeVerification, text: "Enable") {
+                                            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                            viewModel.verifyAndEnableReceivedTwoFactorEnableCode()
+                                            //viewModel.testEnableCode()
+                                        }
+                                    }
+                                    .padding(.horizontal, 32)
+                                    Spacer()
+                                }
+                                .safeAreaInset(edge: .bottom, content: {
+                                    Color.blue25
+                                        .frame(height: 300)
+                                        .id(bottomButtonId)
+                                })
+                                .background(Color.blue25)
+                            } else {
+                                Spacer()
+                            }
+                        }
                     }
-                    .disabled(viewModel.phoneAlreadyConfirmed)
-                    .opacity(viewModel.phoneAlreadyConfirmed ? 0.5 : 1)
-                    RoundButtonUsualFontView(isDisabled: !viewModel.rawPhone.isUSPhoneNumber || viewModel.isLoading || viewModel.remainingTime > 0, isLoading: viewModel.isLoading, text: viewModel.sendCodeButtonTitle) {
-                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                        viewModel.sendTwoFactorEnableCode()
+                    .frame(minHeight: geometry.size.height)
+                    .frame(maxWidth: .infinity)
+                    .onAppear {
+                        UIScrollView.appearance().bounces = false
+                    }
+                    .onDisappear {
+                        UIScrollView.appearance().bounces = true
+                        
+                    }
+                    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { event in
+                        if let keyboardSize = event.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                            if codeInputIsFocused {
+                                withAnimation {
+                                    scrollView.scrollTo(bottomButtonId, anchor: .bottom)
+                                }
+                            }
+                        }
+                    }
+                    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) { event in
+                        if let keyboardSize = event.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+                            if !codeInputIsFocused {
+                                withAnimation {
+                                    scrollView.scrollTo(topTextId, anchor: .top)
+                                }
+                            }
+                        }
                     }
                 }
-                Spacer()
             }
-            .frame(maxWidth: .infinity)
-            .padding(32)
+            .ignoresSafeArea(.all, edges: .bottom)
         }
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
     }
+}
+
+#Preview {
+    TwoStepChoosePhoneView(viewModel: TwoStepChoosePhoneViewModel(containerViewModel: TwoStepConfirmationContainerViewModel()))
 }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepConfirmationContainerView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepConfirmationContainerView.swift
@@ -11,67 +11,74 @@ struct TwoStepConfirmationContainerView: View {
     @Environment(\.presentationMode) var presentationMode
     
     var body: some View {
-        SimpleCustomNavigationView(content: {
-            ZStack(alignment: .top) {
+        ZStack{
+            SimpleCustomNavigationView(content: {
+                ZStack(alignment: .top) {
+                    switch viewModel.contentType {
+                    case .confirmPassword:
+                        TwoStepConfirmPasswordView(viewModel: TwoStepConfirmPasswordViewModel(containerViewModel: viewModel))
+                            .transition(AnyTransition.asymmetric(
+                                insertion: viewModel.insertionViewTransition,
+                                removal: .opacity)
+                            )
+                    case .chooseVerification:
+                        TwoStepChooseVerificationView(viewModel: TwoStepChooseVerificationViewModel(containerViewModel: viewModel, isEmailMethodSelected: nil))
+                            .transition(AnyTransition.asymmetric(
+                                insertion: viewModel.insertionViewTransition,
+                                removal: .opacity)
+                            )
+                    case .chooseEmail:
+                        TwoStepChooseEmailView(viewModel: TwoStepChooseEmailViewModel(containerViewModel: viewModel))
+                            .transition(AnyTransition.asymmetric(
+                                insertion: viewModel.insertionViewTransition,
+                                removal: .opacity)
+                            )
+                    case .choosePhoneNumber:
+                        TwoStepChoosePhoneView(viewModel: TwoStepChoosePhoneViewModel(containerViewModel: viewModel))
+                            .transition(AnyTransition.asymmetric(
+                                insertion: viewModel.insertionViewTransition,
+                                removal: .opacity)
+                            )
+                    default:
+                        EmptyView()
+                    }
+                    TwoStepBottomNotificationView(message: viewModel.bannerErrorMessage, isVisible: $viewModel.showErrorBanner)
+                        .padding(.horizontal, 32)
+                }
+                .navigationBarTitle(viewModel.contentType.screenTitle(), displayMode: .inline)
+                .onTapGesture {
+                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                }
+                .onChange(of: viewModel.dismissContainer) { newValue in
+                    if newValue {
+                        presentationMode.wrappedValue.dismiss()
+                    }
+                }
+            }, leftButton: {
                 switch viewModel.contentType {
-                case .confirmPassword:
-                    TwoStepConfirmPasswordView(viewModel: TwoStepConfirmPasswordViewModel(containerViewModel: viewModel))
-                        .transition(AnyTransition.asymmetric(
-                            insertion: viewModel.insertionViewTransition,
-                            removal: .opacity)
-                        )
-                case .chooseVerification:
-                    TwoStepChooseVerificationView(viewModel: TwoStepChooseVerificationViewModel(containerViewModel: viewModel, isEmailMethodSelected: nil))
-                        .transition(AnyTransition.asymmetric(
-                            insertion: viewModel.insertionViewTransition,
-                            removal: .opacity)
-                        )
-                case .chooseEmail:
-                    TwoStepChooseEmailView(viewModel: TwoStepChooseEmailViewModel(containerViewModel: viewModel))
-                        .transition(AnyTransition.asymmetric(
-                            insertion: viewModel.insertionViewTransition,
-                            removal: .opacity)
-                        )
-                case .choosePhoneNumber:
-                    TwoStepChoosePhoneView(viewModel: TwoStepChoosePhoneViewModel(containerViewModel: viewModel))
-                        .transition(AnyTransition.asymmetric(
-                            insertion: viewModel.insertionViewTransition,
-                            removal: .opacity)
-                        )
+                case .chooseEmail, .choosePhoneNumber:
+                    Button {
+                        viewModel.setContentType(.chooseVerification)
+                    } label: {
+                        Image(.twoStepBack)
+                            .frame(width: 24, height: 24)
+                    }
                 default:
                     EmptyView()
                 }
-                TwoStepBottomNotificationView(message: viewModel.bannerErrorMessage, isVisible: $viewModel.showErrorBanner)
-                    .padding(.horizontal, 32)
-            }
-            .navigationBarTitle(viewModel.contentType.screenTitle(), displayMode: .inline)
-            .onTapGesture {
-                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-            }
-        }, leftButton: {
-            switch viewModel.contentType {
-            case .chooseEmail, .choosePhoneNumber:
+            }, rightButton: {
                 Button {
-                    viewModel.setContentType(.chooseVerification)
+                    presentationMode.wrappedValue.dismiss()
                 } label: {
-                    Image(.twoStepBack)
+                    Image(.twoStepClose)
                         .frame(width: 24, height: 24)
                 }
-            default:
-                EmptyView()
-            }
-        }, rightButton: {
-            Button {
-                presentationMode.wrappedValue.dismiss()
-            } label: {
-                Image(.twoStepClose)
-                    .frame(width: 24, height: 24)
-            }
-        },
-                                   backgroundColor: .white,
-                                   textColor: UIColor(Color.blue900),
-                                   textStyle: TextFontStyle.style50,
-                                   showLeftChevron: false
-        )
+            },
+                                       backgroundColor: .white,
+                                       textColor: UIColor(Color.blue900),
+                                       textStyle: TextFontStyle.style50,
+                                       showLeftChevron: false
+            )
+        }
     }
 }

--- a/Permanent/Modules/AccountSecurity/Views/TwoStepVerificationView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/TwoStepVerificationView.swift
@@ -14,7 +14,6 @@ struct TwoStepVerificationView: View {
     init(isTwoFactorEnabled: Bool = false, twoFactorMethods: [TwoFactorMethod]) {
         self._viewModel = StateObject(wrappedValue: TwoStepVerificationViewModel(isTwoFactorEnabled: isTwoFactorEnabled, twoFactorMethods: twoFactorMethods))
     }
-    
     var body: some View {
         CustomNavigationView {
             ZStack {
@@ -68,9 +67,14 @@ struct TwoStepVerificationView: View {
                 .padding(.bottom, 32)
             }
         }
+        .onChange(of: viewModel.refreshAccountDataRequired, perform: { newValue in
+            if newValue {
+                viewModel.refreshAccountData()
+            }
+        })
         .navigationBarTitle("Two-step verification", displayMode: .inline)
         .sheet(isPresented: $viewModel.showAddVerificationMethod) {
-            TwoStepConfirmationContainerView(viewModel: TwoStepConfirmationContainerViewModel())
+            TwoStepConfirmationContainerView(viewModel: TwoStepConfirmationContainerViewModel(refreshSecurityView: $viewModel.refreshAccountDataRequired))
         }
     }
     

--- a/Permanent/Modules/Authentication/Screens/Register/RegisterView.swift
+++ b/Permanent/Modules/Authentication/Screens/Register/RegisterView.swift
@@ -178,7 +178,8 @@ struct RegisterView: View {
                     }
                 }
             }
-        }.onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) { event in
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)) { event in
             if let keyboardSize = event.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                 keyboardHeight = 0
                 if keyboardSize.height > 120 {

--- a/Permanent/Modules/SideMenus/ViewModels/SettingsScreenViewModel.swift
+++ b/Permanent/Modules/SideMenus/ViewModels/SettingsScreenViewModel.swift
@@ -25,7 +25,7 @@ class SettingsScreenViewModel: ObservableObject {
     @Published var isLoading: Bool = false
     @Published var loggedOut: Bool = false
     
-    @Published var twoFactorAuthenticationEnabled: Bool? = nil
+    @Published var twoFactorAuthenticationEnabled: Bool? = true
     @Published var isLoading2FAStatus: Bool = false
     @Published var twoFactorMethods: [TwoFactorMethod] = []
     
@@ -39,11 +39,7 @@ class SettingsScreenViewModel: ObservableObject {
                 self.getCurrentArchiveThumbnail()
             }
         }
-        if let twoFactorStatus: Bool = PreferencesManager.shared.getValue(forKey: Constants.Keys.StorageKeys.twoFactorAuthEnabled) {
-            twoFactorAuthenticationEnabled = twoFactorStatus
-        } else {
             getTwoFAStatus()
-        }
     }
     
     func getAccountInfo(_ completionBlock: @escaping ((Error?) -> Void) ) {


### PR DESCRIPTION
- Added a new digit input field for confirming the inserted email/phone number.
- Added scroll navigation when digits are entered.
- Added API request to check for added 2FA methods
- Resolved the refresh of the 2FA badge on settings menu.

![AddEmail2FA](https://github.com/user-attachments/assets/b3bc4c2d-3875-4610-8406-2416327d0d58)

![AddPhone2FA](https://github.com/user-attachments/assets/94e69c31-e736-4c37-8409-7368ac09cc54)
