### PR TITLE
VSP-1511 [iOS] Add archive name field to archive profile

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		5E0B1BD42B961CE800B10BB5 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0B1BD32B961CE800B10BB5 /* OnboardingView.swift */; };
 		5E0E3C2E2886DBCA001C7F10 /* ShareExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0E3C2D2886DBCA001C7F10 /* ShareExtensionTests.swift */; };
 		5E0E3C302886EB69001C7F10 /* ShareExtensionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1CCC18287EE4B800913EEA /* ShareExtensionViewModel.swift */; };
+		5E10173B2DF0A3E80097A649 /* ArchiveNameProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E10173A2DF0A3E80097A649 /* ArchiveNameProfileItem.swift */; };
+		5E10173C2DF0A3E80097A649 /* ArchiveNameProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E10173A2DF0A3E80097A649 /* ArchiveNameProfileItem.swift */; };
 		5E1582B52C5BA3C300103EA8 /* OnboardingContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1582B42C5BA3C300103EA8 /* OnboardingContainerViewModel.swift */; };
 		5E1582B72C5CD63500103EA8 /* OnboardingArchiveNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1582B62C5CD63500103EA8 /* OnboardingArchiveNameViewModel.swift */; };
 		5E1582B92C5CD66500103EA8 /* OnboardingInvitedWelcomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1582B82C5CD66500103EA8 /* OnboardingInvitedWelcomeViewModel.swift */; };
@@ -1073,6 +1075,7 @@
 		5E0ADB8C279052A500F39E7E /* PublicProfileLocationSetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicProfileLocationSetViewController.swift; sourceTree = "<group>"; };
 		5E0B1BD32B961CE800B10BB5 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		5E0E3C2D2886DBCA001C7F10 /* ShareExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionTests.swift; sourceTree = "<group>"; };
+		5E10173A2DF0A3E80097A649 /* ArchiveNameProfileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveNameProfileItem.swift; sourceTree = "<group>"; };
 		5E1582B42C5BA3C300103EA8 /* OnboardingContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerViewModel.swift; sourceTree = "<group>"; };
 		5E1582B62C5CD63500103EA8 /* OnboardingArchiveNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingArchiveNameViewModel.swift; sourceTree = "<group>"; };
 		5E1582B82C5CD66500103EA8 /* OnboardingInvitedWelcomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInvitedWelcomeViewModel.swift; sourceTree = "<group>"; };
@@ -2219,6 +2222,7 @@
 		5E2CFA23274EEB040055941C /* PublicProfile */ = {
 			isa = PBXGroup;
 			children = (
+				5E10173A2DF0A3E80097A649 /* ArchiveNameProfileItem.swift */,
 				5E2CFA24274EEB570055941C /* ProfileItemVO.swift */,
 				5EB6201E278445B6001B9AFD /* BlurbProfileItem.swift */,
 				5EB6202027844A46001B9AFD /* DescriptionProfileItem.swift */,
@@ -5236,6 +5240,7 @@
 				5E865D092D4045A7005B41B7 /* TwoStepConfirmationContainerViewModel.swift in Sources */,
 				BC76DAEB25C075E70041DCC3 /* ViewController.swift in Sources */,
 				F53D0A1C25FB71960080579F /* FileDetailsDateCollectionViewCell.swift in Sources */,
+				5E10173B2DF0A3E80097A649 /* ArchiveNameProfileItem.swift in Sources */,
 				5E2E3D1B26D517E10090EF02 /* ArchiveType.swift in Sources */,
 				5E6CCEE72B72D24000D192FF /* ArchivesViewControllerRepresentable.swift in Sources */,
 				5E181B7F2AF0640E002DE69A /* GiftStorageView.swift in Sources */,
@@ -5505,6 +5510,7 @@
 				5E4739F82A4187B300A20D85 /* EmailProfileItem.swift in Sources */,
 				F559F8B5290164000015A522 /* ShareFileBrowserViewController.swift in Sources */,
 				5E4739EF2A41874200A20D85 /* APIErrors.swift in Sources */,
+				5E10173C2DF0A3E80097A649 /* ArchiveNameProfileItem.swift in Sources */,
 				5E4739FE2A4187D100A20D85 /* FieldNameUI.swift in Sources */,
 				5E83CC49286C601C00A5775B /* StringExtension.swift in Sources */,
 				F559F89528FEE99E0015A522 /* APIError.swift in Sources */,

--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		5E0E3C302886EB69001C7F10 /* ShareExtensionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1CCC18287EE4B800913EEA /* ShareExtensionViewModel.swift */; };
 		5E10173B2DF0A3E80097A649 /* ArchiveNameProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E10173A2DF0A3E80097A649 /* ArchiveNameProfileItem.swift */; };
 		5E10173C2DF0A3E80097A649 /* ArchiveNameProfileItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E10173A2DF0A3E80097A649 /* ArchiveNameProfileItem.swift */; };
+		5E1017412DF1A6B80097A649 /* ScrollViewAppearanceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1017402DF1A6B80097A649 /* ScrollViewAppearanceManager.swift */; };
+		5E1017422DF1A6B80097A649 /* ScrollViewAppearanceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1017402DF1A6B80097A649 /* ScrollViewAppearanceManager.swift */; };
 		5E1582B52C5BA3C300103EA8 /* OnboardingContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1582B42C5BA3C300103EA8 /* OnboardingContainerViewModel.swift */; };
 		5E1582B72C5CD63500103EA8 /* OnboardingArchiveNameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1582B62C5CD63500103EA8 /* OnboardingArchiveNameViewModel.swift */; };
 		5E1582B92C5CD66500103EA8 /* OnboardingInvitedWelcomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1582B82C5CD66500103EA8 /* OnboardingInvitedWelcomeViewModel.swift */; };
@@ -1076,6 +1078,7 @@
 		5E0B1BD32B961CE800B10BB5 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		5E0E3C2D2886DBCA001C7F10 /* ShareExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionTests.swift; sourceTree = "<group>"; };
 		5E10173A2DF0A3E80097A649 /* ArchiveNameProfileItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveNameProfileItem.swift; sourceTree = "<group>"; };
+		5E1017402DF1A6B80097A649 /* ScrollViewAppearanceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewAppearanceManager.swift; sourceTree = "<group>"; };
 		5E1582B42C5BA3C300103EA8 /* OnboardingContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingContainerViewModel.swift; sourceTree = "<group>"; };
 		5E1582B62C5CD63500103EA8 /* OnboardingArchiveNameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingArchiveNameViewModel.swift; sourceTree = "<group>"; };
 		5E1582B82C5CD66500103EA8 /* OnboardingInvitedWelcomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingInvitedWelcomeViewModel.swift; sourceTree = "<group>"; };
@@ -3863,6 +3866,7 @@
 		BC4526E6251CACD500E24A51 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				5E1017402DF1A6B80097A649 /* ScrollViewAppearanceManager.swift */,
 				92430A8D2B10A55E0098597D /* Events */,
 				BC4526E7251CACDF00E24A51 /* CodableHelper.swift */,
 				BC1C7B38254861E7008E9A0D /* DateUtils.swift */,
@@ -5349,6 +5353,7 @@
 				5E8A3E5124F3AFCE00812361 /* PageViewModelDelegateInterface.swift in Sources */,
 				5E7C852029A39F84000DF3CA /* FABTagsManagementActionSheet.swift in Sources */,
 				BC8945132524BE1100FA8D7A /* AccountEndpoint.swift in Sources */,
+				5E1017422DF1A6B80097A649 /* ScrollViewAppearanceManager.swift in Sources */,
 				F59C3B8129C3260100337E45 /* ArchivesRepository.swift in Sources */,
 				924F16352A45CBD800B75D4E /* TextExtension.swift in Sources */,
 				BCF906642587B0C200DF1B64 /* MembersViewController.swift in Sources */,
