### PR TITLE
VSP-1644[IOS][Mobile] Multiple select file size not accurate and VSP-1646[iOS][Mobile] Show confirmation popup for deny access to archive

### DIFF
--- a/Permanent/Modules/FileOperations/Views/FileMoreMenuView.swift
+++ b/Permanent/Modules/FileOperations/Views/FileMoreMenuView.swift
@@ -13,11 +13,12 @@ struct FileMoreMenuView: View {
     private let onShareManagementRequested: ((FileModel) -> Void)?
     private let onGetLinkRequested: ((FileModel) -> Void)?
     
-    init(fileViewModel: FileModel, menuItems: [FileMenuViewModel.MenuItem], selectedItemCount: Int? = nil, onDismiss: @escaping () -> Void, onShareManagementRequested: ((FileModel) -> Void)? = nil, onGetLinkRequested: ((FileModel) -> Void)? = nil, downloadHandler: FileMenuViewModel.DownloadHandler? = nil) {
+    init(fileViewModel: FileModel, menuItems: [FileMenuViewModel.MenuItem], selectedItemCount: Int? = nil, selectedFiles: [FileModel]? = nil, onDismiss: @escaping () -> Void, onShareManagementRequested: ((FileModel) -> Void)? = nil, onGetLinkRequested: ((FileModel) -> Void)? = nil, downloadHandler: FileMenuViewModel.DownloadHandler? = nil) {
         let newViewModel = FileMenuViewModel(
             fileViewModel: fileViewModel,
             menuItems: menuItems,
             selectedItemCount: selectedItemCount,
+            selectedFiles: selectedFiles,
             onDismiss: onDismiss
         )
         

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -1376,13 +1376,16 @@ extension MainViewController: FABActionSheetDelegate {
         }
         
         if file.permissions.contains(.edit) {
-            menuItems.append(FileMenuViewModel.MenuItem(type: .editMetadata, action: { [weak self] in
-                self?.presentMetadataEditView { hasUpdates in
-                    if hasUpdates {
-                        self?.refreshCurrentFolder()
+            let hasFolder = viewModel?.selectedFiles?.contains(where: { $0.type.isFolder }) ?? false
+            if !hasFolder {
+                menuItems.append(FileMenuViewModel.MenuItem(type: .editMetadata, action: { [weak self] in
+                    self?.presentMetadataEditView { hasUpdates in
+                        if hasUpdates {
+                            self?.refreshCurrentFolder()
+                        }
                     }
-                }
-            }))
+                }))
+            }
         }
         
         if file.permissions.contains(.move) {
@@ -1423,6 +1426,7 @@ extension MainViewController: FABActionSheetDelegate {
             fileViewModel: file,
             menuItems: menuItems,
             selectedItemCount: viewModel?.selectedFiles?.count,
+            selectedFiles: viewModel?.selectedFiles,
             onDismiss: { [weak self] in
                 self?.dismiss(animated: true)
             },

--- a/Permanent/Modules/Shares/SwiftUIViews/ArchiveAccessManagementView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ArchiveAccessManagementView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ArchiveAccessManagementView: View {
     @ObservedObject var viewModel: ShareItemViewModel
+    @State private var revokeArchiveName: String = ""
     
     var body: some View {
         VStack(spacing: 0) {
@@ -117,8 +118,11 @@ struct ArchiveAccessManagementView: View {
                     // Revoke Access Section
                     VStack(alignment: .leading, spacing: 16) {
                         Button(action: {
-                            // Show revoke confirmation dialog
-                            viewModel.showRevokeArchiveAccessAlert = true
+                            revokeArchiveName = viewModel.selectedArchiveForEdit?.archiveVO?.fullName ?? "Archive"
+
+                            DispatchQueue.main.async {
+                                viewModel.showRevokeArchiveAccessAlert = true
+                            }
                         }) {
                             HStack(spacing: 16) {
                                 Image(.publishRevokeLink2)
@@ -132,7 +136,6 @@ struct ArchiveAccessManagementView: View {
                                 
                                 Spacer()
                             }
-                          //  .padding(.vertical, 12)
                         }
                         .buttonStyle(PlainButtonStyle())
                     }
@@ -204,6 +207,15 @@ struct ArchiveAccessManagementView: View {
                 buttonText: "Revoke access",
                 onRevoke: {
                     revokeAccess()
+                },
+                titleView: {
+                    AnyView(
+                        Group {
+                            Text("Are you sure you want to revoke access from ")
+                            + Text("The \(revokeArchiveName) Archive").fontWeight(.semibold)
+                            + Text("? This action will immediately remove all permissions granted.")
+                        }
+                    )
                 }
             )
         }

--- a/Permanent/Modules/Shares/SwiftUIViews/Components/RevokeBottomAlertView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/Components/RevokeBottomAlertView.swift
@@ -13,19 +13,22 @@ struct RevokeBottomAlertView: View {
     let buttonText: String
     let onRevoke: () -> Void
     let onCancel: (() -> Void)?
+    let titleView: (() -> AnyView)?
     
     init(
         isPresented: Binding<Bool>,
         title: String = "Are you sure you want to revoke this share link?",
         buttonText: String = "Revoke link",
         onRevoke: @escaping () -> Void,
-        onCancel: (() -> Void)? = nil
+        onCancel: (() -> Void)? = nil,
+        titleView: (() -> AnyView)? = nil
     ) {
         self._isPresented = isPresented
         self.title = title
         self.buttonText = buttonText
         self.onRevoke = onRevoke
         self.onCancel = onCancel
+        self.titleView = titleView
     }
     
     var body: some View {
@@ -43,7 +46,6 @@ struct RevokeBottomAlertView: View {
             
             alertCard
                 .offset(y: isPresented ? 0 : 400)
-                .opacity(isPresented ? 1 : 0)
                 .animation(.easeOut(duration: 0.3), value: isPresented)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
@@ -52,17 +54,27 @@ struct RevokeBottomAlertView: View {
     
     private var alertCard: some View {
         VStack {
-            HStack {
-                Spacer()
+            if let titleView = titleView {
+                titleView()
+                    .font(.custom("Usual-Regular", size: 14))
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(6)
+                    .foregroundColor(.blue700)
+                    .padding(.top, 32)
+                    .padding(.horizontal, 32)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .animation(nil, value: title)
+            } else {
                 Text(title)
-                Spacer()
+                    .font(.custom("Usual-Regular", size: 14))
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(6)
+                    .foregroundColor(.blue700)
+                    .padding(.top, 32)
+                    .padding(.horizontal, 32)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .animation(nil, value: title)
             }
-                .font(.custom("Usual-Regular", size: 14))
-                .multilineTextAlignment(.center)
-                .lineSpacing(6)
-                .foregroundColor(.blue700)
-                .padding(.top, 32)
-                .padding(.horizontal, 32)
             
             VStack(spacing: 16) {
                 Button(action: revokeAction) {

--- a/Permanent/Modules/Shares/SwiftUIViews/ShareItemView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ShareItemView.swift
@@ -89,7 +89,7 @@ struct ShareItemView: View {
             RevokeBottomAlertView(
                 isPresented: $viewModel.showDenyArchiveAccessAlert,
                 title: denyConfirmationTitle,
-                buttonText: "Yes",
+                buttonText: "Deny access",
                 onRevoke: {
                     if let shareVO = viewModel.selectedArchiveForDeny {
                         withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {

--- a/Permanent/Modules/Shares/SwiftUIViews/ShareItemView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ShareItemView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ShareItemView: View {
     @ObservedObject var viewModel: ShareItemViewModel
     @Environment(\.dismiss) private var dismiss
+    @State private var denyConfirmationTitle: String = "Are you sure you want to deny access?"
+    @State private var denyArchiveName: String = ""
     
     init(viewModel: ShareItemViewModel) {
         self.viewModel = viewModel
@@ -21,66 +23,98 @@ struct ShareItemView: View {
     }
     
     var body: some View {
-        VStack(spacing: 0) {
-            ZStack {
-                topBar
-                    .padding(.horizontal, 16)
-                    .padding(.top, 12)
-                    .padding(.bottom, 8)
-            }
-            .frame(height: 64)
-            .background(Color.white)
-            
+        ZStack {
             VStack(spacing: 0) {
-                Rectangle()
-                    .foregroundColor(.clear)
-                    .frame(maxWidth: .infinity, minHeight: 1, maxHeight: 1)
-                    .background(Color.blue50)
+                ZStack {
+                    topBar
+                        .padding(.horizontal, 16)
+                        .padding(.top, 12)
+                        .padding(.bottom, 8)
+                }
+                .frame(height: 64)
+                .background(Color.white)
                 
-                VStack(spacing: 20) {
-                    fileInfoSection
+                VStack(spacing: 0) {
+                    Rectangle()
+                        .foregroundColor(.clear)
+                        .frame(maxWidth: .infinity, minHeight: 1, maxHeight: 1)
+                        .background(Color.blue50)
                     
-                    Group {
-                        if viewModel.genLinkLoading {
-                            linkCreationLoadingSection
-                                .transition(.opacity.combined(with: .scale))
-                        } else if viewModel.shouldShowCreateButton {
-                            createLinkSection
-                                .transition(.opacity.combined(with: .scale))
-                        } else if viewModel.hasShareLink {
-                            shareLinkSection
-                                .transition(.opacity.combined(with: .scale))
+                    VStack(spacing: 20) {
+                        fileInfoSection
+                        
+                        Group {
+                            if viewModel.genLinkLoading {
+                                linkCreationLoadingSection
+                                    .transition(.opacity.combined(with: .scale))
+                            } else if viewModel.shouldShowCreateButton {
+                                createLinkSection
+                                    .transition(.opacity.combined(with: .scale))
+                            } else if viewModel.hasShareLink {
+                                shareLinkSection
+                                    .transition(.opacity.combined(with: .scale))
+                            }
                         }
+                        .animation(.easeInOut(duration: 0.3), value: viewModel.isLoading)
+                        .animation(.easeInOut(duration: 0.3), value: viewModel.genLinkLoading)
+                        .animation(.easeInOut(duration: 0.3), value: viewModel.hasShareLink)
+                        .animation(.easeInOut(duration: 0.3), value: viewModel.shouldShowCreateButton)
                     }
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.isLoading)
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.genLinkLoading)
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.hasShareLink)
-                    .animation(.easeInOut(duration: 0.3), value: viewModel.shouldShowCreateButton)
+                    .padding(24)
+                    
+                    // Current Requests and Access Section - Scrollable
+                    if !viewModel.sharedArchives.isEmpty || viewModel.isLoadingArchives {
+                        currentRequestsAndAccessSection
+                    } else {
+                        // Spacer to fill remaining space with blue25 background when no archives
+                        Spacer()
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .background(Color.blue25)
+                    }
                 }
-                .padding(24)
-                
-                // Current Requests and Access Section - Scrollable
-                if !viewModel.sharedArchives.isEmpty || viewModel.isLoadingArchives {
-                    currentRequestsAndAccessSection
-                } else {
-                    // Spacer to fill remaining space with blue25 background when no archives
-                    Spacer()
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(Color.blue25)
-                }
+                .background(Color.blue25)
             }
             .background(Color.blue25)
-        }
-        .background(Color.blue25)
-        .overlay {
-            if viewModel.isLoading && !viewModel.genLinkLoading {
-                loadingOverlay
+            .overlay {
+                if viewModel.isLoading && !viewModel.genLinkLoading {
+                    loadingOverlay
+                }
             }
-        }
-        .alert("Error", isPresented: .constant(viewModel.errorMessage != nil)) {
-            Button("OK") { viewModel.errorMessage = nil }
-        } message: {
-            if let errorMessage = viewModel.errorMessage { Text(errorMessage) }
+            .alert("Error", isPresented: .constant(viewModel.errorMessage != nil)) {
+                Button("OK") { viewModel.errorMessage = nil }
+            } message: {
+                if let errorMessage = viewModel.errorMessage { Text(errorMessage) }
+            }
+            
+            RevokeBottomAlertView(
+                isPresented: $viewModel.showDenyArchiveAccessAlert,
+                title: denyConfirmationTitle,
+                buttonText: "Yes",
+                onRevoke: {
+                    if let shareVO = viewModel.selectedArchiveForDeny {
+                        withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+                            viewModel.denyShareRequest(shareVO)
+                        }
+                        viewModel.selectedArchiveForDeny = nil
+                        denyConfirmationTitle = ""
+                        denyArchiveName = ""
+                    }
+                },
+                onCancel: {
+                    viewModel.selectedArchiveForDeny = nil
+                    denyConfirmationTitle = ""
+                    denyArchiveName = ""
+                },
+                titleView: {
+                    AnyView(
+                        Group {
+                            Text("Are you sure you want to deny access from ")
+                            + Text("The \(denyArchiveName) Archive").fontWeight(.semibold)
+                            + Text("?")
+                        }
+                    )
+                }
+            )
         }
     }
     
@@ -384,8 +418,15 @@ struct ShareItemView: View {
                                 let impactFeedback = UIImpactFeedbackGenerator(style: .light)
                                 impactFeedback.impactOccurred()
                                 
-                                withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
-                                    viewModel.denyShareRequest(shareVO)
+                                // Capture the archive name before showing the alert
+                                let archiveName = shareVO.archiveVO?.fullName ?? "Archive"
+                                denyConfirmationTitle = "Are you sure you want to deny access from The \(archiveName) Archive?"
+                                denyArchiveName = archiveName
+                                viewModel.selectedArchiveForDeny = shareVO
+                                
+                                // Delay showing the alert to ensure the title is set first
+                                DispatchQueue.main.async {
+                                    viewModel.showDenyArchiveAccessAlert = true
                                 }
                             }) {
                                 Image(.shareDeny)

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
@@ -14,7 +14,6 @@ enum NavigationDirection {
     case backward
 }
 
-// Using a local enum to avoid conflicts - can be refactored later
 enum ShareViewAccessLevel: CaseIterable {
     case anyoneCanView
     case restricted
@@ -128,6 +127,11 @@ class ShareItemViewModel: ObservableObject {
     
     // Bottom alert for archive access revoke confirmation
     @Published var showRevokeArchiveAccessAlert = false
+    
+    // Bottom alert for deny pending archive access confirmation
+    @Published var showDenyArchiveAccessAlert = false
+    @Published var selectedArchiveForDeny: ShareVOData?
+    @Published var denyArchiveName: String = ""
     
     lazy var revokeAction: () -> Void = { [weak self] in
         self?.performRevokeLink()

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -826,6 +826,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             fileViewModel: file,
             menuItems: menuItems,
             selectedItemCount: viewModel?.selectedFiles?.count,
+            selectedFiles: viewModel?.selectedFiles,
             onDismiss: { [weak self] in
                 self?.dismiss(animated: true)
             },

--- a/Permanent/ViewModels/ViewModel/FileMenuViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FileMenuViewModel.swift
@@ -53,6 +53,7 @@ class FileMenuViewModel: ObservableObject {
     let fileViewModel: FileModel
     let menuItems: [MenuItem]
     let selectedItemCount: Int?
+    let selectedFiles: [FileModel]?
     let onDismiss: () -> Void
     
     // MARK: - Cached/Computed Properties
@@ -75,14 +76,37 @@ class FileMenuViewModel: ObservableObject {
     private var capturedPresentingViewController: UIViewController?
     
     // MARK: - Initialization
-    init(fileViewModel: FileModel, menuItems: [MenuItem], selectedItemCount: Int? = nil, onDismiss: @escaping () -> Void) {
+    init(fileViewModel: FileModel, menuItems: [MenuItem], selectedItemCount: Int? = nil, selectedFiles: [FileModel]? = nil, onDismiss: @escaping () -> Void) {
         self.fileViewModel = fileViewModel
         self.menuItems = menuItems
         self.selectedItemCount = selectedItemCount
+        self.selectedFiles = selectedFiles
         self.onDismiss = onDismiss
         
-        self.cachedFormattedFileSize = Self.formatFileSize(fileViewModel.size)
-        self.cachedFormattedDate = Self.formatDate(fileViewModel.date)
+        // Calculate size and date based on selection
+        if let selectedFiles = selectedFiles, selectedFiles.count > 1 {
+            // Multiple files selected
+            let files = selectedFiles.filter { !$0.type.isFolder }
+            let folders = selectedFiles.filter { $0.type.isFolder }
+            
+            // Calculate total file size (only for files, not folders)
+            let totalSize = files.reduce(Int64(0)) { $0 + $1.size }
+            self.cachedFormattedFileSize = totalSize > 0 ? Self.formatFileSize(totalSize) : nil
+            
+            // If there are folders, use the date of the first folder, otherwise use the date of the first file
+            if let firstFolder = folders.first {
+                self.cachedFormattedDate = Self.formatDate(firstFolder.date)
+            } else if let firstFile = files.first {
+                self.cachedFormattedDate = Self.formatDate(firstFile.date)
+            } else {
+                self.cachedFormattedDate = ""
+            }
+        } else {
+            // Single file selected
+            self.cachedFormattedFileSize = Self.formatFileSize(fileViewModel.size)
+            self.cachedFormattedDate = Self.formatDate(fileViewModel.date)
+        }
+        
         self.preCalculatedHeight = Self.calculateSheetHeight(for: menuItems)
     }
     


### PR DESCRIPTION
Multiple file selection fixes: 
 - Show total size of all selected files
 - Display first folder's date for mixed selections
 - Hide edit metadata when folders are selected

Deny confirmation dialog:
 - Added styled confirmation matching the revoke access dialog
 - Fixed animation timing issues with text visibility

Preview:

https://github.com/user-attachments/assets/d96344f4-6670-4ef2-987d-4de80a7e716f

