### PR TITLE
VSP-1696 [IOS][Mobile]Open share management, when user taps on the received notification for a file/folder access request

### DIFF
--- a/Permanent/Common/Scenes/Share Preview/ViewControllers/SharePreviewHostingController.swift
+++ b/Permanent/Common/Scenes/Share Preview/ViewControllers/SharePreviewHostingController.swift
@@ -92,6 +92,53 @@ class SharePreviewHostingController: UIHostingController<SharePreviewView> {
                 }
                 
                 AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: sharesVC)
+            },
+            onNavigateToFilePreview: { [weak self] params in
+                guard let self = self else { return }
+                
+                // Navigate to Shared with Me tab first
+                guard let sharesVC = UIViewController.create(
+                    withIdentifier: .shares,
+                    from: .share
+                ) as? SharesViewController else { return }
+                
+                sharesVC.selectedIndex = ShareListType.sharedWithMe.rawValue
+                
+                // Get current archive permissions
+                let permissions = AuthenticationManager.shared.session?.selectedArchive?.accessRole.flatMap { 
+                    ArchiveVOData.permissions(forAccessRole: $0) 
+                } ?? []
+                
+                // Create the file model
+                let file = FileModel(
+                    name: params.name,
+                    recordId: params.recordId,
+                    folderLinkId: params.folderLinkId,
+                    archiveNbr: params.archiveNbr,
+                    type: params.type,
+                    permissions: permissions,
+                    thumbnailURL2000: params.thumbnailURL
+                )
+                
+                // Change to shares view
+                AppDelegate.shared.rootViewController.changeDrawerRoot(viewController: sharesVC)
+                
+                // After a short delay to allow the view to load, present the file preview
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    let filePreviewVC = FilePreviewListViewController(nibName: nil, bundle: nil)
+                    filePreviewVC.modalPresentationStyle = .fullScreen
+                    filePreviewVC.currentFile = file
+                    filePreviewVC.isFromNotification = true
+                    
+                    // Use a minimal view model
+                    let viewModel = MyFilesViewModel()
+                    filePreviewVC.viewModel = viewModel
+                    
+                    let navController = FilePreviewNavigationController(rootViewController: filePreviewVC)
+                    navController.modalPresentationStyle = .fullScreen
+                    
+                    sharesVC.present(navController, animated: true)
+                }
             }
         )
     }

--- a/Permanent/Modules/Shares/SwiftUIViews/SharePreview/SharePreviewView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/SharePreview/SharePreviewView.swift
@@ -21,12 +21,14 @@ struct SharePreviewView: View {
          onNavigateToFolder: ((NavigateMinParams) -> Void)? = nil,
          onNavigateToShares: ((String) -> Void)? = nil,
          onNavigateToSharedWithMe: ((NavigateMinParams?) -> Void)? = nil,
-         onNavigateToSharedByMe: ((NavigateMinParams?) -> Void)? = nil) {
+         onNavigateToSharedByMe: ((NavigateMinParams?) -> Void)? = nil,
+         onNavigateToFilePreview: ((FilePreviewParams) -> Void)? = nil) {
         let vm = SharePreviewSwiftUIViewModel(shareToken: shareToken)
         vm.onNavigateToFolder = onNavigateToFolder
         vm.onNavigateToShares = onNavigateToShares
         vm.onNavigateToSharedWithMe = onNavigateToSharedWithMe
         vm.onNavigateToSharedByMe = onNavigateToSharedByMe
+        vm.onNavigateToFilePreview = onNavigateToFilePreview
         _viewModel = StateObject(wrappedValue: vm)
     }
     

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
@@ -1179,6 +1179,12 @@ class ShareItemViewModel: ObservableObject {
                 return nil
             }
             
+            // Skip if the access role is owner
+            if let accessRole = share.accessRole,
+               AccessRole.roleForValue(accessRole) == .owner {
+                return nil
+            }
+            
             let folderLinkId = self.correctFolderLinkId ?? self.fileModel.folderLinkId
             let archiveVO = self.makeArchiveVO(from: archiveData)
 
