### PR TITLE
VSP-1756 [iOS][Mobile] Disable already-accessed archives from being selected again & show proper message

### DIFF
--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		5E68830828902DBF0006F434 /* LoginUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E68830728902DBF0006F434 /* LoginUITests.swift */; };
 		5E68F2D926A9A2CD00CC936E /* TestURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E68F2D826A9A2CD00CC936E /* TestURLs.swift */; };
 		5E68F2DB26A9A32400CC936E /* ResponseURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E68F2DA26A9A32400CC936E /* ResponseURLProtocol.swift */; };
+		5E6930452FB6530900A1C3A6 /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6930442FB6530900A1C3A6 /* CachedAsyncImage.swift */; };
 		5E6AD37528A1A85A005ADF7E /* PhotoLibraryPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6AD37428A1A85A005ADF7E /* PhotoLibraryPage.swift */; };
 		5E6C22272DD62DB10078A875 /* ChecklistCongratsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6C22262DD62DB00078A875 /* ChecklistCongratsView.swift */; };
 		5E6CCEDC2B71145E00D192FF /* SettingsRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6CCEDB2B71145E00D192FF /* SettingsRouter.swift */; };
@@ -1424,6 +1425,7 @@
 		5E68F2D026A74FCD00CC936E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5E68F2D826A9A2CD00CC936E /* TestURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestURLs.swift; sourceTree = "<group>"; };
 		5E68F2DA26A9A32400CC936E /* ResponseURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseURLProtocol.swift; sourceTree = "<group>"; };
+		5E6930442FB6530900A1C3A6 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
 		5E6AD37428A1A85A005ADF7E /* PhotoLibraryPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryPage.swift; sourceTree = "<group>"; };
 		5E6C22262DD62DB00078A875 /* ChecklistCongratsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecklistCongratsView.swift; sourceTree = "<group>"; };
 		5E6CCEDB2B71145E00D192FF /* SettingsRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRouter.swift; sourceTree = "<group>"; };
@@ -3693,6 +3695,7 @@
 				5EA70D8E2B2C793A00175D9C /* GradientCustomBarView.swift */,
 				926273692BCD31DC00D824CE /* SnackBarView.swift */,
 				5EE77BD82C3EADD4006D854C /* AccessRoleChipView.swift */,
+				5E6930442FB6530900A1C3A6 /* CachedAsyncImage.swift */,
 			);
 			path = SwiftUIViews;
 			sourceTree = "<group>";
@@ -5564,6 +5567,7 @@
 				5EAB11222EDDF8A0003A902E /* CreateNewFolderViewModel.swift in Sources */,
 				F56AA040261F1B930054B6EF /* DeviceEndpoint.swift in Sources */,
 				92430A5E2AF2A1F00098597D /* EmailChipsTextField.swift in Sources */,
+				5E6930452FB6530900A1C3A6 /* CachedAsyncImage.swift in Sources */,
 				5E624DC5294B27F7002D6ECB /* MFASession.swift in Sources */,
 				5EAB11192ED8690D003A902E /* FABMenuView.swift in Sources */,
 				925FF4662CFF52AC000B44D4 /* EventActions.swift in Sources */,
