### PR TITLE
VSP-1549[IOS] Cannot delete a tag in manage tags

### DIFF
--- a/Permanent/Common/Network/TagEndpoint.swift
+++ b/Permanent/Common/Network/TagEndpoint.swift
@@ -111,7 +111,7 @@ extension TagEndpoint {
         let data = tags.map {
             [
                 "TagVO": [
-                    "id": ($0.tagVO.tagId ?? Int() ) as Int
+                    "tagId": ($0.tagVO.tagId ?? Int() ) as Int
                 ]
             ]
         }


### PR DESCRIPTION
Corrected a mismatch for the tag deletion functionality.