### PR TITLE
VSP-1649[IOS][Mobile] Update Share leave confirmation in the share workspace.

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -313,12 +313,11 @@
 		5E7141452AFD25D5003952CD /* GiftingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7141442AFD25D5003952CD /* GiftingModel.swift */; };
 		5E71E5F12C9C60D600B7A315 /* Login2FAFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E71E5F02C9C60B700B7A315 /* Login2FAFieldView.swift */; };
 		5E72081D2E9D455D001300CA /* ArchiveAccessManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E72081C2E9D455D001300CA /* ArchiveAccessManagementView.swift */; };
-
-
 		5E744F9127E36EAA00A47D27 /* RCValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E744F9027E36EAA00A47D27 /* RCValues.swift */; };
 		5E744F9327E38DB900A47D27 /* LoadingScreenViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E744F9227E38DB900A47D27 /* LoadingScreenViewController.swift */; };
 		5E75AFE12DBFC0250074159F /* ChecklistItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E75AFE02DBFC0160074159F /* ChecklistItem.swift */; };
 		5E781EA82787006B0007E397 /* ProfileItemOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E781EA72787006B0007E397 /* ProfileItemOperation.swift */; };
+		5E7A697D2EBA4CB4005FA69B /* ConfirmationBottomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7A697B2EBA4CB4005FA69B /* ConfirmationBottomAlertView.swift */; };
 		5E7A87F72C99C83D00228EB4 /* AuthImageForRightSidePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7A87F62C99C83700228EB4 /* AuthImageForRightSidePageView.swift */; };
 		5E7A87F92C99C84C00228EB4 /* AuthTextForRightSidePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7A87F82C99C84A00228EB4 /* AuthTextForRightSidePageView.swift */; };
 		5E7AE8AB291CE7FF00F2A41D /* ShareManagementSeparatorFooterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7AE8A9291CE7FF00F2A41D /* ShareManagementSeparatorFooterCollectionViewCell.swift */; };