@@ -6479,7 +6483,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D COCOAPODS";
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -6512,7 +6516,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -6536,7 +6540,7 @@
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive.PermanentUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6561,7 +6565,7 @@
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive.PermanentUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6586,7 +6590,7 @@
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive.PermanentUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6611,7 +6615,7 @@
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive.PermanentUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6642,7 +6646,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vsp.PermanentTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6672,7 +6676,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vsp.PermanentTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6702,7 +6706,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vsp.PermanentTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6732,7 +6736,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.vsp.PermanentTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -6980,7 +6984,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				OTHER_SWIFT_FLAGS = "-D COCOAPODS -DSTAGING_ENVIRONMENT";
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.permanent.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -7070,7 +7074,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				OTHER_SWIFT_FLAGS = "-D COCOAPODS -DSTAGING_ENVIRONMENT";
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.permanent.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -7100,7 +7104,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive.PushExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7129,7 +7133,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.permanent.staging.PushExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7158,7 +7162,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.PermanentArchive.PushExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7187,7 +7191,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.14.2;
+				MARKETING_VERSION = 1.15.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.permanent.permanent.staging.PushExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Permanent/Common/Base/SwiftUIViews/CachedAsyncImage.swift
+++ b/Permanent/Common/Base/SwiftUIViews/CachedAsyncImage.swift
@@ -1,0 +1,66 @@
+//
+//  CachedAsyncImage.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 14.05.2026.
+//
+
+import SwiftUI
+import UIKit
+
+final class ImageCache {
+    static let shared = ImageCache()
+    private let cache = NSCache<NSURL, UIImage>()
+
+    private init() {}
+
+    func image(for url: URL) -> UIImage? {
+        cache.object(forKey: url as NSURL)
+    }
+
+    func insert(_ image: UIImage, for url: URL) {
+        cache.setObject(image, forKey: url as NSURL)
+    }
+}
+
+struct CachedAsyncImage<Placeholder: View>: View {
+    let url: URL?
+    let placeholder: () -> Placeholder
+
+    @State private var image: UIImage?
+
+    init(url: URL?, @ViewBuilder placeholder: @escaping () -> Placeholder) {
+        self.url = url
+        self.placeholder = placeholder
+        if let url, let cached = ImageCache.shared.image(for: url) {
+            self._image = State(initialValue: cached)
+        }
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                placeholder()
+            }
+        }
+        .onAppear {
+            Task { await load() }
+        }
+    }
+
+    private func load() async {
+        guard image == nil, let url else { return }
+        if let cached = ImageCache.shared.image(for: url) {
+            self.image = cached
+            return
+        }
+        guard let (data, _) = try? await URLSession.shared.data(from: url),
+              let downloaded = UIImage(data: data) else { return }
+        ImageCache.shared.insert(downloaded, for: url)
+        self.image = downloaded
+    }
+}

