### PR TITLE
VSP-1634 [IOS] When a shared link (non restricted) is opened by a user, the preview need to navigate the user to the folder of the item

### DIFF
--- a/Permanent/Common/Scenes/Share Preview/ViewModels/SharePreviewViewModel.swift
+++ b/Permanent/Common/Scenes/Share Preview/ViewModels/SharePreviewViewModel.swift
@@ -112,6 +112,7 @@ class SharePreviewViewModel {
                 let status = ShareStatus.status(forValue: shareVO.status)
                 self.shareDetails?.status = status
             
+                self.viewDelegate?.updateScreen(status: .success, shareDetails: self.shareDetails)
                 self.viewDelegate?.updateShareAccess(status: .success, shareStatus: status)
             
             break
@@ -154,7 +155,15 @@ class SharePreviewViewModel {
         
         let details = ShareDetailsVM(model: model)
         self.shareDetails = details
-        viewDelegate?.updateScreen(status: .success, shareDetails: details)
+        
+        let isNonRestrictive = model.autoApproveToggle == 1
+        let hasAccess = model.shareVO != nil
+        
+        if isNonRestrictive && !hasAccess {
+            requestShareAccess(urlToken: urlToken)
+        } else {
+            viewDelegate?.updateScreen(status: .success, shareDetails: details)
+        }
         
         // Delete the saved token if it existed.
         PreferencesManager.shared.removeValue(forKey: Constants.Keys.StorageKeys.shareURLToken)

--- a/Permanent/Modules/SideMenus/ViewController/DrawerViewController.swift
+++ b/Permanent/Modules/SideMenus/ViewController/DrawerViewController.swift
@@ -119,6 +119,9 @@ class DrawerViewController: UIViewController {
                 leftSideMenuController.selectedMenuOption = .files
             }
             
+        case _ where viewController is SharesViewController:
+            leftSideMenuController.selectedMenuOption = .shares
+            
         default:
             break
         }


### PR DESCRIPTION
Added share link auto approve operation for non restricted links.

Preview: 


https://github.com/user-attachments/assets/611b93dd-11be-4884-9400-783f7d12edeb

