### PR TITLE
VSP-1664 [IOS][Mobile] UI Changes

### DIFF
--- a/Permanent/Common/Models/Enums/AccessRole.swift
+++ b/Permanent/Common/Models/Enums/AccessRole.swift
@@ -85,17 +85,17 @@ extension AccessRole: SelectableOption {
     var description: String {
         switch self {
         case .viewer:
-            return "A member with permission to view records only."
+            return "Can view all materials but cannot edit, delete, upload, publish, or share anything."
         case .contributor:
-            return "A member with permission to view and create file and folder records (upload only)."
+            return "Can upload new materials but cannot edit metadata, delete items, publish content, or share."
         case .editor:
-            return "A member with permission to view and create file and folder records."
+            return "Can upload and edit metadata but cannot delete materials, publish them, or share anything."
         case .curator:
-            return "A member with permission to view and create file and folder records."
-        case .manager: //will not be included in the role selector for share
-            return "A member with permission to view and create file and folder records."
+            return "Trusted member with full control: edit, organize, delete, publish, share, and manage archive membership."
+        case .manager:
+            return "Trusted member with full control: edit, organize, delete, publish, share, and manage archive membership."
         case .owner:
-            return "A member with permission to view and create file and folder records."
+            return "Has ultimate control: manages roles, settings, and full archive access, including deletion."
         }
     }
     

--- a/Permanent/Modules/FileOperations/ViewController/FileMenuViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FileMenuViewController.swift
@@ -292,7 +292,9 @@ class FileMenuViewController: BaseViewController<ShareLinkViewModel> {
         permissionLabel.setTextSpacingBy(value: 0.8)
         
         let permissionValueLabel = UILabel(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 20))
-        permissionValueLabel.text = fileViewModel.accessRole.groupName
+        // For file sharing, display curator when backend returns manager
+        let displayRole = fileViewModel.accessRole == .manager ? AccessRole.curator : fileViewModel.accessRole
+        permissionValueLabel.text = displayRole.groupName
         permissionValueLabel.font = TextFontStyle.style34.font
         permissionValueLabel.textColor = .dustyGray
         
@@ -452,7 +454,10 @@ class FileMenuViewController: BaseViewController<ShareLinkViewModel> {
         
         let maxArchivesShown = showAllArchives ? fileViewModel.minArchiveVOS.count : min(fileViewModel.minArchiveVOS.count, 2)
         for (idx, archive) in fileViewModel.minArchiveVOS[0 ..< maxArchivesShown].enumerated() {
-            let accessRole = ShareStatus.status(forValue: archive.shareStatus) == .pending  ? "Pending...".localized() : AccessRole.roleForValue(archive.accessRole).groupName
+            let role = AccessRole.roleForValue(archive.accessRole)
+            // For file sharing, display curator when backend returns manager
+            let displayRole = role == .manager ? AccessRole.curator : role
+            let accessRole = ShareStatus.status(forValue: archive.shareStatus) == .pending  ? "Pending...".localized() : displayRole.groupName
             
             let archiveStackView = archiveStackView(withArchiveName: "The \(archive.name) Archive", role: accessRole, imagePath: archive.thumbnail ?? "", tag: idx + 1)
             subviews.append(archiveStackView)

--- a/Permanent/Modules/Shares/Cells/ShareManagementCollectionViewCells/ShareManagementSharedWithCollectionViewCell.swift
+++ b/Permanent/Modules/Shares/Cells/ShareManagementCollectionViewCells/ShareManagementSharedWithCollectionViewCell.swift
@@ -46,7 +46,10 @@ class ShareManagementSharedWithCollectionViewCell: UICollectionViewCell {
     
     func configure(withShareVO shareVO: MinArchiveVO) {
         nameLabel.text = "The " + (shareVO.name) + " Archive"
-        roleLabel.text = AccessRole.roleForValue(shareVO.accessRole).groupName.uppercased()
+        let role = AccessRole.roleForValue(shareVO.accessRole)
+        // For file sharing, display curator when backend returns manager
+        let displayRole = role == .manager ? AccessRole.curator : role
+        roleLabel.text = displayRole.groupName.uppercased()
         
         let url = URL(string: shareVO.thumbnail)
         archiveImageView.sd_setImage(with: url)

--- a/Permanent/Modules/Shares/SwiftUIViews/Components/SelectableOptionView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/Components/SelectableOptionView.swift
@@ -26,7 +26,7 @@ struct SelectableOptionView<T: SelectableOption>: View {
                 // Content
                 VStack(alignment: .leading, spacing: 16) {
                     Text(option.title)
-                        .font(.custom("Usual-Medium", size: 14))
+                        .font(.custom(isSelected ? "Usual-Medium" : "Usual-Regular", size: 14))
                         .foregroundColor(Color.blue900)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     

--- a/Permanent/Modules/Shares/SwiftUIViews/Components/ShareComponents.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/Components/ShareComponents.swift
@@ -255,6 +255,81 @@ struct ArchiveAccessNotificationView: View {
     }
 }
 
+struct LinkSettingsNotificationView: View {
+    @State private var isVisible = false
+    @State private var checkmarkScale: CGFloat = 0.5
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .font(.system(size: 20, weight: .medium))
+                .scaleEffect(checkmarkScale)
+                .animation(.spring(response: 0.4, dampingFraction: 0.6), value: checkmarkScale)
+            
+            Text("Link settings have been updated.")
+                .foregroundColor(.white)
+                .font(.custom("Usual-Regular", size: 14))
+                .opacity(isVisible ? 1.0 : 0.0)
+                .animation(.easeInOut(duration: 0.3).delay(0.1), value: isVisible)
+            
+            Spacer()
+        }
+        .padding(.vertical, 4)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.black.opacity(0.85))
+                .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
+                .scaleEffect(isVisible ? 1.0 : 0.8)
+                .animation(.spring(response: 0.5, dampingFraction: 0.7), value: isVisible)
+        )
+        .onAppear {
+            withAnimation {
+                isVisible = true
+                checkmarkScale = 1.0
+            }
+        }
+    }
+}
+
+struct RevokeLinkNotificationView: View {
+    @State private var isVisible = false
+    @State private var checkmarkScale: CGFloat = 0.5
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .font(.system(size: 20, weight: .medium))
+                .scaleEffect(checkmarkScale)
+                .animation(.spring(response: 0.4, dampingFraction: 0.6), value: checkmarkScale)
+            
+            Text("Link has been revoked.")
+                .foregroundColor(.white)
+                .font(.custom("Usual-Regular", size: 14))
+                .opacity(isVisible ? 1.0 : 0.0)
+                .animation(.easeInOut(duration: 0.3).delay(0.1), value: isVisible)
+            
+            Spacer()
+        }
+        .padding(.vertical, 4)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.black.opacity(0.85))
+                .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
+                .scaleEffect(isVisible ? 1.0 : 0.8)
+                .animation(.spring(response: 0.5, dampingFraction: 0.7), value: isVisible)
+        )
+        .onAppear {
+            withAnimation {
+                isVisible = true
+                checkmarkScale = 1.0
+            }
+        }
+    }
+}
 struct AnimatedTextWithDotsView: View {
     @State private var dotCount = 0
     

--- a/Permanent/Modules/Shares/SwiftUIViews/RoleSelectionView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/RoleSelectionView.swift
@@ -24,7 +24,7 @@ struct RoleSelectionView: View {
                 .background(Color.blue50)
             ScrollView {
                 LazyVStack(spacing: 0) {
-                    ForEach(AccessRole.allCases.filter { $0 != .curator }, id: \.self) { role in
+                    ForEach([AccessRole.viewer, .contributor, .editor, .curator, .owner], id: \.self) { role in
                         SelectableOptionView(
                             option: role,
                             isSelected: isRoleSelected(role),

--- a/Permanent/Modules/Shares/SwiftUIViews/ShareContainerView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ShareContainerView.swift
@@ -76,6 +76,26 @@ struct ShareContainerView: View {
                         .padding(.horizontal, 24)
                         .frame(maxWidth: .infinity, alignment: .center)
                 }
+                
+                if viewModel.showLinkSettingsNotification {
+                    LinkSettingsNotificationView()
+                        .transition(.asymmetric(
+                            insertion: .move(edge: .bottom).combined(with: .opacity).combined(with: .scale(scale: 0.8)),
+                            removal: .move(edge: .bottom).combined(with: .opacity)
+                        ))
+                        .padding(.horizontal, 24)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+                
+                if viewModel.showRevokeLinkNotification {
+                    RevokeLinkNotificationView()
+                        .transition(.asymmetric(
+                            insertion: .move(edge: .bottom).combined(with: .opacity).combined(with: .scale(scale: 0.8)),
+                            removal: .move(edge: .bottom).combined(with: .opacity)
+                        ))
+                        .padding(.horizontal, 24)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
             }
         }
         .animation(.easeInOut(duration: 0.3), value: viewModel.showLinkSettings)
@@ -83,5 +103,9 @@ struct ShareContainerView: View {
         .animation(.easeInOut(duration: 0.3), value: viewModel.showRoleSelection)
         .animation(.easeInOut(duration: 0.3), value: viewModel.showArchiveAccessManagement)
         .animation(.easeInOut(duration: 0.3), value: viewModel.navigationDirection)
+        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: viewModel.showCopyNotification)
+        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: viewModel.showArchiveAccessNotification)
+        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: viewModel.showLinkSettingsNotification)
+        .animation(.spring(response: 0.4, dampingFraction: 0.7), value: viewModel.showRevokeLinkNotification)
     }
 }

--- a/Permanent/Modules/Shares/SwiftUIViews/ShareItemView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ShareItemView.swift
@@ -557,7 +557,9 @@ struct ShareItemView: View {
     
     private func accessRoleFromShareVO(_ shareVO: ShareVOData) -> AccessRole {
         let accessRole = shareVO.accessRole ?? "viewer"
-        return AccessRole.roleForValue(accessRole)
+        let role = AccessRole.roleForValue(accessRole)
+        // For file sharing, display curator when backend returns manager
+        return role == .manager ? .curator : role
     }
     
     // MARK: - Loading Overlay

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
@@ -100,6 +100,8 @@ class ShareItemViewModel: ObservableObject {
     @Published var selectedExpiration: ShareExpirationOption = .none
     @Published var showCopyNotification = false
     @Published var showArchiveAccessNotification = false
+    @Published var showLinkSettingsNotification = false
+    @Published var showRevokeLinkNotification = false
     @Published var hasUnsavedChanges = false
     @Published var selectedAccessLevel: ShareViewAccessLevel = .anyoneCanView
     @Published var showGeneralAccess = false
@@ -555,7 +557,7 @@ class ShareItemViewModel: ObservableObject {
         case "viewer": return .viewer
         case "contributor": return .contributor
         case "editor": return .editor
-        case "manager": return .manager
+        case "manager": return .curator // Backend uses manager, UI shows curator
         case "owner": return .owner
         default: return .viewer
         }
@@ -585,16 +587,58 @@ class ShareItemViewModel: ObservableObject {
     }
     
     func showArchiveAccessUpdatedNotification() {
-        withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
-            showArchiveAccessNotification = true
-        }
-        
-        // Hide notification after 2 seconds with animation
+        // Delay showing the notification to allow view transition to complete
         Task {
+            try await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds delay
+            await MainActor.run {
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                    showArchiveAccessNotification = true
+                }
+            }
+            
+            // Hide notification after 2 seconds with animation
             try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
             await MainActor.run {
                 withAnimation(.easeInOut(duration: 0.3)) {
                     showArchiveAccessNotification = false
+                }
+            }
+        }
+    }
+    
+    func showLinkSettingsUpdatedNotification() {
+        // Delay showing the notification to allow view transition to complete
+        Task {
+            try await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds delay
+            await MainActor.run {
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                    showLinkSettingsNotification = true
+                }
+            }
+            
+            // Hide notification after 2 seconds with animation
+            try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+            await MainActor.run {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    showLinkSettingsNotification = false
+                }
+            }
+        }
+    }
+    
+    func showRevokeLinkSuccessNotification() {
+        Task {
+            try await Task.sleep(nanoseconds: 500_000_000) // 0.5 seconds delay
+            await MainActor.run {
+                withAnimation(.spring(response: 0.6, dampingFraction: 0.8)) {
+                    showRevokeLinkNotification = true
+                }
+            }
+            
+            try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+            await MainActor.run {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    showRevokeLinkNotification = false
                 }
             }
         }
@@ -642,6 +686,7 @@ class ShareItemViewModel: ObservableObject {
                                 self.shareLinkV2Data = nil
                                 self.navigationDirection = .backward
                                 self.showLinkSettings = false
+                                self.showRevokeLinkSuccessNotification()
                             case .error(let message):
                                 self.errorMessage = message
                             }
@@ -664,6 +709,7 @@ class ShareItemViewModel: ObservableObject {
                                 self.shareLinkV2Data = nil
                                 self.navigationDirection = .backward
                                 self.showLinkSettings = false
+                                self.showRevokeLinkSuccessNotification()
                             case .error(_):
                                 // If V2 API fails, fallback to V1 API
                                 self.revokeLinkV1(shareVO: shareVO)
@@ -693,6 +739,7 @@ class ShareItemViewModel: ObservableObject {
                         self.shareLinkV2Data = nil
                         self.navigationDirection = .backward
                         self.showLinkSettings = false
+                        self.showRevokeLinkSuccessNotification()
                     case .error(let message):
                         self.errorMessage = message
                     }
@@ -905,6 +952,9 @@ class ShareItemViewModel: ObservableObject {
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                                     self.navigationDirection = .backward
                                     self.showLinkSettings = false
+                                    
+                                    // Show success notification
+                                    self.showLinkSettingsUpdatedNotification()
                                 }
                             }
                         }