@@ -1292,11 +1291,11 @@
 		5E7141442AFD25D5003952CD /* GiftingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftingModel.swift; sourceTree = "<group>"; };
 		5E71E5F02C9C60B700B7A315 /* Login2FAFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Login2FAFieldView.swift; sourceTree = "<group>"; };
 		5E72081C2E9D455D001300CA /* ArchiveAccessManagementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveAccessManagementView.swift; sourceTree = "<group>"; };
-
 		5E744F9027E36EAA00A47D27 /* RCValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCValues.swift; sourceTree = "<group>"; };
 		5E744F9227E38DB900A47D27 /* LoadingScreenViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingScreenViewController.swift; sourceTree = "<group>"; };
 		5E75AFE02DBFC0160074159F /* ChecklistItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistItem.swift; sourceTree = "<group>"; };
 		5E781EA72787006B0007E397 /* ProfileItemOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileItemOperation.swift; sourceTree = "<group>"; };
+		5E7A697B2EBA4CB4005FA69B /* ConfirmationBottomAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationBottomAlertView.swift; sourceTree = "<group>"; };
 		5E7A87F62C99C83700228EB4 /* AuthImageForRightSidePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthImageForRightSidePageView.swift; sourceTree = "<group>"; };
 		5E7A87F82C99C84A00228EB4 /* AuthTextForRightSidePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTextForRightSidePageView.swift; sourceTree = "<group>"; };
 		5E7AE8A9291CE7FF00F2A41D /* ShareManagementSeparatorFooterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareManagementSeparatorFooterCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -3272,6 +3271,14 @@
 			path = Billing;
 			sourceTree = "<group>";
 		};
+		5E7A697C2EBA4CB4005FA69B /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				5E7A697B2EBA4CB4005FA69B /* ConfirmationBottomAlertView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		5E814A492C90DDA6005FF97C /* Container */ = {
 			isa = PBXGroup;
 			children = (
@@ -3396,7 +3403,6 @@
 		5EA9C2B62E45FF78003BA1E9 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-
 				5ECB0C902E856F15006EFDA7 /* RevokeBottomAlertView.swift */,
 				5E317C652E7C1D8600DE5A77 /* SelectableOptionView.swift */,
 				5E28C32B2E7BEECB00A073A8 /* SelectableOption.swift */,
@@ -3493,6 +3499,7 @@
 		5EC7CD282E26A74E00D80AE4 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				5E7A697C2EBA4CB4005FA69B /* Components */,
 				5EC7CD262E26A74E00D80AE4 /* FileMoreMenuView.swift */,
 				5E04DAE02E3697C600D17F67 /* FileMoreMenuItemRow.swift */,
 			);
@@ -4905,6 +4912,7 @@
 				5E62F7C927F79FF40046F6C8 /* PopularArchive.swift in Sources */,
 				5E2E3D1826D3C9FD0090EF02 /* LeftSideHeaderTableViewCell.swift in Sources */,
 				BC6AF9AC25933FAB00483BBA /* MembersEndpoint.swift in Sources */,
+				5E7A697D2EBA4CB4005FA69B /* ConfirmationBottomAlertView.swift in Sources */,
 				5E5979D72DCCEC7000694BDA /* ChecklistBottomMenuViewModel.swift in Sources */,
 				5EF0B6E727F43CFA000CBAF6 /* PublicGalleryViewController.swift in Sources */,
 				5E2CFA25274EEB570055941C /* ProfileItemVO.swift in Sources */,
@@ -4961,7 +4969,6 @@
 				BCF4E5DB255C3782003505BA /* AttachmentRecordVO.swift in Sources */,
 				06644A8B24EBF4CD003CD359 /* CustomView.swift in Sources */,
 				BC6D3B4D2514E57500390927 /* NetworkSessionProtocol.swift in Sources */,
-
 				5EB2D2362C245EEA0029D0DE /* OnboardingArchive.swift in Sources */,
 				5E5AB60F2A6494170030BF61 /* AddTagsView.swift in Sources */,
 				F54596C325FF737200E0BC5F /* FilePreviewNavigationController.swift in Sources */,
@@ -5595,7 +5602,6 @@
 				F5ADBF3B290BBF900007A516 /* ArchiveScreenChooseArchiveDetailsTableViewCell.swift in Sources */,
 				5E4739DC2A4185A700A20D85 /* FilePreviewNavigationController.swift in Sources */,
 				F5ADBF36290ADB7C0007A516 /* ArchivesViewController.swift in Sources */,
-
 				5ED4B9C52876DF0E00CF044B /* ArchiveVO.swift in Sources */,
 				F559F89F28FEEAD50015A522 /* RelocateFolderPayload.swift in Sources */,
 				5ED3B3B329F7E945000CFF48 /* LegacyPlanningViewModel.swift in Sources */,

--- a/Permanent/Modules/FileOperations/Views/Components/ConfirmationBottomAlertView.swift
+++ b/Permanent/Modules/FileOperations/Views/Components/ConfirmationBottomAlertView.swift
@@ -1,0 +1,181 @@
+//
+//  ConfirmationBottomAlertView.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 04.11.2025.
+//
+
+import SwiftUI
+
+struct ConfirmationBottomAlertView: View {
+    @Binding var isPresented: Bool
+    let fileName: String
+    let actionType: ActionType
+    let onConfirm: () -> Void
+    let onCancel: (() -> Void)?
+    
+    enum ActionType {
+        case delete
+        case leaveShare
+        
+        var title: String {
+            switch self {
+            case .delete:
+                return "Are you sure you want to delete"
+            case .leaveShare:
+                return "Are you sure you want to give up your access to the"
+            }
+        }
+        
+        var buttonText: String {
+            switch self {
+            case .delete:
+                return "Delete"
+            case .leaveShare:
+                return "Leave share"
+            }
+        }
+    }
+    
+    init(
+        isPresented: Binding<Bool>,
+        fileName: String,
+        actionType: ActionType,
+        onConfirm: @escaping () -> Void,
+        onCancel: (() -> Void)? = nil
+    ) {
+        self._isPresented = isPresented
+        self.fileName = fileName
+        self.actionType = actionType
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.blue700
+                .opacity(isPresented ? 0.5 : 0)
+                .ignoresSafeArea()
+                .animation(.easeOut(duration: 0.2), value: isPresented)
+                .onTapGesture {
+                    withAnimation(.easeOut(duration: 0.3)) {
+                        isPresented = false
+                    }
+                    onCancel?()
+                }
+            
+            alertCard
+                .offset(y: isPresented ? 0 : 400)
+                .animation(.easeOut(duration: 0.3), value: isPresented)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .ignoresSafeArea()
+    }
+    
+    private var alertCard: some View {
+        VStack {
+            titleView
+                .padding(.top, 32)
+                .padding(.horizontal, 32)
+                .fixedSize(horizontal: false, vertical: true)
+            
+            VStack(spacing: 16) {
+                Button(action: confirmAction) {
+                    HStack {
+                        Spacer()
+                        Text(actionType.buttonText)
+                            .fontWeight(.medium)
+                            .font(.custom("Usual-Regular", size: 14))
+                            .foregroundColor(.white)
+                        Spacer()
+                    }
+                    .padding(16)
+                    .frame(height: 56)
+                    .background(Color.error500)
+                    .cornerRadius(12)
+                    .shadow(color: Color.black.opacity(0.07), radius: 40, x: 0, y: 5)
+                    .frame(maxWidth: .infinity)
+                }
+                
+                Button(action: cancelAction) {
+                    HStack {
+                        Spacer()
+                        Text("Cancel")
+                            .font(.custom("Usual-Regular", size: 14))
+                            .fontWeight(.medium)
+                            .foregroundColor(.blue900)
+                        Spacer()
+                    }
+                    .padding(16)
+                    .frame(height: 56)
+                    .background(Color.blue50)
+                    .cornerRadius(12)
+                    .shadow(color: Color.black.opacity(0.07), radius: 40, x: 0, y: 5)
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .padding(32)
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color(.white))
+        .cornerRadius(12)
+        .padding(.horizontal, 0)
+    }
+    
+    private var titleView: some View {
+        Group {
+            Text(actionType.title + " ")
+                .font(.custom("Usual-Regular", size: 14))
+                .foregroundColor(.blue700)
+            + Text(fileName)
+                .font(.custom("Usual-Regular", size: 14))
+                .fontWeight(.bold)
+                .foregroundColor(.blue700)
+            + Text(actionType == .leaveShare ? " item?" : "?")
+                .font(.custom("Usual-Regular", size: 14))
+                .foregroundColor(.blue700)
+        }
+        .multilineTextAlignment(.center)
+        .lineSpacing(6)
+    }
+    
+    private func confirmAction() {
+        if #available(iOS 17.0, *) {
+            withAnimation(.easeOut(duration: 0.3)) {
+                isPresented = false
+            } completion: {
+                onConfirm()
+            }
+        } else {
+            withAnimation(.easeOut(duration: 0.3)) {
+                isPresented = false
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                onConfirm()
+            }
+        }
+    }
+    
+    private func cancelAction() {
+        withAnimation(.easeOut(duration: 0.3)) {
+            isPresented = false
+        }
+        onCancel?()
+    }
+}
+
+#Preview {
+    VStack {
+        ConfirmationBottomAlertView(
+            isPresented: .constant(true),
+            fileName: "Summer Holiday 2022",
+            actionType: .leaveShare,
+            onConfirm: {
+                print("Confirmed")
+            },
+            onCancel: {
+                print("Cancelled")
+            }
+        )
+    }
+}

--- a/Permanent/Modules/FileOperations/Views/FileMoreMenuView.swift
+++ b/Permanent/Modules/FileOperations/Views/FileMoreMenuView.swift
@@ -12,8 +12,10 @@ struct FileMoreMenuView: View {
     @ObservedObject private var viewModel: FileMenuViewModel
     private let onShareManagementRequested: ((FileModel) -> Void)?
     private let onGetLinkRequested: ((FileModel) -> Void)?
+    private let onDeleteConfirmed: (([FileModel]) -> Void)?
+    private let onLeaveShareConfirmed: ((FileModel) -> Void)?
     
-    init(fileViewModel: FileModel, menuItems: [FileMenuViewModel.MenuItem], selectedItemCount: Int? = nil, selectedFiles: [FileModel]? = nil, showArchiveInfo: Bool = false, onDismiss: @escaping () -> Void, onShareManagementRequested: ((FileModel) -> Void)? = nil, onGetLinkRequested: ((FileModel) -> Void)? = nil, downloadHandler: FileMenuViewModel.DownloadHandler? = nil) {
+    init(fileViewModel: FileModel, menuItems: [FileMenuViewModel.MenuItem], selectedItemCount: Int? = nil, selectedFiles: [FileModel]? = nil, showArchiveInfo: Bool = false, onDismiss: @escaping () -> Void, onShareManagementRequested: ((FileModel) -> Void)? = nil, onGetLinkRequested: ((FileModel) -> Void)? = nil, onDeleteConfirmed: (([FileModel]) -> Void)? = nil, onLeaveShareConfirmed: ((FileModel) -> Void)? = nil, downloadHandler: FileMenuViewModel.DownloadHandler? = nil) {
         let newViewModel = FileMenuViewModel(
             fileViewModel: fileViewModel,
             menuItems: menuItems,
@@ -30,6 +32,8 @@ struct FileMoreMenuView: View {
         self.viewModel = newViewModel
         self.onShareManagementRequested = onShareManagementRequested
         self.onGetLinkRequested = onGetLinkRequested
+        self.onDeleteConfirmed = onDeleteConfirmed
+        self.onLeaveShareConfirmed = onLeaveShareConfirmed
     }
     
     
@@ -207,6 +211,40 @@ struct FileMoreMenuView: View {
                     }
                 }
             }
+            
+            ConfirmationBottomAlertView(
+                isPresented: $viewModel.showDeleteConfirmation,
+                fileName: viewModel.fileViewModel.name,
+                actionType: .delete,
+                onConfirm: {
+                    handleDeleteConfirmation()
+                },
+                onCancel: {
+                    viewModel.cancelDeleteAction()
+                }
+            )
+            
+            ConfirmationBottomAlertView(
+                isPresented: $viewModel.showLeaveShareConfirmation,
+                fileName: viewModel.fileViewModel.name,
+                actionType: .leaveShare,
+                onConfirm: {
+                    handleLeaveShareConfirmation()
+                },
+                onCancel: {
+                    viewModel.cancelLeaveShareAction()
+                }
+            )
+            
+            if viewModel.isExecutingAction {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea()
+                    .overlay(
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                            .scaleEffect(1.5)
+                    )
+            }
         }
         .ignoresSafeArea(.container, edges: .bottom)
     }
@@ -379,6 +417,42 @@ struct FileMoreMenuView: View {
         }
     }
 