@@ -5435,6 +5440,7 @@
 				925FF46B2D00668C000B44D4 /* EventsPayload.swift in Sources */,
 				5E1CCC23287F052400913EEA /* UIViewExtension.swift in Sources */,
 				5ED4B9D02876E03B00CF044B /* FolderVO.swift in Sources */,
+				5E1017412DF1A6B80097A649 /* ScrollViewAppearanceManager.swift in Sources */,
 				F559F8A928FF02650015A522 /* APINetworkSession.swift in Sources */,
 				F5ADBF38290BBD110007A516 /* AccountEndpoint.swift in Sources */,
 				5ED4B9C22875378000CF044B /* TextStyle.swift in Sources */,

--- a/Permanent/Common/Base/SwiftUINavigationViews/CustomNavigationView.swift
+++ b/Permanent/Common/Base/SwiftUINavigationViews/CustomNavigationView.swift
@@ -23,7 +23,6 @@ struct CustomNavigationView<Content: View, LeftButton: View, RightButton: View>:
             NSAttributedString.Key.font: TextFontStyle.style51.font
         ]
         UINavigationBar.appearance().isTranslucent = false
-        UIScrollView.appearance().bounces = false
         
         if #available(iOS 15, *) {
             let navigationBarAppearance = UINavigationBarAppearance()
@@ -83,14 +82,18 @@ struct CustomNavigationView<Content: View, LeftButton: View, RightButton: View>:
             }
             .navigationBarTitleDisplayMode(.inline)
             .navigationViewStyle(StackNavigationViewStyle())
-        }.onAppear {
+        }
+        .onAppear {
             UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
             #if !canImport(ShareExtension)
             AppDelegate.orientationLock = .portrait
+            ScrollViewAppearanceManager.shared.pushScrollViewBounce(enabled: false, identifier: "CustomNavigationView")
             #endif
-        }.onDisappear {
+        }
+        .onDisappear {
             #if !canImport(ShareExtension)
             AppDelegate.orientationLock = .all
+            ScrollViewAppearanceManager.shared.popScrollViewBounce(identifier: "CustomNavigationView")
             #endif
         }
         .edgesIgnoringSafeArea(.all)

--- a/Permanent/Common/Base/SwiftUINavigationViews/SimpleCustomNavigationView.swift
+++ b/Permanent/Common/Base/SwiftUINavigationViews/SimpleCustomNavigationView.swift
@@ -24,8 +24,6 @@ struct SimpleCustomNavigationView<Content: View, LeftButton: View, RightButton: 
         self.textColor = textColor
         self.textStyle = textStyle
         self.showLeftChevron = showLeftChevron
-        
-        UIScrollView.appearance().bounces = false
     }
     
     var body: some View {
@@ -75,11 +73,13 @@ struct SimpleCustomNavigationView<Content: View, LeftButton: View, RightButton: 
             UIDevice.current.setValue(UIInterfaceOrientation.portrait.rawValue, forKey: "orientation")
             #if !canImport(ShareExtension)
             AppDelegate.orientationLock = .portrait
+            ScrollViewAppearanceManager.shared.pushScrollViewBounce(enabled: false, identifier: "SimpleCustomNavigationView")
             #endif
         }
         .onDisappear {
             #if !canImport(ShareExtension)
             AppDelegate.orientationLock = .all
+            ScrollViewAppearanceManager.shared.popScrollViewBounce(identifier: "SimpleCustomNavigationView")
             #endif
         }
         .edgesIgnoringSafeArea(.all)