--- a/Permanent/Modules/Shares/SwiftUIViews/ShareArchivesFromPastSharesView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ShareArchivesFromPastSharesView.swift
@@ -241,49 +241,68 @@ struct ShareArchivesFromPastSharesView: View {
     }
 
     private func archiveRow(_ archive: ShareArchivesFromPastSharesViewModel.PastSharedArchive) -> some View {
-        Button(action: {
-            dismissKeyboard()
-            viewModel.openGrantArchiveAccess(
-                archiveName: archive.title,
-                archiveInitials: archive.initials,
-                archiveID: archive.archiveID,
-                thumbnailURL: archive.thumbnailURL,
-                source: .pastShares
-            )
-        }) {
-            HStack(spacing: 16) {
-                archiveThumbnail(thumbnailURL: archive.thumbnailURL)
-                    .frame(width: 40, height: 40)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+        let hasAccess = archivesViewModel.hasAccess(archive)
 
+        return Group {
+            if hasAccess {
+                archiveRowContent(archive, hasAccess: true)
+            } else {
+                Button(action: {
+                    dismissKeyboard()
+                    viewModel.openGrantArchiveAccess(
+                        archiveName: archive.title,
+                        archiveInitials: archive.initials,
+                        archiveID: archive.archiveID,
+                        thumbnailURL: archive.thumbnailURL,
+                        source: .pastShares
+                    )
+                }) {
+                    archiveRowContent(archive, hasAccess: false)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+    }
+
+    private func archiveRowContent(_ archive: ShareArchivesFromPastSharesViewModel.PastSharedArchive, hasAccess: Bool) -> some View {
+        HStack(spacing: 16) {
+            archiveThumbnail(thumbnailURL: archive.thumbnailURL)
+                .frame(width: 40, height: 40)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .opacity(hasAccess ? 0.5 : 1)
+
+            VStack(alignment: .leading, spacing: 2) {
                 Text(archive.title)
                     .font(.custom("Usual-Regular", size: 14))
-                    .foregroundColor(Color.blue900)
+                    .foregroundColor(hasAccess ? Color.blue300 : Color.blue900)
                     .lineLimit(1)
 
-                Spacer()
+                if hasAccess {
+                    Text("Already has access to this share")
+                        .font(.custom("Usual-Regular", size: 12))
+                        .foregroundColor(Color.success500)
+                        .lineLimit(1)
+                }
+            }
 
+            Spacer()
+
+            if hasAccess {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundColor(Color.blue200)
+            } else {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(Color.blue200)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .buttonStyle(PlainButtonStyle())
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder
     private func archiveThumbnail(thumbnailURL: String?) -> some View {
-        if let thumbnailURL, let url = URL(string: thumbnailURL) {
-            AsyncImage(url: url) { image in
-                image
-                    .resizable()
-                    .scaledToFill()
-            } placeholder: {
-                Image(.shareArchivePending)
-                    .cornerRadius(8)
-            }
-        } else {
+        CachedAsyncImage(url: thumbnailURL.flatMap { URL(string: $0) }) {
             Image(.shareArchivePending)
                 .cornerRadius(8)
         }

--- a/Permanent/Modules/Shares/SwiftUIViews/ShareFindArchiveByEmailView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ShareFindArchiveByEmailView.swift
@@ -285,7 +285,7 @@ struct ShareFindArchiveByEmailView: View {
 
     private func archiveResultsSection(_ archives: [ShareFindArchiveByEmailViewModel.ArchiveResult]) -> some View {
         VStack(spacing: 24) {
-            ForEach(archives) { archive in
+            ForEach(findArchiveViewModel.sortedByAccess(archives)) { archive in
                 archiveRow(archive)
             }
         }
@@ -345,62 +345,78 @@ struct ShareFindArchiveByEmailView: View {
     }
 
     private func archiveRow(_ archive: ShareFindArchiveByEmailViewModel.ArchiveResult) -> some View {
-        Button(action: {
-            if isSearchFocused || isKeyboardVisible {
-                isSearchFocused = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                    viewModel.openGrantArchiveAccess(
-                        archiveName: archive.name,
-                        archiveInitials: archive.initials,
-                        archiveID: archive.archiveID,
-                        thumbnailURL: archive.thumbnailURL,
-                        source: .findByEmail
-                    )
-                }
+        let hasAccess = findArchiveViewModel.hasAccess(archive)
+
+        return Group {
+            if hasAccess {
+                archiveRowContent(archive, hasAccess: true)
             } else {
-                viewModel.openGrantArchiveAccess(
-                    archiveName: archive.name,
-                    archiveInitials: archive.initials,
-                    archiveID: archive.archiveID,
-                    thumbnailURL: archive.thumbnailURL,
-                    source: .findByEmail
-                )
-            }
-        }) {
-            HStack(spacing: 16) {
-                Group {
-                    if let thumbnailURL = archive.thumbnailURL,
-                       let url = URL(string: thumbnailURL) {
-                        AsyncImage(url: url) { image in
-                            image
-                                .resizable()
-                                .scaledToFill()
-                        } placeholder: {
-                            Image(.shareArchivePending)
-                                .cornerRadius(8)
+                Button(action: {
+                    if isSearchFocused || isKeyboardVisible {
+                        isSearchFocused = false
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                            viewModel.openGrantArchiveAccess(
+                                archiveName: archive.name,
+                                archiveInitials: archive.initials,
+                                archiveID: archive.archiveID,
+                                thumbnailURL: archive.thumbnailURL,
+                                source: .findByEmail
+                            )
                         }
                     } else {
-                        Image(.shareArchivePending)
-                            .cornerRadius(8)
+                        viewModel.openGrantArchiveAccess(
+                            archiveName: archive.name,
+                            archiveInitials: archive.initials,
+                            archiveID: archive.archiveID,
+                            thumbnailURL: archive.thumbnailURL,
+                            source: .findByEmail
+                        )
                     }
+                }) {
+                    archiveRowContent(archive, hasAccess: false)
                 }
-                .frame(width: 40, height: 40)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+    }
 
+    private func archiveRowContent(_ archive: ShareFindArchiveByEmailViewModel.ArchiveResult, hasAccess: Bool) -> some View {
+        HStack(spacing: 16) {
+            CachedAsyncImage(url: archive.thumbnailURL.flatMap { URL(string: $0) }) {
+                Image(.shareArchivePending)
+                    .cornerRadius(8)
+            }
+            .frame(width: 40, height: 40)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .opacity(hasAccess ? 0.5 : 1)
+
+            VStack(alignment: .leading, spacing: 2) {
                 Text(archive.name)
                     .font(.custom("Usual-Regular", size: 14))
-                    .foregroundColor(Color.blue900)
+                    .foregroundColor(hasAccess ? Color.blue300 : Color.blue900)
                     .lineLimit(1)
 
-                Spacer()
+                if hasAccess {
+                    Text("Already has access to this share")
+                        .font(.custom("Usual-Regular", size: 12))
+                        .foregroundColor(Color.success500)
+                        .lineLimit(1)
+                }
+            }
 
+            Spacer()
+
+            if hasAccess {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundColor(Color.blue200)
+            } else {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(Color.blue200)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .buttonStyle(PlainButtonStyle())
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var bottomActionSection: some View {

--- a/Permanent/Modules/Shares/SwiftUIViews/ShareGrantArchiveAccessView.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ShareGrantArchiveAccessView.swift
@@ -220,21 +220,9 @@ struct ShareGrantArchiveAccessView: View {
     }
 
     private var avatar: some View {
-        Group {
-            if let thumbnailURL = archiveThumbnailURL,
-               let url = URL(string: thumbnailURL) {
-                AsyncImage(url: url) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                } placeholder: {
-                    Image(.shareArchivePending)
-                        .cornerRadius(8)
-                }
-            } else {
-                Image(.shareArchivePending)
-                    .cornerRadius(8)
-            }
+        CachedAsyncImage(url: archiveThumbnailURL.flatMap { URL(string: $0) }) {
+            Image(.shareArchivePending)
+                .cornerRadius(8)
         }
         .frame(width: 32, height: 32)
         .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareArchivesFromPastSharesViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareArchivesFromPastSharesViewModel.swift
@@ -28,6 +28,16 @@ final class ShareArchivesFromPastSharesViewModel: ObservableObject {
     @Published private(set) var myArchivesList: [PastSharedArchive] = []
     @Published private(set) var otherArchivesList: [PastSharedArchive] = []
     @Published private(set) var isLoading = false
+    @Published private(set) var accessedArchiveIDs: Set<Int> = []
+
+    func setAccessedArchiveIDs(_ ids: Set<Int>) {
+        accessedArchiveIDs = ids
+    }
+
+    func hasAccess(_ archive: PastSharedArchive) -> Bool {
+        guard let id = archive.archiveID else { return false }
+        return accessedArchiveIDs.contains(id)
+    }
 
     var title: String {
         "Select archive from past shares"
@@ -53,17 +63,24 @@ final class ShareArchivesFromPastSharesViewModel: ObservableObject {
         }
     }
 
+    func accessedLast(_ list: [PastSharedArchive]) -> [PastSharedArchive] {
+        list.filter { !hasAccess($0) } + list.filter { hasAccess($0) }
+    }
+
     var myArchives: [PastSharedArchive] {
-        filtered(myArchivesList)
+        accessedLast(filtered(myArchivesList))
     }
 
     var otherArchives: [PastSharedArchive] {
-        filtered(otherArchivesList)
+        accessedLast(filtered(otherArchivesList))
     }
 
-    func fetchArchives() {
+    func fetchArchives(completion: (() -> Void)? = nil) {
         guard let accountId = PermSession.currentSession?.account.accountID,
-              let archiveId = AuthenticationManager.shared.session?.selectedArchive?.archiveID else { return }
+              let archiveId = AuthenticationManager.shared.session?.selectedArchive?.archiveID else {
+            completion?()
+            return
+        }
 
         isLoading = true
 
@@ -139,13 +156,17 @@ final class ShareArchivesFromPastSharesViewModel: ObservableObject {
         }
 
         group.notify(queue: .main) { [weak self] in
-            guard let self else { return }
+            guard let self else {
+                completion?()
+                return
+            }
             let myArchiveIDs = Set(fetchedMyArchives.compactMap { $0.archiveID })
             let dedupedOther = fetchedOtherArchives.filter { !myArchiveIDs.contains($0.archiveID ?? -1) }
 
             self.myArchivesList = fetchedMyArchives
             self.otherArchivesList = dedupedOther
             self.isLoading = false
+            completion?()
         }
     }
 

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareFindArchiveByEmailViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareFindArchiveByEmailViewModel.swift
@@ -30,6 +30,20 @@ final class ShareFindArchiveByEmailViewModel: ObservableObject {
     @Published private(set) var submittedSearchEmail: String?
     @Published private(set) var searchOutcome: SearchOutcome = .idle
     @Published private(set) var isSearching = false
+    @Published private(set) var accessedArchiveIDs: Set<Int> = []
+
+    func setAccessedArchiveIDs(_ ids: Set<Int>) {
+        accessedArchiveIDs = ids
+    }
+
+    func hasAccess(_ archive: ArchiveResult) -> Bool {
+        guard let id = archive.archiveID else { return false }
+        return accessedArchiveIDs.contains(id)
+    }
+
+    func sortedByAccess(_ archives: [ArchiveResult]) -> [ArchiveResult] {
+        archives.filter { !hasAccess($0) } + archives.filter { hasAccess($0) }
+    }
 
     private var searchOperation: APIOperation?
     private let searchProvider: SearchProvider?

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemGrantAndInviteViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemGrantAndInviteViewModel.swift
@@ -21,10 +21,15 @@ extension ShareItemViewModel {
     func openFindArchiveByEmail() {
         navigationDirection = .forward
         findArchiveByEmailViewModel.reset()
+        findArchiveByEmailViewModel.setAccessedArchiveIDs(currentlyAccessedArchiveIDs())
         showInviteAndGrantAccess = false
         showGrantArchiveAccess = false
         showSelectArchiveFromPastShares = false
         showFindArchiveByEmail = true
+    }
+
+    private func currentlyAccessedArchiveIDs() -> Set<Int> {
+        Set(sharedArchives.compactMap { $0.archiveID })
     }
 
     func closeFindArchiveByEmail() {
@@ -36,10 +41,17 @@ extension ShareItemViewModel {
     // MARK: - Select Archive from Past Shares Flow
 
     func openSelectArchiveFromPastShares() {
-        pastSharesViewModel.fetchArchives()
-        navigationDirection = .forward
-        showFindArchiveByEmail = false
-        showSelectArchiveFromPastShares = true
+        guard !isPreparingPastShares else { return }
+
+        pastSharesViewModel.setAccessedArchiveIDs(currentlyAccessedArchiveIDs())
+        isPreparingPastShares = true
+        pastSharesViewModel.fetchArchives { [weak self] in
+            guard let self else { return }
+            self.isPreparingPastShares = false
+            self.navigationDirection = .forward
+            self.showFindArchiveByEmail = false
+            self.showSelectArchiveFromPastShares = true
+        }
     }
 
     func closeSelectArchiveFromPastShares() {

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareItemViewModel.swift
@@ -147,6 +147,7 @@ class ShareItemViewModel: ObservableObject {
 
     @Published var showFindArchiveByEmail = false
     @Published var showSelectArchiveFromPastShares = false
+    @Published var isPreparingPastShares = false
     @Published var showGrantArchiveAccess = false
     @Published var showInviteAndGrantAccess = false
     @Published var pendingArchiveGrant: PendingArchiveGrant?

--- a/PermanentTests/ShareArchivesFromPastSharesViewModelTests.swift
+++ b/PermanentTests/ShareArchivesFromPastSharesViewModelTests.swift
@@ -159,4 +159,120 @@ final class ShareArchivesFromPastSharesViewModelTests: XCTestCase {
         sut.searchText = "café résumé"
         XCTAssertTrue(sut.myArchives.isEmpty)
     }
+
+    // MARK: - accessedArchiveIDs / setAccessedArchiveIDs
+
+    func testAccessedArchiveIDs_InitialState_IsEmpty() {
+        XCTAssertTrue(sut.accessedArchiveIDs.isEmpty)
+    }
+
+    func testSetAccessedArchiveIDs_UpdatesPublishedValue() {
+        sut.setAccessedArchiveIDs([1, 2, 3])
+        XCTAssertEqual(sut.accessedArchiveIDs, [1, 2, 3])
+    }
+
+    func testSetAccessedArchiveIDs_ReplacesPreviousSnapshot() {
+        sut.setAccessedArchiveIDs([1, 2])
+        sut.setAccessedArchiveIDs([7, 8, 9])
+        XCTAssertEqual(sut.accessedArchiveIDs, [7, 8, 9])
+    }
+
+    func testSetAccessedArchiveIDs_EmptySet_Clears() {
+        sut.setAccessedArchiveIDs([1, 2])
+        sut.setAccessedArchiveIDs([])
+        XCTAssertTrue(sut.accessedArchiveIDs.isEmpty)
+    }
+
+    // MARK: - hasAccess
+
+    private func makeArchive(id: Int?, name: String = "Test") -> ShareArchivesFromPastSharesViewModel.PastSharedArchive {
+        ShareArchivesFromPastSharesViewModel.PastSharedArchive(
+            group: .mine,
+            archiveID: id,
+            rawName: name,
+            title: "The \(name) Archive",
+            initials: String(name.prefix(2)).uppercased(),
+            thumbnailURL: nil
+        )
+    }
+
+    func testHasAccess_ReturnsTrueWhenArchiveIDInAccessedSet() {
+        sut.setAccessedArchiveIDs([42])
+        XCTAssertTrue(sut.hasAccess(makeArchive(id: 42)))
+    }
+
+    func testHasAccess_ReturnsFalseWhenArchiveIDNotInAccessedSet() {
+        sut.setAccessedArchiveIDs([42])
+        XCTAssertFalse(sut.hasAccess(makeArchive(id: 99)))
+    }
+
+    func testHasAccess_ReturnsFalseWhenArchiveIDIsNil() {
+        sut.setAccessedArchiveIDs([42])
+        XCTAssertFalse(sut.hasAccess(makeArchive(id: nil)))
+    }
+
+    func testHasAccess_ReturnsFalseWhenAccessedSetIsEmpty() {
+        XCTAssertFalse(sut.hasAccess(makeArchive(id: 42)))
+    }
+
+    // MARK: - accessedLast Ordering
+
+    func testAccessedLast_EmptyList_ReturnsEmpty() {
+        XCTAssertTrue(sut.accessedLast([]).isEmpty)
+    }
+
+    func testAccessedLast_NoneAccessed_PreservesOrder() {
+        let a = makeArchive(id: 1, name: "Alpha")
+        let b = makeArchive(id: 2, name: "Bravo")
+        let c = makeArchive(id: 3, name: "Charlie")
+        sut.setAccessedArchiveIDs([])
+
+        let result = sut.accessedLast([a, b, c])
+
+        XCTAssertEqual(result.map { $0.archiveID }, [1, 2, 3])
+    }
+
+    func testAccessedLast_AllAccessed_PreservesOrder() {
+        let a = makeArchive(id: 1, name: "Alpha")
+        let b = makeArchive(id: 2, name: "Bravo")
+        sut.setAccessedArchiveIDs([1, 2])
+
+        let result = sut.accessedLast([a, b])
+
+        XCTAssertEqual(result.map { $0.archiveID }, [1, 2])
+    }
+
+    func testAccessedLast_MixedAccessed_MovesAccessedToEnd() {
+        let a = makeArchive(id: 1, name: "Alpha")
+        let b = makeArchive(id: 2, name: "Bravo")
+        let c = makeArchive(id: 3, name: "Charlie")
+        let d = makeArchive(id: 4, name: "Delta")
+        sut.setAccessedArchiveIDs([2, 3])
+
+        let result = sut.accessedLast([a, b, c, d])
+
+        XCTAssertEqual(result.map { $0.archiveID }, [1, 4, 2, 3])
+    }
+
+    func testAccessedLast_PreservesAlphabeticalWithinGroups() {
+        let alpha = makeArchive(id: 1, name: "Alpha")
+        let bravo = makeArchive(id: 2, name: "Bravo")
+        let charlie = makeArchive(id: 3, name: "Charlie")
+        let delta = makeArchive(id: 4, name: "Delta")
+        sut.setAccessedArchiveIDs([1, 3])
+
+        let result = sut.accessedLast([alpha, bravo, charlie, delta])
+
+        XCTAssertEqual(result.map { $0.rawName }, ["Bravo", "Delta", "Alpha", "Charlie"])
+    }
+
+    func testAccessedLast_NilArchiveID_TreatedAsNotAccessed() {
+        let nilID = makeArchive(id: nil, name: "NoID")
+        let accessed = makeArchive(id: 1, name: "Accessed")
+        sut.setAccessedArchiveIDs([1])
+
+        let result = sut.accessedLast([nilID, accessed])
+
+        XCTAssertEqual(result.map { $0.rawName }, ["NoID", "Accessed"])
+    }
 }

--- a/PermanentTests/ShareFindArchiveByEmailViewModelTests.swift
+++ b/PermanentTests/ShareFindArchiveByEmailViewModelTests.swift
@@ -499,4 +499,118 @@ final class ShareFindArchiveByEmailViewModelTests: XCTestCase {
             XCTFail("Expected .noAccount")
         }
     }
+
+    // MARK: - accessedArchiveIDs / setAccessedArchiveIDs
+
+    func testAccessedArchiveIDs_InitialState_IsEmpty() {
+        XCTAssertTrue(sut.accessedArchiveIDs.isEmpty)
+    }
+
+    func testSetAccessedArchiveIDs_UpdatesPublishedValue() {
+        sut.setAccessedArchiveIDs([1, 2, 3])
+        XCTAssertEqual(sut.accessedArchiveIDs, [1, 2, 3])
+    }
+
+    func testSetAccessedArchiveIDs_ReplacesPreviousSnapshot() {
+        sut.setAccessedArchiveIDs([1, 2])
+        sut.setAccessedArchiveIDs([7, 8, 9])
+        XCTAssertEqual(sut.accessedArchiveIDs, [7, 8, 9])
+    }
+
+    func testSetAccessedArchiveIDs_EmptySet_Clears() {
+        sut.setAccessedArchiveIDs([1, 2])
+        sut.setAccessedArchiveIDs([])
+        XCTAssertTrue(sut.accessedArchiveIDs.isEmpty)
+    }
+
+    // MARK: - hasAccess
+
+    private func makeArchiveResult(id: Int?, name: String = "Test") -> ShareFindArchiveByEmailViewModel.ArchiveResult {
+        ShareFindArchiveByEmailViewModel.ArchiveResult(
+            archiveID: id,
+            initials: String(name.prefix(2)).uppercased(),
+            name: name,
+            thumbnailURL: nil
+        )
+    }
+
+    func testHasAccess_ReturnsTrueWhenArchiveIDInAccessedSet() {
+        sut.setAccessedArchiveIDs([42])
+        XCTAssertTrue(sut.hasAccess(makeArchiveResult(id: 42)))
+    }
+
+    func testHasAccess_ReturnsFalseWhenArchiveIDNotInAccessedSet() {
+        sut.setAccessedArchiveIDs([42])
+        XCTAssertFalse(sut.hasAccess(makeArchiveResult(id: 99)))
+    }
+
+    func testHasAccess_ReturnsFalseWhenArchiveIDIsNil() {
+        sut.setAccessedArchiveIDs([42])
+        XCTAssertFalse(sut.hasAccess(makeArchiveResult(id: nil)))
+    }
+
+    func testHasAccess_ReturnsFalseWhenAccessedSetIsEmpty() {
+        XCTAssertFalse(sut.hasAccess(makeArchiveResult(id: 42)))
+    }
+
+    // MARK: - sortedByAccess Ordering
+
+    func testSortedByAccess_EmptyList_ReturnsEmpty() {
+        XCTAssertTrue(sut.sortedByAccess([]).isEmpty)
+    }
+
+    func testSortedByAccess_NoneAccessed_PreservesOrder() {
+        let a = makeArchiveResult(id: 1, name: "Alpha")
+        let b = makeArchiveResult(id: 2, name: "Bravo")
+        let c = makeArchiveResult(id: 3, name: "Charlie")
+        sut.setAccessedArchiveIDs([])
+
+        let result = sut.sortedByAccess([a, b, c])
+
+        XCTAssertEqual(result.map { $0.archiveID }, [1, 2, 3])
+    }
+
+    func testSortedByAccess_AllAccessed_PreservesOrder() {
+        let a = makeArchiveResult(id: 1, name: "Alpha")
+        let b = makeArchiveResult(id: 2, name: "Bravo")
+        sut.setAccessedArchiveIDs([1, 2])
+
+        let result = sut.sortedByAccess([a, b])
+
+        XCTAssertEqual(result.map { $0.archiveID }, [1, 2])
+    }
+
+    func testSortedByAccess_MixedAccessed_MovesAccessedToEnd() {
+        let a = makeArchiveResult(id: 1, name: "Alpha")
+        let b = makeArchiveResult(id: 2, name: "Bravo")
+        let c = makeArchiveResult(id: 3, name: "Charlie")
+        let d = makeArchiveResult(id: 4, name: "Delta")
+        sut.setAccessedArchiveIDs([2, 3])
+
+        let result = sut.sortedByAccess([a, b, c, d])
+
+        XCTAssertEqual(result.map { $0.archiveID }, [1, 4, 2, 3])
+    }
+
+    func testSortedByAccess_PreservesOrderWithinGroups() {
+        let alpha = makeArchiveResult(id: 1, name: "Alpha")
+        let bravo = makeArchiveResult(id: 2, name: "Bravo")
+        let charlie = makeArchiveResult(id: 3, name: "Charlie")
+        let delta = makeArchiveResult(id: 4, name: "Delta")
+        sut.setAccessedArchiveIDs([1, 3])
+
+        let result = sut.sortedByAccess([alpha, bravo, charlie, delta])
+
+        XCTAssertEqual(result.map { $0.name }, ["Bravo", "Delta", "Alpha", "Charlie"])
+    }
+
+    func testSortedByAccess_NilArchiveID_TreatedAsNotAccessed() {
+        let nilID = makeArchiveResult(id: nil, name: "NoID")
+        let accessed = makeArchiveResult(id: 1, name: "Accessed")
+        sut.setAccessedArchiveIDs([1])
+
+        let result = sut.sortedByAccess([nilID, accessed])
+
+        XCTAssertEqual(result.map { $0.name }, ["NoID", "Accessed"])
+    }
 }


### PR DESCRIPTION
Implemented the following: 
 - The design for adding an archive that already have access to the share link was updated.
 - Fixed an issue where the thumbnails of the archives had a fade effect when the animation to the next screen( when selected an archive in shared links) was performed.

Preview: 

https://github.com/user-attachments/assets/d71a4891-1595-4c5d-903b-d8f58644c8ae

