### PR TITLE
VSP-1632[iOS][Mobile] Share preview remove request access if the file is shared by current user

### DIFF
--- a/Permanent/App/AppDelegate.swift
+++ b/Permanent/App/AppDelegate.swift
@@ -147,7 +147,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     }
                 }
                         
-                    case .error(let error, _):
+                    case .error(_, _):
                         break
                         
                     default:
@@ -279,9 +279,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     fileprivate func configureLogging() {
         #if STAGING_ENVIRONMENT
-            NetworkLogger.configuration.logLevel = .debug
-            NetworkLogger.configuration.environmentRestriction = nil // Log in all environments
-            NetworkLogger.configuration.logBodies = true
             NetworkLogger.enableLogging()
         #else
              NetworkLogger.disableLogging()
@@ -312,13 +309,32 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         viewModel.urlToken = url.lastPathComponent
         sharePreviewVC.viewModel = viewModel
         
-        rootViewController.navigateTo(viewController: sharePreviewVC)
-        
         sharePreviewVC.navigateTo = { [weak self] params in
             self?.navigateToFolder(params: params)
         }
         
+        // Dismiss any presented SwiftUI views or modal controllers before navigating
+        dismissPresentedViewsAndNavigate(to: sharePreviewVC)
+        
         return true
+    }
+    
+    private func dismissPresentedViewsAndNavigate(to viewController: UIViewController) {
+        // Find the topmost presented view controller
+        var topMostPresentedVC: UIViewController = rootViewController
+        while let presentedVC = topMostPresentedVC.presentedViewController {
+            topMostPresentedVC = presentedVC
+        }
+        
+        // If we found any presented view controllers, dismiss from the root
+        if topMostPresentedVC != rootViewController {
+            rootViewController.dismiss(animated: true) { [weak self] in
+                self?.rootViewController.navigateTo(viewController: viewController)
+            }
+        } else {
+            // No presented view controllers, navigate directly
+            rootViewController.navigateTo(viewController: viewController)
+        }
     }
     
     fileprivate func navigateToFolder(params: NavigateMinParams) {

--- a/Permanent/Common/Helpers/NetworkLogger.swift
+++ b/Permanent/Common/Helpers/NetworkLogger.swift
@@ -69,6 +69,9 @@ class NetworkLogger {
     
     /// Enable network logging with default settings
     static func enableLogging() {
+        NetworkLogger.configuration.logLevel = .debug
+        NetworkLogger.configuration.environmentRestriction = nil // Log in all environments
+        NetworkLogger.configuration.logBodies = true
         configuration.isEnabled = true
     }
     

--- a/Permanent/Common/Scenes/Share Preview/Models/ShareDetails.swift
+++ b/Permanent/Common/Scenes/Share Preview/Models/ShareDetails.swift
@@ -30,4 +30,10 @@ protocol ShareDetails {
     var fileType: FileType? { get }
     
     var thumbURL2000: String? { get }
+    
+    // Archive number of the original archive where the share was created
+    var originalArchiveNbr: String? { get }
+    
+    // Clean archive name without "From" prefix
+    var cleanArchiveName: String? { get }
 }

--- a/Permanent/Common/Scenes/Share Preview/Models/ShareDetailsVM.swift
+++ b/Permanent/Common/Scenes/Share Preview/Models/ShareDetailsVM.swift
@@ -20,15 +20,32 @@ struct ShareDetailsVM: ShareDetails {
     var fileType: FileType?
     var thumbURL2000: String?
     
+    // Additional property to track the creator account ID
+    var creatorAccountId: Int?
+    
+    // Additional property to track the parent folder link ID for navigation
+    var parentFolderLinkId: Int?
+    
+    // Archive number of the original archive where the share was created
+    var originalArchiveNbr: String?
+    
+    // Clean archive name without "From" prefix
+    var cleanArchiveName: String?
+    
     init(model: SharebyURLVOData) {
         if let archive = model.archiveVO?.fullName {
             archiveName = String.init(format: .fromArchive, archive)
+            cleanArchiveName = "The \(archive) Archive" // Format the clean name properly
         }
         if let name = model.accountVO?.fullName {
             accountName = String.init(format: .sharedBy, name)
         }
         
         archiveThumbURL = URL(string: model.archiveVO?.thumbURL200)
+        
+        // Store the original archive number from the share
+        originalArchiveNbr = model.archiveVO?.archiveNbr
+        
         sharedFileName =
             model.recordData?.displayName ??
             model.folderData?.displayName ?? ""
@@ -38,6 +55,16 @@ struct ShareDetailsVM: ShareDetails {
         status = ShareStatus.status(forValue: model.shareVO?.status)
         folderLinkId = (model.folderLinkID?.value as? Int) ?? -1
         thumbURL2000 = model.recordData?.thumbURL2000
+        
+        // Store the creator account ID from byAccountID field
+        creatorAccountId = model.byAccountID
+        
+        // Store the parent folder link ID for navigation (for files)
+        if let recordData = model.recordData {
+            parentFolderLinkId = recordData.parentFolderLinkID
+        } else {
+            parentFolderLinkId = nil
+        }
         
         if let recordType = model.recordData?.type {
             fileType = FileType.init(rawValue: recordType )

--- a/Permanent/Common/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
+++ b/Permanent/Common/Scenes/Share Preview/ViewControllers/SharePreviewViewController.swift
@@ -115,12 +115,28 @@ class SharePreviewViewController: UIViewController {
     }
     
     fileprivate func setupActionButton(forStatus status: ShareStatus) {
+        // Check if current user is the share creator
+        let isShareCreator = isCurrentUserShareCreator()
+        
         switch status {
         case .pending:
-            actionButton.isEnabled = false
-            actionButton.titleLabel?.adjustsFontSizeToFitWidth = true
-            actionButton.setTitleColor(.primary, for: [])
-            actionButton.configureActionButtonUI(title: status.infoText, bgColor: .backgroundPrimary)
+            // If user is the creator, they should be able to view their own share
+            if isShareCreator {
+                actionButton.configureActionButtonUI(title: viewModel.navigateParams == nil ? .viewInArchive : .viewInArchive)
+            } else {
+                actionButton.isEnabled = false
+                actionButton.titleLabel?.adjustsFontSizeToFitWidth = true
+                actionButton.setTitleColor(.primary, for: [])
+                actionButton.configureActionButtonUI(title: status.infoText, bgColor: .backgroundPrimary)
+            }
+            
+        case .needsApproval:
+            // If user is the creator, they shouldn't need to request approval
+            if isShareCreator {
+                actionButton.configureActionButtonUI(title: viewModel.navigateParams == nil ? .viewInArchive : .viewInArchive)
+            } else {
+                actionButton.configureActionButtonUI(title: viewModel.navigateParams == nil ? status.infoText : .viewInArchive)
+            }
             
         default:
             actionButton.configureActionButtonUI(title: viewModel.navigateParams == nil ? status.infoText : .viewInArchive)
@@ -129,15 +145,125 @@ class SharePreviewViewController: UIViewController {
         actionButton.isHidden = false
     }
     
+    // MARK: - Helper Methods
+    
+    /// Checks if the current user is the creator of the share
+    private func isCurrentUserShareCreator() -> Bool {
+        guard let currentUserAccountId = AuthenticationManager.shared.session?.account.accountID else {
+            return false
+        }
+        
+        // Primary check: Use the creator account ID stored in ShareDetailsVM
+        if let shareDetailsVM = viewModel.shareDetails as? ShareDetailsVM,
+           let creatorAccountId = shareDetailsVM.creatorAccountId {
+            return creatorAccountId == currentUserAccountId
+        }
+        
+        // Fallback check: Use navigateParams which is set in the ViewModel when current user is the creator
+        // This is set in SharePreviewViewModel.onFetchSharedItemsSuccess when the share creator email
+        // matches the current user email
+        if viewModel.navigateParams != nil {
+            return true
+        }
+        
+        return false
+    }
+    
+    /// Fallback method to navigate to shared folder when navigateParams is not available
+    private func navigateToSharedFolder() {
+        guard let shareDetails = viewModel?.shareDetails,
+              let currentArchive = viewModel?.currentArchive else {
+            // Fallback to shares view if we can't get the necessary data
+            viewInArchive()
+            return
+        }
+        
+        // Check if the currently selected archive matches the original archive where the share was created
+        let currentArchiveNbr = currentArchive.archiveNbr ?? ""
+        let originalArchiveNbr = shareDetails.originalArchiveNbr ?? ""
+        
+        if !originalArchiveNbr.isEmpty && currentArchiveNbr != originalArchiveNbr {
+            showArchiveMismatchAlert(correctArchiveName: shareDetails.cleanArchiveName ?? shareDetails.archiveName)
+            return
+        }
+        
+        // Try to construct navigation parameters from available data
+        let archiveNo = currentArchive.archiveNbr ?? ""
+        
+        // Check if this is a folder share (we can navigate directly)
+        if let fileType = shareDetails.fileType, fileType == .publicFolder {
+            let folderLinkId = shareDetails.folderLinkId
+            let folderName = shareDetails.sharedFileName
+            
+            if !archiveNo.isEmpty && folderLinkId > 0 {
+                let params: NavigateMinParams = (archiveNo: archiveNo, folderLinkId: folderLinkId, folderName: folderName)
+                DispatchQueue.main.async { [weak self] in
+                    self?.navigateTo(params)
+                }
+                return
+            }
+        }
+        
+        // For file shares, try to navigate to the parent folder using parentFolderLinkId
+        if let shareDetailsVM = shareDetails as? ShareDetailsVM,
+           let parentFolderLinkId = shareDetailsVM.parentFolderLinkId,
+           !archiveNo.isEmpty && parentFolderLinkId > 0 {
+            
+            let params: NavigateMinParams = (archiveNo: archiveNo, folderLinkId: parentFolderLinkId, folderName: "Containing Folder")
+            DispatchQueue.main.async { [weak self] in
+                self?.navigateTo(params)
+            }
+            return
+        }
+        
+        // Fallback to viewInArchive as last resort
+        viewInArchive()
+    }
+    
     // MARK: - Actions
     
     @IBAction func previewAction(_ sender: UIButton) {
-        if viewModel.navigateParams == nil {
-            viewModel.performAction()
-        } else {
-            navigationController?.popViewController(animated: true)
+        // Add safety check to prevent any potential issues
+        guard let viewModel = viewModel else {
+            return
+        }
+        
+        // Check if the currently selected archive matches the original archive where the share was created
+        if let shareDetails = viewModel.shareDetails,
+           let currentArchive = viewModel.currentArchive {
+            let currentArchiveNbr = currentArchive.archiveNbr ?? ""
+            let originalArchiveNbr = shareDetails.originalArchiveNbr ?? ""
+            
+            if !originalArchiveNbr.isEmpty && currentArchiveNbr != originalArchiveNbr {
+                showArchiveMismatchAlert(correctArchiveName: shareDetails.cleanArchiveName ?? shareDetails.archiveName)
+                return
+            }
+        }
+        
+        let isShareCreator = isCurrentUserShareCreator()
+        
+        if isShareCreator {
+            // If user is the share creator, navigate directly to the folder without back navigation
             if let params = viewModel.navigateParams {
-                self.navigateTo(params)
+                // Use the existing navigation params to go to the folder directly
+                DispatchQueue.main.async { [weak self] in
+                    self?.navigateTo(params)
+                }
+            } else {
+                // Fallback: try to construct navigation params from share details
+                navigateToSharedFolder()
+            }
+        } else {
+            // For non-creators, use the standard flow based on status
+            if viewModel.navigateParams == nil {
+                viewModel.performAction()
+            } else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.navigationController?.popViewController(animated: true)
+                    if let params = viewModel.navigateParams {
+                        self?.navigateTo(params)
+                    }
+                }
             }
         }
     }
@@ -155,6 +281,24 @@ class SharePreviewViewController: UIViewController {
     @objc
     fileprivate func dismissScreen() {
         navigationController?.popViewController(animated: true)
+    }
+    
+    /// Shows an alert when the user has selected the wrong archive
+    private func showArchiveMismatchAlert(correctArchiveName: String) {
+        let alert = UIAlertController(
+            title: "Incorrect Archive",
+            message: "This item is shared from '\(correctArchiveName)'. You need to select the correct archive to view this content.",
+            preferredStyle: .alert
+        )
+        
+        // Add action to change archive
+        alert.addAction(UIAlertAction(title: "Change Archive", style: .default) { [weak self] _ in
+            self?.changeArchiveButtonPressed(self?.actionButton as Any)
+        })
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        
+        present(alert, animated: true)
     }
 }
 
@@ -221,7 +365,19 @@ extension SharePreviewViewController: SharePreviewViewModelViewDelegate {
                 shareNameLabel.text = details.sharedFileName
                 archiveNameLabel.text = details.archiveName
                 sharedByLabel.text = details.accountName
-                archiveImage.sd_setImage(with: details.archiveThumbURL)
+                
+                // Load archive thumbnail with better error handling
+                if let archiveThumbURL = details.archiveThumbURL {
+                    archiveImage.sd_setImage(with: archiveThumbURL, placeholderImage: nil) { [weak self] image, error, _, _ in
+                        if error != nil {
+                            // If there's an error loading the thumbnail, try to use a default archive icon
+                            self?.archiveImage.image = UIImage(named: "archiveThumb") ?? UIImage(systemName: "folder.fill")
+                        }
+                    }
+                } else {
+                    // No thumbnail URL available, use default
+                    archiveImage.image = UIImage(named: "archiveThumb") ?? UIImage(systemName: "folder.fill")
+                }
                 archiveImage.isHidden = false
                 
                 setupActionButton(forStatus: details.status)
@@ -245,22 +401,64 @@ extension SharePreviewViewController: SharePreviewViewModelViewDelegate {
     }
     
     func viewInArchive() {
-        guard let sharesVC = UIViewController.create(
-            withIdentifier: .shares,
-            from: .share
-        ) as? SharesViewController else {
-            return
-        }
+        let isShareCreator = isCurrentUserShareCreator()
         
-        sharesVC.sharedRecordId = viewModel.shareDetails?.recordId ?? -1
-        sharesVC.fileType = viewModel.shareDetails?.fileType
-        sharesVC.sharedFolderLinkId = viewModel.shareDetails?.folderLinkId ?? -1
-        sharesVC.sharedFolderName = viewModel.shareDetails?.sharedFileName ?? ""
-        sharesVC.sharedFolderArchiveNo = viewModel.currentArchive?.archiveNbr ?? ""
-        sharesVC.shareThumbnailURL = viewModel.shareDetails?.thumbURL2000
-        sharesVC.selectedIndex = ShareListType.sharedWithMe.rawValue
-        sharesVC.selectedFileId = viewModel.shareDetails?.folderLinkId
-        AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: sharesVC)
+        if isShareCreator {
+            // For share creators, navigate to the actual location in their private archive
+            guard let shareDetails = viewModel?.shareDetails,
+                  let currentArchive = viewModel?.currentArchive else {
+                return
+            }
+            
+            let archiveNo = currentArchive.archiveNbr ?? ""
+            
+            // Check if this is a folder share
+            if let fileType = shareDetails.fileType, fileType == .publicFolder {
+                let folderLinkId = shareDetails.folderLinkId
+                let folderName = shareDetails.sharedFileName
+                
+                if !archiveNo.isEmpty && folderLinkId > 0 {
+                    let params: NavigateMinParams = (archiveNo: archiveNo, folderLinkId: folderLinkId, folderName: folderName)
+                    DispatchQueue.main.async { [weak self] in
+                        self?.navigateTo(params)
+                    }
+                    return
+                }
+            }
+            
+            // For file shares, navigate to the parent folder using parentFolderLinkId
+            if let shareDetailsVM = shareDetails as? ShareDetailsVM,
+               let parentFolderLinkId = shareDetailsVM.parentFolderLinkId,
+               !archiveNo.isEmpty && parentFolderLinkId > 0 {
+                
+                let params: NavigateMinParams = (archiveNo: archiveNo, folderLinkId: parentFolderLinkId, folderName: "Containing Folder")
+                DispatchQueue.main.async { [weak self] in
+                    self?.navigateTo(params)
+                }
+                return
+            }
+            
+            // Fallback: navigate to the main files view if we can't determine the specific location
+            DispatchQueue.main.async {
+                let mainVC = UIViewController.create(withIdentifier: .main, from: .main) as! MainViewController
+                mainVC.viewModel = MyFilesViewModel()
+                AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: mainVC)
+            }
+        } else {
+            // For non-creators, show the shares list
+            guard let sharesVC = UIViewController.create(
+                withIdentifier: .shares,
+                from: .share
+            ) as? SharesViewController else {
+                return
+            }
+            
+            // Set only the basic information needed for the shares view
+            sharesVC.sharedFolderArchiveNo = viewModel.currentArchive?.archiveNbr ?? ""
+            sharesVC.selectedIndex = ShareListType.sharedWithMe.rawValue
+            
+            AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: sharesVC)
+        }
     }
 }
 

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -460,6 +460,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     
     @IBAction
     func backButtonAction(_ sender: UIButton) {
+        // Fall back to regular navigation hierarchy
         guard
             let viewModel = viewModel,
             let _ = viewModel.removeCurrentFolderFromHierarchy(),
@@ -660,9 +661,17 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     func navigationToShareFolderLink() {
         if let navParamsOptional: NavigationDataForShareFolderLink? = try? PreferencesManager.shared.getCodableObject(forKey: Constants.Keys.StorageKeys.navigationToShareFolderLink),
            let navParams = navParamsOptional  {
-            directoryLabel.text = navParams.folderName
             backButton.isHidden = false
-            navigateToFolder(withParams: NavigateMinParams(archiveNo: navParams.archiveNo, folderLinkId: navParams.folderLinkId, folderName: navParams.folderName), backNavigation: false, shouldDisplaySpinner: true, then: {
+            
+            // Standard navigation to shared folder
+            navigateToFolder(withParams: NavigateMinParams(archiveNo: navParams.archiveNo, folderLinkId: navParams.folderLinkId, folderName: navParams.folderName), backNavigation: false, shouldDisplaySpinner: true, then: { [weak self] in
+                // Ensure the folder name is preserved even after navigation completes
+                if let folderName = navParams.folderName, !folderName.isEmpty {
+                    self?.directoryLabel.text = folderName
+                } else {
+                    // Fallback to current folder name if available
+                    self?.directoryLabel.text = self?.viewModel?.currentFolder?.name ?? "Folder"
+                }
             })
             
             PreferencesManager.shared.removeValue(forKey: Constants.Keys.StorageKeys.navigationToShareFolderLink)

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
@@ -544,6 +544,22 @@ class ShareItemViewModel: ObservableObject {
                 }
             }
         }
+        
+        // Track copy link event for analytics (matching UIKit version)
+        trackCopyLinkEvent()
+    }
+    
+    private func trackCopyLinkEvent() {
+        guard let accountId = AuthenticationManager.shared.session?.account.accountID,
+              let payload = EventsPayloadBuilder.build(accountId: accountId,
+                                                       eventAction: AccountEventAction.copyShareLink,
+                                                       entityId: String(accountId)) else { 
+            return 
+        }
+        
+        let updateAccountOperation = APIOperation(EventsEndpoint.sendEvent(eventsPayload: payload))
+        updateAccountOperation.execute(in: APIRequestDispatcher()) { _ in
+        }
     }
     
     func revokeLink() {

--- a/Permanent/Modules/SideMenus/ViewModels/SettingsScreenViewModel.swift
+++ b/Permanent/Modules/SideMenus/ViewModels/SettingsScreenViewModel.swift
@@ -97,7 +97,8 @@ class SettingsScreenViewModel: ObservableObject {
                     self.showFinishSetUpAccount = true
                 }
                 
-                
+            case .error(let error, _):
+                self.showFinishSetUpAccount = false
             default:
                 self.showFinishSetUpAccount = false
             }
@@ -239,7 +240,7 @@ class SettingsScreenViewModel: ObservableObject {
                 case .success:
                     self.loggedOut = true
                     
-                case .error(let message):
+                case .error(_):
                         self.showError = true
                 }
             })

--- a/Permanent/ViewModels/ViewModel/ShareLinkViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/ShareLinkViewModel.swift
@@ -203,7 +203,10 @@ class ShareLinkViewModel: NSObject, ViewModelInterface {
         guard let accountId = AuthenticationManager.shared.session?.account.accountID,
               let payload = EventsPayloadBuilder.build(accountId: accountId,
                                                        eventAction: AccountEventAction.copyShareLink,
-                                                       entityId: String(accountId)) else { return }
+                                                       entityId: String(accountId)) else { 
+            return 
+        }
+        
         let updateAccountOperation = APIOperation(EventsEndpoint.sendEvent(eventsPayload: payload))
         updateAccountOperation.execute(in: APIRequestDispatcher()) {_ in}
     }


### PR DESCRIPTION
Refactor share link handling and enhance navigation logic for share creators

- Updated error handling in SettingsScreenViewModel to simplify error cases.
- Improved navigation logic in SharePreviewViewController to differentiate actions for share creators and non-creators.
- Implemented fallback navigation in MainViewController and improved user feedback for archive mismatches.
- Added analytics tracking for copy link events in ShareItemViewModel and ShareLinkViewModel.

Preview: 

https://github.com/user-attachments/assets/1c874304-9e9b-4f5f-845a-192beeba6911