+    // MARK: - Confirmation Actions
+    private func handleDeleteConfirmation() {
+        viewModel.showDeleteConfirmation = false
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.viewModel.dismissWithAnimation()
+            
+            // Wait for menu dismiss animation to complete before executing action
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                if let onDeleteConfirmed = self.onDeleteConfirmed {
+                    let filesToDelete = self.viewModel.selectedFiles ?? [self.viewModel.fileViewModel]
+                    onDeleteConfirmed(filesToDelete)
+                } else {
+                    self.viewModel.executeDeleteAction()
+                }
+            }
+        }
+    }
+    
+    private func handleLeaveShareConfirmation() {
+        viewModel.showLeaveShareConfirmation = false
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.viewModel.dismissWithAnimation()
+            
+            // Wait for menu dismiss animation to complete before executing action
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                if let onLeaveShareConfirmed = self.onLeaveShareConfirmed {
+                    onLeaveShareConfirmed(self.viewModel.fileViewModel)
+                } else {
+                    self.viewModel.executeLeaveShareAction()
+                }
+            }
+        }
+    }
+    
     // MARK: - Helper Methods
     private func formatFileSize(_ size: Int64) -> String {
         let formatter = ByteCountFormatter()

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -1327,6 +1327,26 @@ extension MainViewController: FABActionSheetDelegate {
                     self?.getPublicLinkAction(file: file)
                 })
             },
