### PR TITLE
VSP-1548[IOS] Buttons/fields in gift storage modal not tappable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "fastlane"
-gem 'cocoapods', '~> 1.15.2'
+gem 'cocoapods', '~> 1.16.2'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
-  cocoapods (~> 1.15.2)
+  cocoapods (~> 1.16.2)
   fastlane
   fastlane-plugin-firebase_app_distribution
 

--- a/Permanent/Modules/AccountSecurity/Views/LoginSecurityView.swift
+++ b/Permanent/Modules/AccountSecurity/Views/LoginSecurityView.swift
@@ -54,7 +54,6 @@ struct LoginSecurityView: View {
                             titleText: "Change password",
                             descText: "Update your password to keep your account secure."
                         )
-                        .frame(height: 112)
                     }
                     Divider()
                     NavigationLink {
@@ -78,7 +77,6 @@ struct LoginSecurityView: View {
                             badgeText: viewModel.twoFactorBadgeStatus?.text ?? "",
                             badgeColor: viewModel.twoFactorBadgeStatus?.color ?? .clear
                         )
-                        .frame(height: 112)
                         .animation(.spring(response: 0.3, dampingFraction: 0.6), value: viewModel.twoFactorBadgeStatus)
                     }
                     Divider()

--- a/Permanent/Modules/Storage/Views/GiftStorageView.swift
+++ b/Permanent/Modules/Storage/Views/GiftStorageView.swift
@@ -28,14 +28,14 @@ struct GiftStorageView: View {
                             isKeyboardPresented = value.isFirstResponder
                         }
                 }
+                .onTapGesture {
+                    dismissKeyboard()
+                }
                 .ignoresSafeArea(.all)
             } leftButton: {
                 backButton
             } rightButton: {
                 EmptyView()
-            }
-            .onTapGesture {
-                dismissKeyboard()
             }
             if viewModel.showConfirmation {
                 CustomDialogView(isActive: $viewModel.showConfirmation, title: "Are you sure you’d like to gift storage? This can't be undone!", message: nil, buttonTitle: "Yes, gift storage", addCornerRadius: true) {


### PR DESCRIPTION
- Resolved a bug where the buttons for adding storage as a gift didn't work.
- Removed the height of the submenus in the 2fa menu.

Preview:

https://github.com/user-attachments/assets/8c494ef3-a980-4973-a0b9-f44808d63c7a