--- a/Permanent/Common/Files/ViewModel/FilesViewModel.swift
+++ b/Permanent/Common/Files/ViewModel/FilesViewModel.swift
@@ -609,7 +609,7 @@ class FilesViewModel: NSObject, ViewModelInterface {
                 }
                 
                 if let archive = model.results[0].data?[0].archiveVO {
-                    AuthenticationManager.shared.session?.selectedArchive = archive
+                    AuthenticationManager.shared.updateSelectedArchive(archive)
                     
                     completion(true)
                 } else {

--- a/Permanent/Common/Helpers/ScrollViewAppearanceManager.swift
+++ b/Permanent/Common/Helpers/ScrollViewAppearanceManager.swift
@@ -1,0 +1,37 @@
+//
+//  ProfilePageData.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 05.06.2025.
+
+import UIKit
+
+class ScrollViewAppearanceManager {
+    static let shared = ScrollViewAppearanceManager()
+    private var appearanceStack: [(Bool, String)] = []
+    
+    private init() {}
+    
+    func pushScrollViewBounce(enabled: Bool, identifier: String) {
+        appearanceStack.append((enabled, identifier))
+        updateScrollViewBounce()
+    }
+    
+    func popScrollViewBounce(identifier: String) {
+        if let index = appearanceStack.lastIndex(where: { $0.1 == identifier }) {
+            appearanceStack.remove(at: index)
+            updateScrollViewBounce()
+        }
+    }
+    
+    private func updateScrollViewBounce() {
+        // If no settings are pushed, default to true (bouncing enabled)
+        let bounceEnabled = appearanceStack.last?.0 ?? true
+        UIScrollView.appearance().bounces = bounceEnabled
+    }
+    
+    func reset() {
+        appearanceStack.removeAll()
+        updateScrollViewBounce()
+    }
+} 

--- a/Permanent/Common/Models/Data/PublicProfile/ArchiveNameProfileItem.swift
+++ b/Permanent/Common/Models/Data/PublicProfile/ArchiveNameProfileItem.swift
@@ -1,0 +1,26 @@
+//
+//  ArchiveNameProfileItem.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 04.06.2025.
+import Foundation
+
+class ArchiveNameProfileItem: ProfileItemModel {
+    var archiveName: String? {
+        get {
+            return string1
+        }
+        set {
+            string1 = newValue
+        }
+    }
+    
+    init() {
+        super.init(fieldNameUI: FieldNameUI.basic.rawValue)
+        self.type = "type.profile_item.basic"
+    }
+    
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+}

--- a/Permanent/Common/Models/Data/PublicProfile/ProfileItemVO.swift
+++ b/Permanent/Common/Models/Data/PublicProfile/ProfileItemVO.swift
@@ -16,11 +16,12 @@ struct ProfileItemVO: Model {
     
     enum ItemCodingKeys: String, CodingKey {
         case fieldNameUI
+        case type
     }
     
     init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: Self.CodingKeys)
-        let profileItemContainer = try container.nestedContainer(keyedBy: Self.ItemCodingKeys, forKey: .profileItemVO)
+        let container = try decoder.container(keyedBy: Self.CodingKeys.self)
+        let profileItemContainer = try container.nestedContainer(keyedBy: Self.ItemCodingKeys.self, forKey: .profileItemVO)
         let fieldNameUI = try profileItemContainer.decode(String?.self, forKey: .fieldNameUI)
         
         switch fieldNameUI {
@@ -28,7 +29,12 @@ struct ProfileItemVO: Model {
             profileItemVO = try container.decode(BlurbProfileItem?.self, forKey: .profileItemVO)
             
         case FieldNameUI.basic.rawValue:
-            profileItemVO = try container.decode(BasicProfileItem?.self, forKey: .profileItemVO)
+            let type = try profileItemContainer.decode(String?.self, forKey: .type)
+            if type == "type.profile_item.basic" {
+                profileItemVO = try container.decode(ArchiveNameProfileItem?.self, forKey: .profileItemVO)
+            } else {
+                profileItemVO = try container.decode(BasicProfileItem?.self, forKey: .profileItemVO)
+            }
             
         case FieldNameUI.description.rawValue:
             profileItemVO = try container.decode(DescriptionProfileItem?.self, forKey: .profileItemVO)

--- a/Permanent/Common/Models/Enums/ArchiveType.swift
+++ b/Permanent/Common/Models/Enums/ArchiveType.swift
@@ -30,7 +30,7 @@ enum ArchiveType: String, CaseIterable, Identifiable {
         }
     }
     
-    var archiveName: String {
+    var archiveTypeName: String {
         switch self {
         case .person, .individual, .other, .unsure: return "Person".localized()
         case .family, .familyHistory: return "Family".localized()
@@ -68,7 +68,7 @@ enum ArchiveType: String, CaseIterable, Identifiable {
     }
     
     var aboutPublicPageTitle: String {
-        return "About This Archive".localized()
+        return "Archive information".localized()
     }
     var personalInformationPublicPageTitle: String {
         switch self {
@@ -87,22 +87,22 @@ enum ArchiveType: String, CaseIterable, Identifiable {
         return "What is this Archive for?".localized()
     }
     var shortDescriptionHint: String {
-        return "Add a short description about the purpose of this Archive".localized()
+        return "Add a description about this Archive".localized()
     }
     
     var longDescriptionTitle: String {
         switch self {
         case .person, .individual, .other, .unsure:
-            return "Tell us about this Person".localized()
+            return "Tell us the purpose of this Archive".localized()
             
         case .family, .familyHistory:
-            return "Tell us about this Family".localized()
+            return "Tell us the purpose of this Archive".localized()
             
         case .organization, .community:
-            return "Tell us about this Organization".localized()
+            return "Tell us the purpose of this Archive".localized()
             
         case .nonProfit:
-            return "Tell us about this nonprofit Organization".localized()
+            return "Tell us the purpose of this Archive".localized()
         }
     }
     var longDescriptionHint: String {

--- a/Permanent/Modules/Archives/Cells/ArchiveScreenChooseArchiveDetailsTableViewCell.xib
+++ b/Permanent/Modules/Archives/Cells/ArchiveScreenChooseArchiveDetailsTableViewCell.xib
@@ -72,7 +72,7 @@
                             <constraint firstItem="tHz-8X-Jhr" firstAttribute="leading" secondItem="SYv-es-Q6N" secondAttribute="leading" constant="15" id="3T9-ln-STr"/>
                             <constraint firstItem="ZV3-xF-Yyr" firstAttribute="centerY" secondItem="SYv-es-Q6N" secondAttribute="centerY" id="ByJ-u7-Hz1"/>
                             <constraint firstItem="IxC-2L-RBF" firstAttribute="height" secondItem="tHz-8X-Jhr" secondAttribute="height" multiplier="0.25" id="D16-fQ-BhV"/>
-                            <constraint firstAttribute="height" constant="80" id="K78-FK-Huh"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="80" priority="750" id="K78-FK-Huh"/>
                             <constraint firstItem="IxC-2L-RBF" firstAttribute="top" secondItem="tHz-8X-Jhr" secondAttribute="top" constant="2" id="fMY-uR-cfk"/>
                             <constraint firstItem="ZV3-xF-Yyr" firstAttribute="leading" secondItem="tHz-8X-Jhr" secondAttribute="trailing" constant="10" id="pAG-An-nKi"/>
                             <constraint firstItem="Mug-XK-ORg" firstAttribute="centerY" secondItem="SYv-es-Q6N" secondAttribute="centerY" id="uhs-cY-ROb"/>

--- a/Permanent/Modules/Archives/ViewController/ArchivesViewController.swift
+++ b/Permanent/Modules/Archives/ViewController/ArchivesViewController.swift
@@ -97,9 +97,9 @@ class ArchivesViewController: BaseViewController<ArchivesViewModel> {
     
     // MARK: - Actions
     @IBAction func createNewArchiveAction(_ sender: Any) {
-        var archiveTypes = ArchiveType.allCases.map{$0.archiveName}
+        var archiveTypes = ArchiveType.allCases.map{$0.archiveTypeName}
         
-        if let removeItemIdx = archiveTypes.firstIndex(of: ArchiveType.nonProfit.archiveName) {
+        if let removeItemIdx = archiveTypes.firstIndex(of: ArchiveType.nonProfit.archiveTypeName) {
             archiveTypes.remove(at: removeItemIdx)
         }
         

--- a/Permanent/Modules/Archives/ViewModel/ArchivesViewModel.swift
+++ b/Permanent/Modules/Archives/ViewModel/ArchivesViewModel.swift
@@ -145,6 +145,18 @@ class ArchivesViewModel: ViewModelInterface {
     func setCurrentArchive(_ archive: ArchiveVOData) {
         PermSession.currentSession?.selectedArchive = archive
         
+        // Save the session to persist the archive selection
+        if let session = PermSession.currentSession {
+            do {
+                try SessionKeychainHandler().saveSession(session)
+            } catch {
+                print("Failed to save session after archive change")
+            }
+        }
+        
+        // Post notification for UI updates
+        NotificationCenter.default.post(name: ArchivesViewModel.didChangeArchiveNotification, object: nil)
+        
         UploadManager.shared.timer?.fire()
     }
     

--- a/Permanent/Modules/Main/Navigation/Routers/SettingsRouter.swift
+++ b/Permanent/Modules/Main/Navigation/Routers/SettingsRouter.swift
@@ -31,6 +31,9 @@ class SettingsRouter {
     }
     
     func navigate(to page: Page, router: SettingsRouter) {
+        // Reset scroll view appearance before dismissing current screen
+        ScrollViewAppearanceManager.shared.reset()
+        
         if page != .settings {
             self.rootViewController.dismiss(animated: true)
         }
@@ -38,11 +41,11 @@ class SettingsRouter {
         switch page {
         case .settings:
             let screenView = SettingsScreenView(viewModel: StateObject(wrappedValue: SettingsScreenViewModel()), router: router)
-            var host = UIHostingController(rootView: screenView)
+            let host = UIHostingController(rootView: screenView)
             host.sheetPresentationController?.detents = [.large()]
             self.rootViewController.present(host, animated: true, completion: nil)
         case .account:
-            var infoRepresentable: AccountInfoViewControllerRepresentable = AccountInfoViewControllerRepresentable()
+            let infoRepresentable: AccountInfoViewControllerRepresentable = AccountInfoViewControllerRepresentable()
             let screenView = ViewRepresentableContainer(viewRepresentable: infoRepresentable, title: AccountInfoViewControllerRepresentable().title)
             let host = UIHostingController(rootView: screenView)
             host.modalPresentationStyle = .fullScreen

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -223,9 +223,8 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         collectionView.register(UINib(nibName: "FileCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: "FileCell")
         collectionView.register(UINib(nibName: "FileCollectionViewGridCell", bundle: nil), forCellWithReuseIdentifier: "FileGridCell")
         collectionView.register(FileCollectionViewHeaderCell.nib(), forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FileCollectionViewHeaderCell.identifier)
-        
         collectionView.refreshControl = refreshControl
-        collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: 140, right: 6)
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: UIScreen.main.bounds.width - 40, right: 6)
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 6
         flowLayout.minimumLineSpacing = 0
@@ -389,7 +388,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         collectionView.layoutIfNeeded()
         
         // Re-establish content insets to ensure proper scroll behavior
-        collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: 140, right: 6)
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: UIScreen.main.bounds.width, right: 6)
     }
     
     fileprivate func setupBottomActionSheetForMultipleFiles() {

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -224,6 +224,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         collectionView.register(UINib(nibName: "FileCollectionViewGridCell", bundle: nil), forCellWithReuseIdentifier: "FileGridCell")
         collectionView.register(FileCollectionViewHeaderCell.nib(), forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FileCollectionViewHeaderCell.identifier)
         collectionView.refreshControl = refreshControl
+        collectionView.showsVerticalScrollIndicator = false
         collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: UIScreen.main.bounds.width - 40, right: 6)
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 6
@@ -382,6 +383,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         // Reset collection view properties that might affect pull-to-refresh
         collectionView.alwaysBounceVertical = true
         collectionView.isScrollEnabled = true
+        collectionView.showsVerticalScrollIndicator = false
         
         // Force collection view layout update
         collectionView.setNeedsLayout()

--- a/Permanent/Modules/Main/ViewController/RootViewController.swift
+++ b/Permanent/Modules/Main/ViewController/RootViewController.swift
@@ -15,7 +15,7 @@ class RootViewController: UIViewController {
         if UIDevice.current.userInterfaceIdiom == .phone {
             return [.portrait]
         } else {
-            return [.all]
+            return [.landscape]
         }
     }
     

--- a/Permanent/Modules/ManageMembers/ViewModel/MembersViewModel.swift
+++ b/Permanent/Modules/ManageMembers/ViewModel/MembersViewModel.swift
@@ -140,7 +140,7 @@ class MembersViewModel: ViewModelInterface {
                 }
                 
                 if let archive = model.results[0].data?[0].archiveVO {
-                    AuthenticationManager.shared.session?.selectedArchive = archive
+                    AuthenticationManager.shared.updateSelectedArchive(archive)
                     completion(true)
                 } else {
                     completion(false)

--- a/Permanent/Modules/Onboarding/Screens/Welcome/OnboardingInvitedWelcomeViewModel.swift
+++ b/Permanent/Modules/Onboarding/Screens/Welcome/OnboardingInvitedWelcomeViewModel.swift
@@ -108,7 +108,7 @@ class OnboardingInvitedWelcomeViewModel: ObservableObject {
     }
     
     func setCurrentArchive(_ archive: ArchiveVOData) {
-        AuthenticationManager.shared.session?.selectedArchive = archive
+        AuthenticationManager.shared.updateSelectedArchive(archive)
     }
     
     func trackEvents() {

--- a/Permanent/Modules/PublicProfile/Cells/ProfilePageAboutCollectionViewCell.swift
+++ b/Permanent/Modules/PublicProfile/Cells/ProfilePageAboutCollectionViewCell.swift
@@ -11,17 +11,21 @@ class ProfilePageAboutCollectionViewCell: UICollectionViewCell {
     
     static let identifier = "ProfilePageAboutCollectionViewCell"
     
+    @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var contentLabel: UILabel!
     
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        contentLabel.text = ""
-        contentLabel.textColor = .middleGray
-        contentLabel.font = TextFontStyle.style8.font
+        titleLabel.textColor = .darkGray
+        titleLabel.font = TextFontStyle.style12.font
+        
+        contentLabel.textColor = .black
+        contentLabel.font = TextFontStyle.style13.font
     }
     
-    func configure(_ text: String?) {
+    func configure(_ title: String?, _ text: String?) {
+        titleLabel.text = title
         contentLabel.text = text
     }
     
@@ -29,10 +33,42 @@ class ProfilePageAboutCollectionViewCell: UICollectionViewCell {
         return UINib(nibName: identifier, bundle: nil)
     }
     
+    static func size(withTitle title: String?, withText text: String?, collectionView: UICollectionView) -> CGSize {
+        // Calculate the width available for text (collection view width minus 20pt margins on each side)
+        let availableWidth = collectionView.bounds.width - 40
+        
+        // Create attributed strings with the actual fonts used in the cell
+        let titleAttributedString = NSAttributedString(
+            string: title ?? "", 
+            attributes: [NSAttributedString.Key.font: TextFontStyle.style12.font as Any]
+        )
+        let contentAttributedString = NSAttributedString(
+            string: text ?? "", 
+            attributes: [NSAttributedString.Key.font: TextFontStyle.style13.font as Any]
+        )
+        
+        // Calculate height for title text
+        let titleHeight = titleAttributedString.boundingRect(
+            with: CGSize(width: availableWidth, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            context: nil
+        ).height.rounded(.up)
+        
+        // Calculate height for content text
+        let contentHeight = contentAttributedString.boundingRect(
+            with: CGSize(width: availableWidth, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            context: nil
+        ).height.rounded(.up)
+        
+        // Total height = title height + content height + vertical margins (10 + 5 + 10 = 25pt)
+        var totalHeight = titleHeight + contentHeight + 15
+        
+        return CGSize(width: collectionView.bounds.width, height: totalHeight)
+    }
+    
+    // Keep the old method for backward compatibility
     static func size(withText text: String?, collectionView: UICollectionView) -> CGSize {
-        let currentText: NSAttributedString = NSAttributedString(string: text ?? "", attributes: [NSAttributedString.Key.font: TextFontStyle.style8.font as Any])
-        let textHeight = currentText.boundingRect(with: CGSize(width: collectionView.bounds.width - 40, height: CGFloat.greatestFiniteMagnitude), options: [.usesLineFragmentOrigin, .usesFontLeading], context: nil).height.rounded(.up)
-
-        return CGSize(width: collectionView.bounds.width, height: textHeight + 20)
+        return size(withTitle: "Purpose", withText: text, collectionView: collectionView)
     }
 }

--- a/Permanent/Modules/PublicProfile/Cells/ProfilePageAboutCollectionViewCell.xib
+++ b/Permanent/Modules/PublicProfile/Cells/ProfilePageAboutCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,14 +11,20 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="ProfilePageAboutCollectionViewCell" customModule="Permanent" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="383" height="111"/>
+            <rect key="frame" x="0.0" y="0.0" width="365" height="146"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
-                <rect key="frame" x="0.0" y="0.0" width="383" height="111"/>
+                <rect key="frame" x="0.0" y="0.0" width="365" height="146"/>
                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DBn-zu-3Ae" userLabel="Title Label">
+                        <rect key="frame" x="20" y="10" width="325" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fyF-1j-G4y">
-                        <rect key="frame" x="20" y="10" width="343" height="91"/>
+                        <rect key="frame" x="20" y="36" width="325" height="110"/>
                         <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -27,14 +33,18 @@
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
+                <constraint firstItem="DBn-zu-3Ae" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="3Wg-aM-mKH"/>
+                <constraint firstAttribute="trailing" secondItem="DBn-zu-3Ae" secondAttribute="trailing" constant="20" id="6gf-VK-5P6"/>
                 <constraint firstAttribute="trailing" secondItem="fyF-1j-G4y" secondAttribute="trailing" constant="20" id="7LW-BF-4pB"/>
-                <constraint firstItem="fyF-1j-G4y" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="10" id="PwT-i9-F7e"/>
-                <constraint firstAttribute="bottom" secondItem="fyF-1j-G4y" secondAttribute="bottom" constant="10" id="VCV-dL-Fxw"/>
+                <constraint firstItem="fyF-1j-G4y" firstAttribute="top" secondItem="DBn-zu-3Ae" secondAttribute="bottom" constant="5" id="PwT-i9-F7e"/>
+                <constraint firstItem="DBn-zu-3Ae" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="10" id="SAL-ms-R1u"/>
+                <constraint firstAttribute="bottom" secondItem="fyF-1j-G4y" secondAttribute="bottom" id="VCV-dL-Fxw"/>
                 <constraint firstItem="fyF-1j-G4y" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="vNa-ks-Veo"/>
             </constraints>
             <size key="customSize" width="383" height="111"/>
             <connections>
                 <outlet property="contentLabel" destination="fyF-1j-G4y" id="jlO-DG-Jjd"/>
+                <outlet property="titleLabel" destination="DBn-zu-3Ae" id="bG6-rz-YHT"/>
             </connections>
             <point key="canvasLocation" x="-73.188405797101453" y="57.924107142857139"/>
         </collectionViewCell>

--- a/Permanent/Modules/PublicProfile/Cells/ProfilePageFooterCollectionViewCell.xib
+++ b/Permanent/Modules/PublicProfile/Cells/ProfilePageFooterCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,7 +22,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="833" height="131"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wjm-bB-KBd">
-                                <rect key="frame" x="20" y="10" width="53" height="22"/>
+                                <rect key="frame" x="20" y="10" width="61" height="25.5"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Button">
                                     <directionalEdgeInsets key="contentInsets" top="0.0" leading="0.0" bottom="5" trailing="10"/>

--- a/Permanent/Modules/PublicProfile/Cells/ProfilePageInformationCollectionViewCell.xib
+++ b/Permanent/Modules/PublicProfile/Cells/ProfilePageInformationCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,12 +33,15 @@
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
+                <constraint firstItem="eLD-02-WZY" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="20" id="PQX-dR-GcP"/>
                 <constraint firstAttribute="bottom" secondItem="YZW-dm-O0w" secondAttribute="bottom" constant="10" id="VH2-BK-s3l"/>
                 <constraint firstItem="YZW-dm-O0w" firstAttribute="trailing" secondItem="eLD-02-WZY" secondAttribute="trailing" id="YNk-v3-bAx"/>
                 <constraint firstItem="eLD-02-WZY" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="5" id="YTD-XI-CGW"/>
                 <constraint firstItem="YZW-dm-O0w" firstAttribute="top" secondItem="eLD-02-WZY" secondAttribute="bottom" constant="5" id="cn1-ZD-x8f"/>
                 <constraint firstItem="YZW-dm-O0w" firstAttribute="leading" secondItem="eLD-02-WZY" secondAttribute="leading" id="ky1-ST-rlo"/>
                 <constraint firstItem="eLD-02-WZY" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="lDu-t0-gIy"/>
+                <constraint firstItem="eLD-02-WZY" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="mow-D6-clW"/>
+                <constraint firstAttribute="trailing" secondItem="eLD-02-WZY" secondAttribute="trailing" constant="20" id="plb-6B-D8Q"/>
                 <constraint firstAttribute="trailing" secondItem="eLD-02-WZY" secondAttribute="trailing" constant="20" id="qRg-B7-Paa"/>
             </constraints>
             <size key="customSize" width="365" height="146"/>

--- a/Permanent/Modules/PublicProfile/Cells/ProfilePageInformationCollectionViewCell.xib
+++ b/Permanent/Modules/PublicProfile/Cells/ProfilePageInformationCollectionViewCell.xib
@@ -33,16 +33,13 @@
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
-                <constraint firstItem="eLD-02-WZY" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="20" id="PQX-dR-GcP"/>
                 <constraint firstAttribute="bottom" secondItem="YZW-dm-O0w" secondAttribute="bottom" constant="10" id="VH2-BK-s3l"/>
                 <constraint firstItem="YZW-dm-O0w" firstAttribute="trailing" secondItem="eLD-02-WZY" secondAttribute="trailing" id="YNk-v3-bAx"/>
                 <constraint firstItem="eLD-02-WZY" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="5" id="YTD-XI-CGW"/>
                 <constraint firstItem="YZW-dm-O0w" firstAttribute="top" secondItem="eLD-02-WZY" secondAttribute="bottom" constant="5" id="cn1-ZD-x8f"/>
                 <constraint firstItem="YZW-dm-O0w" firstAttribute="leading" secondItem="eLD-02-WZY" secondAttribute="leading" id="ky1-ST-rlo"/>
                 <constraint firstItem="eLD-02-WZY" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="lDu-t0-gIy"/>
-                <constraint firstItem="eLD-02-WZY" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="20" id="mow-D6-clW"/>
                 <constraint firstAttribute="trailing" secondItem="eLD-02-WZY" secondAttribute="trailing" constant="20" id="plb-6B-D8Q"/>
-                <constraint firstAttribute="trailing" secondItem="eLD-02-WZY" secondAttribute="trailing" constant="20" id="qRg-B7-Paa"/>
             </constraints>
             <size key="customSize" width="365" height="146"/>
             <connections>

--- a/Permanent/Modules/PublicProfile/ViewController/PublicArchiveFileViewController.swift
+++ b/Permanent/Modules/PublicProfile/ViewController/PublicArchiveFileViewController.swift
@@ -290,7 +290,9 @@ extension PublicArchiveFileViewController: UICollectionViewDelegateFlowLayout, U
     }
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        // Always try to pass scroll to parent first, let parent decide if it should handle it
         if delegate?.childVC(self, didScrollToOffset: scrollView.contentOffset) ?? false {
+            // Parent handled the scroll, reset our offset
             scrollView.contentOffset.y = 0
         }
     }

--- a/Permanent/Modules/PublicProfile/ViewController/PublicProfileAboutPageViewController.swift
+++ b/Permanent/Modules/PublicProfile/ViewController/PublicProfileAboutPageViewController.swift
@@ -16,6 +16,8 @@ class PublicProfileAboutPageViewController: BaseViewController<PublicProfilePage
     @IBOutlet weak var shortDescriptionEmptyLabel: UILabel!
     @IBOutlet weak var longDescriptionEmptyLabel: UILabel!
     
+    @IBOutlet weak var archiveNameLabel: UILabel!
+    @IBOutlet weak var archiveNameTextField: UITextField!
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -64,6 +66,12 @@ class PublicProfileAboutPageViewController: BaseViewController<PublicProfilePage
         longAboutDescriptionTextView.textColor = .middleGray
         longAboutDescriptionTextView.font = TextFontStyle.style7.font
         
+        archiveNameTextField.layer.borderColor = UIColor.lightGray.cgColor
+        archiveNameTextField.layer.borderWidth = 0.5
+        archiveNameTextField.layer.cornerRadius = 3
+        archiveNameTextField.textColor = .middleGray
+        archiveNameTextField.font = TextFontStyle.style7.font
+        
         shortDescriptionEmptyLabel.textColor = .lightGray
         shortDescriptionEmptyLabel.font = TextFontStyle.style8.font
         shortDescriptionEmptyLabel.textAlignment = .left
@@ -72,14 +80,22 @@ class PublicProfileAboutPageViewController: BaseViewController<PublicProfilePage
         longDescriptionEmptyLabel.font = TextFontStyle.style8.font
         longDescriptionEmptyLabel.textAlignment = .left
         
+        archiveNameLabel.textColor = .middleGray
+        archiveNameLabel.font = TextFontStyle.style12.font
+        
         shortAboutDescriptionTitleLabel.textColor = .middleGray
         shortAboutDescriptionTitleLabel.font = TextFontStyle.style12.font
         
         longAboutDescriptionTitleLabel.textColor = .middleGray
         longAboutDescriptionTitleLabel.font = TextFontStyle.style12.font
         
+        archiveNameLabel.text = "Archive Name"
         shortAboutDescriptionTitleLabel.text = "\(viewModel?.archiveType.shortDescriptionTitle ?? "") (<COUNT>/200)".localized().replacingOccurrences(of: "<COUNT>", with: "\(viewModel?.blurbProfileItem?.shortDescription?.count ?? 0)")
         shortDescriptionEmptyLabel.text = viewModel?.archiveType.shortDescriptionHint
+        
+        if let archiveName = viewModel?.archiveNameProfileItem?.archiveName {
+            archiveNameTextField.text = archiveName
+        }
         
         if let shortDescription = viewModel?.blurbProfileItem?.shortDescription {
             shortAboutDescriptionTextField.text = shortDescription
@@ -103,11 +119,33 @@ class PublicProfileAboutPageViewController: BaseViewController<PublicProfilePage
         dismiss(animated: true)
     }
     @objc func doneButtonAction(_ sender: Any) {
-        var publicProfileUpdateIsSuccessfully: (Bool, Bool) = (true, true)
+        var publicProfileUpdateIsSuccessfully: (Bool, Bool, Bool) = (true, true, true)
         
         let group = DispatchGroup()
         
         showSpinner()
+        
+        if let archiveNameTextField = archiveNameTextField.text {
+            if archiveNameTextField != viewModel?.archiveNameProfileItem?.archiveName && archiveNameTextField.count <= 30 {
+                if !archiveNameTextField.isEmpty {
+                        group.enter()
+                        viewModel?.renameArchiveNameProfileItem(profileItemId: viewModel?.archiveNameProfileItem?.profileItemId ,newValue: archiveNameTextField, { result, error, itemId in
+                            if result {
+                                self.viewModel?.archiveNameProfileItem?.profileItemId = itemId
+                                AuthenticationManager.shared.reloadSession { _ in
+                                    
+                                }
+                            } else {
+                                self.showErrorAlert(message: .errorMessage)
+                                publicProfileUpdateIsSuccessfully.2 = false
+                            }
+                            group.leave()
+                        })
+                } else {
+                    self.archiveNameTextField.text = viewModel?.archiveData.fullName
+                }
+            }
+        }
              
         if let shortTextField = shortAboutDescriptionTextField.text {
             if shortTextField != viewModel?.blurbProfileItem?.shortDescription {
@@ -175,7 +213,7 @@ class PublicProfileAboutPageViewController: BaseViewController<PublicProfilePage
         
         group.notify(queue: DispatchQueue.main) {
             self.hideSpinner()
-            if publicProfileUpdateIsSuccessfully == (true, true) {
+            if publicProfileUpdateIsSuccessfully == (true, true, true) {
                 self.dismiss(animated: true)
             }
         }

--- a/Permanent/Modules/PublicProfile/ViewController/PublicProfilePageViewController.swift
+++ b/Permanent/Modules/PublicProfile/ViewController/PublicProfilePageViewController.swift
@@ -22,6 +22,7 @@ enum ProfileCellType {
     case establishedLocation
     case milestone
     case archiveGallery
+    case archiveName
 }
 
 enum ProfileSection: Int {
@@ -63,8 +64,13 @@ class PublicProfilePageViewController: BaseViewController<PublicProfilePageViewM
         initCollectionView()
         
         NotificationCenter.default.addObserver(forName: PublicProfilePageViewModel.profileItemsUpdatedNotificationName, object: nil, queue: nil) { [weak self] notification in
-            self?.refreshProfileViewData()
+            if let archiveData = self?.archiveData {
+                self?.getAllByArchiveNbr(archiveData)
+            }
             self?.collectionView.reloadData()
+            
+            // Update AuthenticationManager session when archive name changes
+            self?.handleArchiveNameChange()
         }
     }
     
@@ -142,6 +148,14 @@ class PublicProfilePageViewController: BaseViewController<PublicProfilePageViewM
             if error == nil {
                 refreshProfileViewData()
                 
+                // Update title after data is refreshed
+                DispatchQueue.main.async { [weak self] in
+                    if let archiveName = self?.viewModel?.archiveNameProfileItem?.archiveName {
+                        let newTitle = "The <ARCHIVE_NAME> Archive".localized().replacingOccurrences(of: "<ARCHIVE_NAME>", with: archiveName)
+                        self?.title = newTitle
+                    }
+                }
+                
                 collectionView.reloadData()
             } else {
                 showAlert(title: .error, message: .errorMessage)
@@ -151,6 +165,83 @@ class PublicProfilePageViewController: BaseViewController<PublicProfilePageViewM
     
     func refreshProfileViewData() {
         profileViewData = viewModel?.getProfileViewData() ?? [:]
+    }
+    
+    func handleArchiveNameChange() {
+        if let updatedArchiveName = self.viewModel?.archiveNameProfileItem?.archiveName,
+           let currentArchive = AuthenticationManager.shared.session?.selectedArchive,
+           currentArchive.fullName != updatedArchiveName {
+            
+            // Create updated archive data
+            let updatedArchive = createUpdatedArchive(from: currentArchive, withNewName: updatedArchiveName)
+            
+            // Update the session
+            AuthenticationManager.shared.session?.selectedArchive = updatedArchive
+            AuthenticationManager.shared.saveSession()
+            
+            // Update local archive data
+            self.archiveData = updatedArchive
+            self.viewModel?.archiveData = updatedArchive
+            
+            // Post notification to update other parts of the app (like side menu)
+            NotificationCenter.default.post(name: Notification.Name("ArchivesViewModel.didChangeArchiveNotification"), object: nil, userInfo: nil)
+        }
+    }
+    
+    private func createUpdatedArchive(from currentArchive: ArchiveVOData, withNewName newName: String) -> ArchiveVOData {
+        return ArchiveVOData(
+            childFolderVOS: currentArchive.childFolderVOS,
+            folderSizeVOS: currentArchive.folderSizeVOS,
+            recordVOS: currentArchive.recordVOS,
+            accessRole: currentArchive.accessRole,
+            fullName: newName,
+            spaceTotal: currentArchive.spaceTotal,
+            spaceLeft: currentArchive.spaceLeft,
+            fileTotal: currentArchive.fileTotal,
+            fileLeft: currentArchive.fileLeft,
+            relationType: currentArchive.relationType,
+            homeCity: currentArchive.homeCity,
+            homeState: currentArchive.homeState,
+            homeCountry: currentArchive.homeCountry,
+            itemVOS: currentArchive.itemVOS,
+            birthDay: currentArchive.birthDay,
+            company: currentArchive.company,
+            archiveVODescription: currentArchive.archiveVODescription,
+            archiveID: currentArchive.archiveID,
+            publicDT: currentArchive.publicDT,
+            archiveNbr: currentArchive.archiveNbr,
+            view: currentArchive.view,
+            viewProperty: currentArchive.viewProperty,
+            archiveVOPublic: currentArchive.archiveVOPublic,
+            vaultKey: currentArchive.vaultKey,
+            thumbArchiveNbr: currentArchive.thumbArchiveNbr,
+            type: currentArchive.type,
+            thumbStatus: currentArchive.thumbStatus,
+            imageRatio: currentArchive.imageRatio,
+            thumbURL200: currentArchive.thumbURL200,
+            thumbURL500: currentArchive.thumbURL500,
+            thumbURL1000: currentArchive.thumbURL1000,
+            thumbURL2000: currentArchive.thumbURL2000,
+            thumbDT: currentArchive.thumbDT,
+            createdDT: currentArchive.createdDT,
+            updatedDT: currentArchive.updatedDT,
+            status: currentArchive.status
+        )
+    }
+    
+    func handleArchiveChange(newArchiveData: ArchiveVOData) {
+        // Update the archive data
+        self.archiveData = newArchiveData
+        self.viewModel?.archiveData = newArchiveData
+        
+        // Clear existing profile view data to prevent inconsistencies
+        self.profileViewData.removeAll()
+        
+        // Reset button states for new archive
+        initButtonStates()
+        
+        // Refresh with new archive data
+        getAllByArchiveNbr(newArchiveData)
     }
 }
 
@@ -162,7 +253,7 @@ extension PublicProfilePageViewController: UICollectionViewDataSource {
         
         switch currentSection {
         case .about:
-            return (readMoreIsEnabled[.about] ?? false) ? profileViewData[.about]!.count : min(profileViewData[.about]!.count, 1)
+            return (readMoreIsEnabled[.about] ?? false) ? profileViewData[.about]!.count : min(profileViewData[.about]!.count, viewModel?.isEditDataEnabled ?? true ? 2 : 1)
             
         case .onlinePresenceEmail:
             let rowCount = profileViewData[currentSection]?.count ?? 0
@@ -217,20 +308,31 @@ extension PublicProfilePageViewController: UICollectionViewDataSource {
                 })
             }
             returnedCell = cell
+        case .archiveName:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfilePageAboutCollectionViewCell.identifier, for: indexPath) as! ProfilePageAboutCollectionViewCell
+            let title = "Name"
+            let text = viewModel?.archiveNameProfileItem?.archiveName ?? ""
+            
+            cell.configure(title, text)
+
+            returnedCell = cell
+            
             
         case .blurb:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfilePageAboutCollectionViewCell.identifier, for: indexPath) as! ProfilePageAboutCollectionViewCell
-            let shortDescriptionValue = viewModel?.blurbProfileItem?.shortDescription
+            let title = "About"
+            let text = viewModel?.blurbProfileItem?.shortDescription ?? (viewModel?.archiveType.shortDescriptionHint)!
             
-            cell.configure(shortDescriptionValue ?? viewModel?.archiveType.shortDescriptionHint)
+            cell.configure(title, text)
 
             returnedCell = cell
             
         case .longDescription:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ProfilePageAboutCollectionViewCell.identifier, for: indexPath) as! ProfilePageAboutCollectionViewCell
-            let longDescriptionValue = viewModel?.descriptionProfileItem?.longDescription
+            let title = "Purpose"
+            let text = viewModel?.descriptionProfileItem?.longDescription ?? (viewModel?.archiveType.longDescriptionHint)!
             
-            cell.configure(longDescriptionValue ?? viewModel?.archiveType.longDescriptionHint)
+            cell.configure(title, text)
 
             returnedCell = cell
             
@@ -323,7 +425,7 @@ extension PublicProfilePageViewController: UICollectionViewDataSource {
                 headerCell.configure(titleLabel: "Archive", buttonText: "Share")
                 
             case .about:
-                headerCell.configure(titleLabel: "About".localized(), buttonText: "Edit".localized(), buttonIsHidden: !isEditDataEnabled)
+                headerCell.configure(titleLabel: "Archive Information".localized(), buttonText: "Edit".localized(), buttonIsHidden: !isEditDataEnabled)
                 
                 headerCell.buttonAction = { [weak self] in
                     let profileAboutVC = UIViewController.create(withIdentifier: .profileAboutPage, from: .profile) as! PublicProfileAboutPageViewController
@@ -439,13 +541,20 @@ extension PublicProfilePageViewController: UICollectionViewDelegateFlowLayout {
         case .profileVisibility:
             return CGSize(width: UIScreen.main.bounds.width, height: 80)
             
+        case .archiveName:
+            let title = "Name"
+            let text = viewModel?.archiveData.fullName ?? ""
+            return ProfilePageAboutCollectionViewCell.size(withTitle: title, withText: text, collectionView: collectionView)
+            
         case .blurb:
+            let title = "About"
             let text = viewModel?.blurbProfileItem?.shortDescription ?? (viewModel?.archiveType.shortDescriptionHint)!
-            return ProfilePageAboutCollectionViewCell.size(withText: text, collectionView: collectionView)
+            return ProfilePageAboutCollectionViewCell.size(withTitle: title, withText: text, collectionView: collectionView)
             
         case .longDescription:
+            let title = "Purpose"
             let text = viewModel?.descriptionProfileItem?.longDescription ?? (viewModel?.archiveType.longDescriptionHint)!
-            return ProfilePageAboutCollectionViewCell.size(withText: text, collectionView: collectionView)
+            return ProfilePageAboutCollectionViewCell.size(withTitle: title, withText: text, collectionView: collectionView)
 
         case .fullName, .nickName, .gender, .birthDate, .birthLocation, .establishedDate, .establishedLocation:
             return ProfilePageInformationCollectionViewCell.size(collectionView: collectionView)

--- a/Permanent/Modules/PublicProfile/ViewModel/PublicProfilePageViewModel.swift
+++ b/Permanent/Modules/PublicProfile/ViewModel/PublicProfilePageViewModel.swift
@@ -18,6 +18,9 @@ class PublicProfilePageViewModel: ViewModelInterface {
     
     var profileItems = [ProfileItemModel]()
     
+    var archiveNameProfileItem: ArchiveNameProfileItem? {
+        return profileItems.first(where: {$0 is ArchiveNameProfileItem}) as? ArchiveNameProfileItem
+    }
     var blurbProfileItem: BlurbProfileItem? {
         return profileItems.first(where: {$0 is BlurbProfileItem}) as? BlurbProfileItem
     }
@@ -82,13 +85,14 @@ class PublicProfilePageViewModel: ViewModelInterface {
         }
         
         var aboutCells = [ProfileCellType]()
+
         if blurbProfileItem?.shortDescription?.isNotEmpty ?? false {
             aboutCells.append(.blurb)
         }
         if descriptionProfileItem?.longDescription?.isNotEmpty ?? false {
             aboutCells.append(.longDescription)
         }
-        profileViewData[.about] = isEditDataEnabled ? [ProfileCellType.blurb, ProfileCellType.longDescription] : aboutCells
+        profileViewData[.about] = isEditDataEnabled ? [ProfileCellType.archiveName,  ProfileCellType.blurb, ProfileCellType.longDescription] : aboutCells
         
         var informationCells = [ProfileCellType]()
         if basicProfileItem?.fullName?.isNotEmpty ?? false {
@@ -267,6 +271,15 @@ class PublicProfilePageViewModel: ViewModelInterface {
         newBlurbItem.profileItemId = profileItemId
         
         modifyPublicProfileItem(newBlurbItem, operationType, completionBlock)
+    }
+    
+    func renameArchiveNameProfileItem(profileItemId: Int? = nil, newValue: String, _ completionBlock: @escaping ((Bool, Error?, Int?) -> Void)) {
+        let newArchiveNameItem = ArchiveNameProfileItem()
+        newArchiveNameItem.archiveName = newValue
+        newArchiveNameItem.archiveId = archiveData.archiveID
+        newArchiveNameItem.profileItemId = profileItemId
+        
+        modifyPublicProfileItem(newArchiveNameItem, .update, completionBlock)
     }
     
     func modifyDescriptionProfileItem(profileItemId: Int? = nil, newValue: String, operationType: ProfileItemOperation, _ completionBlock: @escaping ((Bool, Error?, Int?) -> Void)) {

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -192,6 +192,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         collectionView.register(FileCollectionViewHeaderCell.nib(), forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FileCollectionViewHeaderCell.identifier)
         
         collectionView.refreshControl = refreshControl
+        collectionView.showsVerticalScrollIndicator = false
         collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: UIScreen.main.bounds.width - 40, right: 6)
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 6

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -192,7 +192,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         collectionView.register(FileCollectionViewHeaderCell.nib(), forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FileCollectionViewHeaderCell.identifier)
         
         collectionView.refreshControl = refreshControl
-        collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: 140, right: 6)
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: UIScreen.main.bounds.width - 40, right: 6)
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 6
         flowLayout.minimumLineSpacing = 0

--- a/Permanent/Modules/SideMenus/Views/SettingsScreenView.swift
+++ b/Permanent/Modules/SideMenus/Views/SettingsScreenView.swift
@@ -98,11 +98,11 @@ struct SettingsScreenView: View {
                             }
                         }
                         .onAppear {
-                            UIScrollView.appearance().bounces = false
+                            ScrollViewAppearanceManager.shared.pushScrollViewBounce(enabled: false, identifier: "SettingsScreen")
                             viewModel.trackEvents()
                         }
                         .onDisappear {
-                            UIScrollView.appearance().bounces = true
+                            ScrollViewAppearanceManager.shared.popScrollViewBounce(identifier: "SettingsScreen")
                         }
                         Divider()
                             .padding(.horizontal, -40)

--- a/Permanent/Resources/Storyboards/Profile.storyboard
+++ b/Permanent/Resources/Storyboards/Profile.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -335,40 +335,40 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g8Q-1C-w6c">
-                                <rect key="frame" x="20" y="68" width="42" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="g94-ye-7Z9">
-                                <rect key="frame" x="20" y="99" width="374" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lum-ya-iBb">
                                 <rect key="frame" x="20" y="153" width="42" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="g94-ye-7Z9">
+                                <rect key="frame" x="20" y="184" width="374" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lum-ya-iBb">
+                                <rect key="frame" x="20" y="238" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="l6p-f4-q2c">
-                                <rect key="frame" x="20" y="184" width="374" height="250"/>
+                                <rect key="frame" x="20" y="269" width="374" height="180"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="250" id="U90-sd-Tro"/>
+                                    <constraint firstAttribute="height" constant="180" id="U90-sd-Tro"/>
                                 </constraints>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8dv-Ut-6xC">
-                                <rect key="frame" x="24" y="99" width="368" height="34"/>
+                                <rect key="frame" x="24" y="184" width="368" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PII-UI-CPm">
-                                <rect key="frame" x="24" y="184" width="368" height="34"/>
+                                <rect key="frame" x="24" y="269" width="368" height="34"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="34" id="vYz-KZ-18l"/>
                                 </constraints>
@@ -376,31 +376,49 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eY2-AY-yeG">
+                                <rect key="frame" x="20" y="68" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Lpv-Qf-lcg">
+                                <rect key="frame" x="20" y="99" width="374" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="if5-IC-3YF"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="if5-IC-3YF" firstAttribute="trailing" secondItem="8dv-Ut-6xC" secondAttribute="trailing" constant="22" id="7bc-np-TBm"/>
                             <constraint firstItem="g94-ye-7Z9" firstAttribute="top" secondItem="g8Q-1C-w6c" secondAttribute="bottom" constant="10" id="Bec-1I-0qI"/>
-                            <constraint firstItem="g8Q-1C-w6c" firstAttribute="top" secondItem="if5-IC-3YF" secondAttribute="top" constant="20" id="C4c-zZ-Mrb"/>
+                            <constraint firstItem="g8Q-1C-w6c" firstAttribute="top" secondItem="Lpv-Qf-lcg" secondAttribute="bottom" constant="20" id="C4c-zZ-Mrb"/>
                             <constraint firstItem="l6p-f4-q2c" firstAttribute="top" secondItem="lum-ya-iBb" secondAttribute="bottom" constant="10" id="CAj-DJ-6Gu"/>
                             <constraint firstItem="lum-ya-iBb" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="20" id="LCo-fV-MM5"/>
                             <constraint firstItem="if5-IC-3YF" firstAttribute="trailing" secondItem="g94-ye-7Z9" secondAttribute="trailing" constant="20" id="Lu0-Hh-Gfi"/>
                             <constraint firstItem="lum-ya-iBb" firstAttribute="top" secondItem="g94-ye-7Z9" secondAttribute="bottom" constant="20" id="QNm-cM-3l5"/>
                             <constraint firstItem="PII-UI-CPm" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="24" id="Y7D-50-R38"/>
+                            <constraint firstItem="eY2-AY-yeG" firstAttribute="top" secondItem="if5-IC-3YF" secondAttribute="top" constant="20" id="ZIg-om-9JY"/>
                             <constraint firstItem="g8Q-1C-w6c" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="20" id="cWv-g0-B3I"/>
                             <constraint firstItem="if5-IC-3YF" firstAttribute="trailing" secondItem="PII-UI-CPm" secondAttribute="trailing" constant="22" id="glM-V7-SSH"/>
                             <constraint firstItem="l6p-f4-q2c" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="20" id="i5s-q3-Rlu"/>
                             <constraint firstItem="PII-UI-CPm" firstAttribute="top" secondItem="l6p-f4-q2c" secondAttribute="top" id="o24-i9-1q8"/>
+                            <constraint firstItem="eY2-AY-yeG" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="20" id="o2K-ad-zJm"/>
                             <constraint firstItem="if5-IC-3YF" firstAttribute="trailing" secondItem="l6p-f4-q2c" secondAttribute="trailing" constant="20" id="uKB-pa-KVu"/>
                             <constraint firstItem="g94-ye-7Z9" firstAttribute="bottom" secondItem="8dv-Ut-6xC" secondAttribute="bottom" id="uup-4o-gwv"/>
+                            <constraint firstItem="if5-IC-3YF" firstAttribute="trailing" secondItem="Lpv-Qf-lcg" secondAttribute="trailing" constant="20" id="wdy-6L-eqV"/>
+                            <constraint firstItem="Lpv-Qf-lcg" firstAttribute="top" secondItem="eY2-AY-yeG" secondAttribute="bottom" constant="10" id="whi-iF-0hH"/>
                             <constraint firstItem="g94-ye-7Z9" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="20" id="wlQ-xh-rK2"/>
+                            <constraint firstItem="Lpv-Qf-lcg" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="20" id="yLp-Nl-iwi"/>
                             <constraint firstItem="8dv-Ut-6xC" firstAttribute="top" secondItem="g94-ye-7Z9" secondAttribute="top" id="z4n-2B-B9x"/>
                             <constraint firstItem="8dv-Ut-6xC" firstAttribute="leading" secondItem="if5-IC-3YF" secondAttribute="leading" constant="24" id="zBg-xa-nIM"/>
                         </constraints>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <connections>
+                        <outlet property="archiveNameLabel" destination="eY2-AY-yeG" id="GAB-wh-1ny"/>
+                        <outlet property="archiveNameTextField" destination="Lpv-Qf-lcg" id="Tsh-Ng-bds"/>
                         <outlet property="longAboutDescriptionTextView" destination="l6p-f4-q2c" id="i60-zi-J5t"/>
                         <outlet property="longAboutDescriptionTitleLabel" destination="lum-ya-iBb" id="exA-rH-1Ns"/>
                         <outlet property="longDescriptionEmptyLabel" destination="PII-UI-CPm" id="Pur-6a-6eZ"/>
@@ -780,20 +798,20 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="linkCell" id="SpH-eY-TUF" customClass="OnlinePresenceTableViewCell" customModule="Permanent" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="414" height="63"/>
+                                        <rect key="frame" x="0.0" y="50" width="414" height="63.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SpH-eY-TUF" id="hpS-Kn-PpP">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="63"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="63.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="blr-Sd-wYX">
-                                                    <rect key="frame" x="20" y="21" width="42" height="21"/>
+                                                    <rect key="frame" x="20" y="21" width="42" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0WU-RV-3m7">
-                                                    <rect key="frame" x="376" y="0.0" width="28" height="63"/>
+                                                    <rect key="frame" x="376" y="0.0" width="28" height="63.5"/>
                                                     <state key="normal" title="Button"/>
                                                     <buttonConfiguration key="configuration" style="plain" image="more"/>
                                                     <connections>
@@ -1100,24 +1118,13 @@
             <point key="canvasLocation" x="1061" y="819"/>
         </scene>
     </scenes>
-    <designables>
-        <designable name="Atj-6Q-xMF">
-            <size key="intrinsicContentSize" width="30" height="30"/>
-        </designable>
-        <designable name="FrO-KT-apn">
-            <size key="intrinsicContentSize" width="30" height="30"/>
-        </designable>
-        <designable name="qto-zC-zA8">
-            <size key="intrinsicContentSize" width="30" height="30"/>
-        </designable>
-    </designables>
     <resources>
         <image name="cameraIcon" width="96" height="96"/>
         <image name="chevron.left" width="13" height="21"/>
         <image name="link" catalog="system" width="128" height="124"/>
         <image name="more" width="4" height="16"/>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Added Archive Profile Enhancements and UI Fixes

Key Changes:
- Added a new text field for changing archive name from Archive profile view
- Archive name changes are now reflected throughout the application
- Archive profile automatically reloads and scrolls to top when archive is changed

Bug Fixes:
- Fixed crash when changing archive while archive profile was selected
- Fixed FABview not showing after changing the archive
- Fixed size adjustment warning when entering ArchivesViewController
- Fixed RootViewController's landscape mode settings
- Fixed UIKit scroll view bounce functionality after navigating from SettingsView
- Fixed gesture handling for public profile archive viewing

UI Improvements:
- Added bottom spacing in private, shared, and public workspaces to improve access to options button for last item
- Removed vertical scroll indicator for file workspaces