+            onDeleteConfirmed: { [weak self] files in
+                self?.dismiss(animated: true, completion: {
+                    self?.showSpinner()
+                    self?.viewModel?.delete(files, then: { status in
+                        self?.hideSpinner()
+                        
+                        switch status {
+                        case .success:
+                            DispatchQueue.main.async {
+                                self?.viewModel?.removeSyncedFiles(files)
+                                self?.refreshCollectionView()
+                            }
+                            
+                        case .error(let message):
+                            self?.showErrorAlert(message: message)
+                        }
+                    })
+                })
+            },
+            onLeaveShareConfirmed: nil,
             downloadHandler: { [weak self] file, completion in
                 self?.viewModel?.download(
                     file,
@@ -1442,6 +1462,29 @@ extension MainViewController: FABActionSheetDelegate {
                     self?.getPublicLinkAction(file: file)
                 })
             },
+            onDeleteConfirmed: { [weak self] files in
+                self?.dismiss(animated: true, completion: {
+                    self?.showSpinner()
+                    self?.viewModel?.delete(files, then: { status in
+                        self?.hideSpinner()
+                        
+                        switch status {
+                        case .success:
+                            DispatchQueue.main.async {
+                                self?.viewModel?.removeSyncedFiles(files)
+                                self?.refreshCollectionView()
+                                self?.dismissFloatingActionIsland()
+                                self?.fabView.isHidden = false
+                                self?.clearButtonWasPressed(UIButton())
+                            }
+                            
+                        case .error(let message):
+                            self?.showErrorAlert(message: message)
+                        }
+                    })
+                })
+            },
+            onLeaveShareConfirmed: nil,
             downloadHandler: { [weak self] file, completion in
                 self?.viewModel?.download(
                     file,

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -763,6 +763,44 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self?.getShareLinkAction(file: file)
                 })
             },