@@ -1274,8 +1280,25 @@ class ShareItemViewModel: ObservableObject {
                         if let folderVO = folderVO,
                            let folderData = folderVO.folderVO {
                             if let shareVOs = folderData.shareVOS, !shareVOs.isEmpty {
+                                // Filter out owner archives (same as V2 API)
+                                let userOwnArchiveId = AuthenticationManager.shared.session?.selectedArchive?.archiveID
+                                let filteredShares = shareVOs.filter { share in
+                                    // Exclude if this is the user's own archive
+                                    if let userOwnId = userOwnArchiveId,
+                                       let shareArchiveId = share.archiveID,
+                                       shareArchiveId == userOwnId {
+                                        return false
+                                    }
+                                    // Exclude if the access role is owner
+                                    if let accessRole = share.accessRole,
+                                       AccessRole.roleForValue(accessRole) == .owner {
+                                        return false
+                                    }
+                                    return true
+                                }
+                                
                                 // Sort pending shares first, then approved shares
-                                self.sharedArchives = shareVOs.sorted { share1, share2 in
+                                self.sharedArchives = filteredShares.sorted { share1, share2 in
                                     let isPending1 = share1.status?.contains("pending") ?? false
                                     let isPending2 = share2.status?.contains("pending") ?? false
                                     return isPending1 && !isPending2
@@ -1310,8 +1333,25 @@ class ShareItemViewModel: ObservableObject {
                         if let recordVO = recordVO,
                            let recordData = recordVO.recordVO {
                             if let shareVOs = recordData.shareVOS, !shareVOs.isEmpty {
+                                // Filter out owner archives (same as V2 API)
+                                let userOwnArchiveId = AuthenticationManager.shared.session?.selectedArchive?.archiveID
+                                let filteredShares = shareVOs.filter { share in
+                                    // Exclude if this is the user's own archive
+                                    if let userOwnId = userOwnArchiveId,
+                                       let shareArchiveId = share.archiveID,
+                                       shareArchiveId == userOwnId {
+                                        return false
+                                    }
+                                    // Exclude if the access role is owner
+                                    if let accessRole = share.accessRole,
+                                       AccessRole.roleForValue(accessRole) == .owner {
+                                        return false
+                                    }
+                                    return true
+                                }
+                                
                                 // Sort pending shares first, then approved shares
-                                self.sharedArchives = shareVOs.sorted { share1, share2 in
+                                self.sharedArchives = filteredShares.sorted { share1, share2 in
                                     let isPending1 = share1.status?.contains("pending") ?? false
                                     let isPending2 = share2.status?.contains("pending") ?? false
                                     return isPending1 && !isPending2

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/SharePreviewSwiftUIViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/SharePreviewSwiftUIViewModel.swift
@@ -107,6 +107,7 @@ final class SharePreviewSwiftUIViewModel: ObservableObject {
     var onNavigateToShares: ((String) -> Void)?
     var onNavigateToSharedWithMe: ((NavigateMinParams?) -> Void)?
     var onNavigateToSharedByMe: ((NavigateMinParams?) -> Void)?
+    var onNavigateToFilePreview: ((FilePreviewParams) -> Void)?
 
     init(shareToken: String,
          repository: SharePreviewRepositoryProtocol = SharePreviewAPIService(),
@@ -353,9 +354,28 @@ final class SharePreviewSwiftUIViewModel: ObservableObject {
     }
     
     private func navigateToFolder() {
-        if let folderData = self.shareDataCache?.folderData,
-           let folderLinkId = folderData.folderLinkID,
+        // Check if it's a single file/record - open in file preview directly
+        if let recordData = self.shareDataCache?.recordData,
+           let recordId = recordData.recordID,
+           let folderLinkId = recordData.folderLinkID,
            let archiveNbr = self.currentArchive?.archiveNbr {
+            let fileType = recordData.type ?? FileType.miscellaneous.rawValue
+            let fileName = recordData.displayName ?? "File"
+            let thumbnailURL = recordData.thumbURL2000 ?? recordData.thumbURL500 ?? ""
+            let params = FilePreviewParams(
+                name: fileName,
+                recordId: recordId,
+                folderLinkId: folderLinkId,
+                archiveNbr: archiveNbr,
+                type: fileType,
+                thumbnailURL: thumbnailURL
+            )
+            self.onNavigateToFilePreview?(params)
+        }
+        // For folders, navigate to shared with me folder view
+        else if let folderData = self.shareDataCache?.folderData,
+                let folderLinkId = folderData.folderLinkID,
+                let archiveNbr = self.currentArchive?.archiveNbr {
             let params: NavigateMinParams = (archiveNo: archiveNbr, folderLinkId: folderLinkId, folderName: folderData.displayName)
             self.onNavigateToSharedWithMe?(params)
         } else if let navigateToShares = self.onNavigateToShares,
@@ -697,6 +717,15 @@ enum SharePreviewItemType: String, Codable {
     case folder = "folder"
     case image = "image"
     case other = "other"
+}
+
+struct FilePreviewParams {
+    let name: String
+    let recordId: Int
+    let folderLinkId: Int
+    let archiveNbr: String
+    let type: String
+    let thumbnailURL: String
 }
 
 // MARK: - Repository Protocol

--- a/Permanent/Tests/Permanent-DEV-UnitTests.xctestplan
+++ b/Permanent/Tests/Permanent-DEV-UnitTests.xctestplan
@@ -9,7 +9,15 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Permanent.xcodeproj",
+          "identifier" : "5E2C5D1624D98EE100E2B95F",
+          "name" : "Permanent"
+        }
+      ]
+    },
     "targetForVariableExpansion" : {
       "containerPath" : "container:Permanent.xcodeproj",
       "identifier" : "5E2C5D1624D98EE100E2B95F",


### PR DESCRIPTION
Fixed a bug where "Current Requests and Access" section wasn't hiding after removing the last visible archive because owner archives were being counted but not displayed.