@@ -948,7 +998,7 @@ class ShareItemViewModel: ObservableObject {
         case .editor: return "editor"
         case .manager: return "manager"
         case .owner: return "owner"
-        case .curator: return "editor" // Map curator to editor since it's not in V2 API
+        case .curator: return "manager" // Backend expects manager for curator role
         }
     }
     

--- a/Permanent/ViewModels/ViewModel/FileMenuViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FileMenuViewModel.swift
@@ -237,7 +237,9 @@ class FileMenuViewModel: ObservableObject {
         guard showArchiveInfo, fileViewModel.sharedByArchive != nil else {
             return nil
         }
-        return fileViewModel.accessRole.title.uppercased()
+        // For file sharing, display curator when backend returns manager
+        let displayRole = fileViewModel.accessRole == .manager ? AccessRole.curator : fileViewModel.accessRole
+        return displayRole.title.uppercased()
     }
     
     // MARK: - Access Role Update


### PR DESCRIPTION
Refactor access role descriptions and enhance share notifications UI
Added notifications for the following actions:
 - Revoke link access
 - Save/Change link settings 
 - Save/Change archive access role
 
In link settings changed the endpoint request for 'Manager' for both Curator and Manager access roles.

Preview of this implementation 


https://github.com/user-attachments/assets/280bd44e-b8d4-41c1-8ca9-82c0d3bdb4b1