+            onDeleteConfirmed: { [weak self] files in
+                self?.dismiss(animated: true, completion: {
+                    self?.showSpinner()
+                    self?.viewModel?.delete(files, then: { status in
+                        self?.hideSpinner()
+                        
+                        switch status {
+                        case .success:
+                            DispatchQueue.main.async {
+                                self?.viewModel?.removeSyncedFiles(files)
+                                self?.refreshCollectionView()
+                            }
+                            
+                        case .error(let message):
+                            self?.showErrorAlert(message: message)
+                        }
+                    })
+                })
+            },
+            onLeaveShareConfirmed: { [weak self] file in
+                self?.dismiss(animated: true, completion: {
+                    self?.showSpinner()
+                    self?.viewModel?.unshare(file, then: { status in
+                        self?.hideSpinner()
+                        
+                        switch status {
+                        case .success:
+                            DispatchQueue.main.async {
+                                self?.viewModel?.removeSyncedFiles([file])
+                                self?.refreshCollectionView()
+                            }
+                            
+                        case .error(let message):
+                            self?.showErrorAlert(message: message)
+                        }
+                    })
+                })
+            },
             downloadHandler: { [weak self] file, completion in
                 self?.viewModel?.download(
                     file,
@@ -862,6 +900,47 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                 // Dismiss the menu first, then handle get link
                 self?.dismiss(animated: true, completion: {
                     self?.getShareLinkAction(file: file)
+                })
+            },
+            onDeleteConfirmed: { [weak self] files in
+                self?.dismiss(animated: true, completion: {
+                    self?.showSpinner()
+                    self?.viewModel?.delete(files, then: { status in
+                        self?.hideSpinner()
+                        
+                        switch status {
+                        case .success:
+                            DispatchQueue.main.async {
+                                self?.viewModel?.removeSyncedFiles(files)
+                                self?.refreshCollectionView()
+                                self?.dismissFloatingActionIsland()
+                                self?.fabView.isHidden = false
+                                self?.clearButtonWasPressed(UIButton())
+                            }
+                            
+                        case .error(let message):
+                            self?.showErrorAlert(message: message)
+                        }
+                    })
+                })
+            },
+            onLeaveShareConfirmed: { [weak self] file in
+                self?.dismiss(animated: true, completion: {
+                    self?.showSpinner()
+                    self?.viewModel?.unshare(file, then: { status in
+                        self?.hideSpinner()
+                        
+                        switch status {
+                        case .success:
+                            DispatchQueue.main.async {
+                                self?.viewModel?.removeSyncedFiles([file])
+                                self?.refreshCollectionView()
+                            }
+                            
+                        case .error(let message):
+                            self?.showErrorAlert(message: message)
+                        }
+                    })
                 })
             },
             downloadHandler: { [weak self] file, completion in

--- a/Permanent/ViewModels/ViewModel/FileMenuViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FileMenuViewModel.swift
@@ -49,6 +49,12 @@ class FileMenuViewModel: ObservableObject {
     @Published var pressedMenuItemId: String?
     @Published var specialMenuItemRequested: MenuItem?
     
+    @Published var showDeleteConfirmation: Bool = false
+    @Published var showLeaveShareConfirmation: Bool = false
+    @Published var pendingDeleteAction: (() -> Void)?
+    @Published var pendingLeaveShareAction: (() -> Void)?
+    @Published var isExecutingAction: Bool = false
+    
     // MARK: - Input Properties
     let fileViewModel: FileModel
     let menuItems: [MenuItem]
@@ -333,6 +339,16 @@ class FileMenuViewModel: ObservableObject {
     
     // MARK: - Action Handling Logic
     func handleMenuItemTap(_ menuItem: MenuItem) {
+        if menuItem.type == .delete {
+            pendingDeleteAction = menuItem.action
+            showDeleteConfirmation = true
+            return
+        } else if menuItem.type == .unshare {
+            pendingLeaveShareAction = menuItem.action
+            showLeaveShareConfirmation = true
+            return
+        }
+        
         if menuItem.type == .shareToAnotherApp || menuItem.type == .shareToPermanent {
             handleMenuItemAction(menuItem)
         } else if menuItem.type == .editMetadata {
@@ -645,6 +661,33 @@ class FileMenuViewModel: ObservableObject {
     
     func clearSpecialMenuItemRequest() {
         specialMenuItemRequested = nil
+    }
+    
+    // MARK: - Confirmation Actions
+    func executeDeleteAction() {
+        dismissWithAnimation()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.pendingDeleteAction?()
+            self.pendingDeleteAction = nil
+        }
+    }
+    
+    func executeLeaveShareAction() {
+        dismissWithAnimation()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.pendingLeaveShareAction?()
+            self.pendingLeaveShareAction = nil
+        }
+    }
+    
+    func cancelDeleteAction() {
+        showDeleteConfirmation = false
+        pendingDeleteAction = nil
+    }
+    
+    func cancelLeaveShareAction() {
+        showLeaveShareConfirmation = false
+        pendingLeaveShareAction = nil
     }
     
     // MARK: - Menu Item Row Helpers


### PR DESCRIPTION
Add confirmation alerts for delete and leave share actions in FileMoreMenuView which is used in both Private and share workspace

Preview: 

https://github.com/user-attachments/assets/5c829190-f6bd-46b5-9d44-a78133f4bcec


