### PR TITLE
VSP-1768 [iOS] Thumbnail Resolution – Success Path: Blur to Sharp for Full Screen View

### DIFF
--- a/.github/workflows/deployStaging.yml
+++ b/.github/workflows/deployStaging.yml
@@ -3,7 +3,7 @@ name: Deploy Firebase Beta
 on:
   workflow_dispatch:
   push:
-    branches: [ "main","development","feature/Share-and-Publish" ]
+    branches: [ "main","Development","feature/Share-and-Publish" ]
 
 jobs:
   test:

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -13,7 +13,7 @@ on:
         - ui-tests
         - all-tests
   pull_request:
-    branches: [ "Development" ]
+    branches: [ "none" ]
 
 jobs:
   build:

--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -975,6 +975,8 @@
 		F5216AE429228E7E0042914D /* PublicProfileUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5216AE329228E7E0042914D /* PublicProfileUITests.swift */; };
 		F5216AED2923E03B0042914D /* XCUIApplication+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5216AEC2923E03B0042914D /* XCUIApplication+Extensions.swift */; };
 		F529C3A227B3F77B003DB312 /* AuthenticationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F529C3A127B3F77B003DB312 /* AuthenticationManager.swift */; };
+		5E17680000000000000000A2 /* ReachabilityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E17680000000000000000A1 /* ReachabilityManager.swift */; };
+		5E17680000000000000000A4 /* ImagePreviewStateOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E17680000000000000000A3 /* ImagePreviewStateOverlayView.swift */; };
 		F53519C6290BCB850035CCE9 /* Archives.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5E2E3D0E26D058940090EF02 /* Archives.storyboard */; };
 		F5379DB9262EF53300E8F06A /* FilePreviewListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5379DB8262EF53300E8F06A /* FilePreviewListViewController.swift */; };
 		F53D0A1C25FB71960080579F /* FileDetailsDateCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53D0A1A25FB71960080579F /* FileDetailsDateCollectionViewCell.swift */; };
@@ -2004,6 +2006,8 @@
 		F5216AE329228E7E0042914D /* PublicProfileUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublicProfileUITests.swift; sourceTree = "<group>"; };
 		F5216AEC2923E03B0042914D /* XCUIApplication+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+Extensions.swift"; sourceTree = "<group>"; };
 		F529C3A127B3F77B003DB312 /* AuthenticationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationManager.swift; sourceTree = "<group>"; };
+		5E17680000000000000000A1 /* ReachabilityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityManager.swift; sourceTree = "<group>"; };
+		5E17680000000000000000A3 /* ImagePreviewStateOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreviewStateOverlayView.swift; sourceTree = "<group>"; };
 		F5379DB8262EF53300E8F06A /* FilePreviewListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewListViewController.swift; sourceTree = "<group>"; };
 		F53D0A1A25FB71960080579F /* FileDetailsDateCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDetailsDateCollectionViewCell.swift; sourceTree = "<group>"; };
 		F53D0A1B25FB71960080579F /* FileDetailsDateCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = FileDetailsDateCollectionViewCell.xib; sourceTree = "<group>"; };
@@ -3866,6 +3870,7 @@
 				5E7A697C2EBA4CB4005FA69B /* Components */,
 				5EC7CD262E26A74E00D80AE4 /* FileMoreMenuView.swift */,
 				5E04DAE02E3697C600D17F67 /* FileMoreMenuItemRow.swift */,
+				5E17680000000000000000A3 /* ImagePreviewStateOverlayView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -4630,6 +4635,7 @@
 				BCE8DA7025652C2A00842ABD /* FileActionManager.swift */,
 				BCE8DA7425652F4400842ABD /* FileAction.swift */,
 				F529C3A127B3F77B003DB312 /* AuthenticationManager.swift */,
+				5E17680000000000000000A1 /* ReachabilityManager.swift */,
 				F51B331D288AF57900EA15DA /* SessionKeychainHandler.swift */,
 			);
 			path = Managers;
@@ -5680,6 +5686,8 @@
 				5EB620272784B01D001B9AFD /* GenderProfileItem.swift in Sources */,
 				92430A5F2AF2A1F00098597D /* EmailChipView.swift in Sources */,
 				F529C3A227B3F77B003DB312 /* AuthenticationManager.swift in Sources */,
+				5E17680000000000000000A2 /* ReachabilityManager.swift in Sources */,
+				5E17680000000000000000A4 /* ImagePreviewStateOverlayView.swift in Sources */,
 				BCEAB27C2580F3C600567E8C /* ShareVO.swift in Sources */,
 				BCE8DA7125652C2A00842ABD /* FileActionManager.swift in Sources */,
 				5E018ABF2D6777BB0023E13A /* DeleteBottomAlertView.swift in Sources */,

--- a/Permanent.xcodeproj/project.pbxproj
+++ b/Permanent.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		5E4A256F2FB492FD009B1BF9 /* SearchFilesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4A256E2FB492FC009B1BF9 /* SearchFilesPage.swift */; };
 		5E4A25712FB4931D009B1BF9 /* SharedFilesBrowsingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4A25702FB4931D009B1BF9 /* SharedFilesBrowsingUITests.swift */; };
 		5E4A25732FB49352009B1BF9 /* MainFileOperationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4A25722FB49352009B1BF9 /* MainFileOperationsUITests.swift */; };
+		5E17680000000000000000B2 /* FilePreviewStateUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E17680000000000000000B1 /* FilePreviewStateUITests.swift */; };
 		5E4A25752FB4937D009B1BF9 /* FileMenuActionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4A25742FB4937D009B1BF9 /* FileMenuActionsUITests.swift */; };
 		5E4A25772FB4AE8D009B1BF9 /* FilePreviewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4A25762FB4AE8D009B1BF9 /* FilePreviewPage.swift */; };
 		5E4A25792FB4AE99009B1BF9 /* FileDetailsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4A25782FB4AE99009B1BF9 /* FileDetailsPage.swift */; };
@@ -1353,6 +1354,7 @@
 		5E4A256E2FB492FC009B1BF9 /* SearchFilesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFilesPage.swift; sourceTree = "<group>"; };
 		5E4A25702FB4931D009B1BF9 /* SharedFilesBrowsingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedFilesBrowsingUITests.swift; sourceTree = "<group>"; };
 		5E4A25722FB49352009B1BF9 /* MainFileOperationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFileOperationsUITests.swift; sourceTree = "<group>"; };
+		5E17680000000000000000B1 /* FilePreviewStateUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewStateUITests.swift; sourceTree = "<group>"; };
 		5E4A25742FB4937D009B1BF9 /* FileMenuActionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMenuActionsUITests.swift; sourceTree = "<group>"; };
 		5E4A25762FB4AE8D009B1BF9 /* FilePreviewPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewPage.swift; sourceTree = "<group>"; };
 		5E4A25782FB4AE99009B1BF9 /* FileDetailsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDetailsPage.swift; sourceTree = "<group>"; };
@@ -3457,6 +3459,7 @@
 				5E7B9C262FB3D8AE00C1D3D0 /* ShareManagementUITests.swift */,
 				5E4A25702FB4931D009B1BF9 /* SharedFilesBrowsingUITests.swift */,
 				5E4A25722FB49352009B1BF9 /* MainFileOperationsUITests.swift */,
+				5E17680000000000000000B1 /* FilePreviewStateUITests.swift */,
 				5E4A25742FB4937D009B1BF9 /* FileMenuActionsUITests.swift */,
 				5EB0CEDD2FB4CC44002B8601 /* SettingsMenuNavigationUITests.swift */,
 			);
@@ -5899,6 +5902,7 @@
 				5E07D44E28915CE0008C0A6B /* SignUpPage.swift in Sources */,
 				F5BEF69029241A1F00668A29 /* PublicProfilePage.swift in Sources */,
 				5E4A25732FB49352009B1BF9 /* MainFileOperationsUITests.swift in Sources */,
+				5E17680000000000000000B2 /* FilePreviewStateUITests.swift in Sources */,
 				5E07D44C28915C8E008C0A6B /* LoginPage.swift in Sources */,
 				F5BEF69229241B8E00668A29 /* PublicProfileAboutPage.swift in Sources */,
 				5E4A25772FB4AE8D009B1BF9 /* FilePreviewPage.swift in Sources */,

--- a/Permanent/App/AppDelegate.swift
+++ b/Permanent/App/AppDelegate.swift
@@ -26,11 +26,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         
         clearShareDeepLinks()
-        
+
         initFirebase()
         initNotifications()
         configureLogging()
         configureImageCache()
+        ReachabilityManager.shared.startMonitoring()
+        #if DEBUG
+        if CommandLine.arguments.contains("--forceOffline") {
+            ReachabilityManager.shared.forceOffline = true
+            if let restoreArg = CommandLine.arguments.first(where: { $0.hasPrefix("--restoreConnectivityAfter=") }),
+               let seconds = Double(restoreArg.split(separator: "=").last ?? "") {
+                DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
+                    ReachabilityManager.shared.forceOffline = false
+                }
+            }
+        }
+        #endif
         
         StripeAPI.defaultPublishableKey = stripeServiceInfo.publishableKey
         

--- a/Permanent/Common/Base/SwiftUIViews/LoadingAnimations/GradientSemiCirclesLoaderView.swift
+++ b/Permanent/Common/Base/SwiftUIViews/LoadingAnimations/GradientSemiCirclesLoaderView.swift
@@ -13,7 +13,6 @@ struct GradientSemiCirclesLoaderView: View {
     var outerCicleWidth: CGFloat = 8
     var frameWidth: CGFloat = 50
     var frameHeight: CGFloat = 50
-
     var body: some View {
         ZStack {
             SemiCircle()
@@ -24,7 +23,7 @@ struct GradientSemiCirclesLoaderView: View {
                 .onAppear {
                     rotate = true
                 }
-            
+
             SemiCircle()
                 .stroke(Gradient.yellowPurpleGradient, style: StrokeStyle(lineWidth: outerCicleWidth, lineCap: .round))
                 .frame(width: frameWidth, height: frameHeight)

--- a/Permanent/Common/Constants/Strings.swift
+++ b/Permanent/Common/Constants/Strings.swift
@@ -37,6 +37,10 @@ extension String {
     static var emailSent: String { return "EmailSent".localized() }
     static var cancel: String { return "Cancel".localized() }
     static var retry: String { return "Retry".localized() }
+    static var couldntLoadImage: String { return "CouldntLoadImage".localized() }
+    static var tapToRetry: String { return "TapToRetry".localized() }
+    static var youreOffline: String { return "YoureOffline".localized() }
+    static var connectToLoadFullQuality: String { return "ConnectToLoadFullQuality".localized() }
     static var resetPassword: String { return "ResetPassword".localized() }
     static var twoStepTitle: String { return "TwoStepTitle".localized() }
     static var twoStepSubtitle: String { return "TwoStepSubtitle".localized() }

--- a/Permanent/Common/Constants/Strings.swift
+++ b/Permanent/Common/Constants/Strings.swift
@@ -38,6 +38,7 @@ extension String {
     static var cancel: String { return "Cancel".localized() }
     static var retry: String { return "Retry".localized() }
     static var couldntLoadImage: String { return "CouldntLoadImage".localized() }
+    static var couldntLoadFile: String { return "CouldntLoadFile".localized() }
     static var tapToRetry: String { return "TapToRetry".localized() }
     static var youreOffline: String { return "YoureOffline".localized() }
     static var connectToLoadFullQuality: String { return "ConnectToLoadFullQuality".localized() }

--- a/Permanent/Common/Managers/ReachabilityManager.swift
+++ b/Permanent/Common/Managers/ReachabilityManager.swift
@@ -1,0 +1,64 @@
+//
+//  ReachabilityManager.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 12.06.2026.
+//
+
+import Foundation
+import Network
+
+protocol ReachabilityProviding: AnyObject {
+    var isConnected: Bool { get }
+}
+
+class ReachabilityManager: ReachabilityProviding {
+    static let shared = ReachabilityManager()
+
+    static let reachabilityDidChangeNotifName = Notification.Name("ReachabilityManager.reachabilityDidChangeNotifName")
+
+    private let monitor = NWPathMonitor()
+    private let monitorQueue = DispatchQueue(label: "org.permanent.reachabilityMonitor")
+    private var isMonitoring = false
+
+    #if DEBUG
+    // Set to true to simulate the offline state regardless of the real network path.
+    var forceOffline = false {
+        didSet {
+            guard oldValue != forceOffline else { return }
+            NotificationCenter.default.post(name: Self.reachabilityDidChangeNotifName, object: self)
+        }
+    }
+    #endif
+
+    private var pathIsConnected = true
+
+    var isConnected: Bool {
+        #if DEBUG
+        if forceOffline { return false }
+        #endif
+        return pathIsConnected
+    }
+
+    func startMonitoring() {
+        guard !isMonitoring else { return }
+        isMonitoring = true
+
+        monitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                let isConnected = path.status == .satisfied
+                guard isConnected != self.pathIsConnected else { return }
+                self.pathIsConnected = isConnected
+                NotificationCenter.default.post(name: Self.reachabilityDidChangeNotifName, object: self)
+            }
+        }
+        monitor.start(queue: monitorQueue)
+    }
+
+    func stopMonitoring() {
+        guard isMonitoring else { return }
+        isMonitoring = false
+        monitor.cancel()
+    }
+}

--- a/Permanent/Modules/FileOperations/Cells/FileDetailsTopCollectionViewCell.swift
+++ b/Permanent/Modules/FileOperations/Cells/FileDetailsTopCollectionViewCell.swift
@@ -23,41 +23,60 @@ class FileDetailsTopCollectionViewCell: FileDetailsBaseCollectionViewCell {
         super.configure(withViewModel: viewModel, type: type)
         
         activityIndicator.startAnimating()
-        
+
         imageView.image = nil
-        
+
         // Stage 1: Load the 256px thumbnail quickly
         let thumbnailURLString = viewModel.file.preferredThumbnailURL ?? viewModel.fileThumbnailURL() ?? ""
-        guard let thumbnailURL = URL(string: thumbnailURLString) else { return }
-        
-        // Determine the full-res download URL if available
-        let fullResURLString = viewModel.fileVO()?.downloadURL
-        let fullResURL = fullResURLString.flatMap { URL(string: $0) }
-        
-        imageView.sd_setImage(with: thumbnailURL) { [weak self] _, error, _, _ in
+        guard let thumbnailURL = URL(string: thumbnailURLString) else {
+            // No thumbnail to load — don't leave the spinner running forever.
+            activityIndicator.stopAnimating()
+            return
+        }
+
+        // Only images upgrade to full resolution. For documents/audio/video the download
+        // URL is the raw file (a PDF binary, etc.), which SDWebImage can't decode as an
+        // image — attempting it always fails and previously left the spinner spinning.
+        // The 256px thumbnail is the preview for those types. Use the record's content
+        // type (reliable) rather than the listing file.type.
+        let fullResURL: URL? = {
+            guard let fileVO = viewModel.fileVO() else { return nil }
+            // Upgrade only for images: an image content type, or (as a fallback for
+            // records with a missing content type) an image file type. Documents/audio/
+            // video are excluded so we don't try to decode a raw binary as an image.
+            let isImage = fileVO.contentType?.hasPrefix("image/") == true || viewModel.file.type == .image
+            guard isImage, let urlString = fileVO.downloadURL else { return nil }
+            return URL(string: urlString)
+        }()
+
+        imageView.sd_setImage(with: thumbnailURL) { [weak self] _, _, _, _ in
             guard let self = self else { return }
-            
-            if let fullResURL = fullResURL, fullResURL != thumbnailURL {
-                // Stage 2: Upgrade to full-res from download URL
-                self.imageView.sd_setImage(
-                    with: fullResURL,
-                    placeholderImage: self.imageView.image,
-                    options: [.avoidAutoSetImage, .retryFailed],
-                    progress: nil
-                ) { [weak self] image, _, cacheType, _ in
-                    guard let self = self, let image = image else { return }
-                    self.activityIndicator.stopAnimating()
-                    
-                    if cacheType == .memory {
+
+            guard let fullResURL = fullResURL, fullResURL != thumbnailURL else {
+                self.activityIndicator.stopAnimating()
+                return
+            }
+
+            // Stage 2: Upgrade to full-res from download URL (images only)
+            self.imageView.sd_setImage(
+                with: fullResURL,
+                placeholderImage: self.imageView.image,
+                options: [.avoidAutoSetImage, .retryFailed],
+                progress: nil
+            ) { [weak self] image, _, cacheType, _ in
+                guard let self = self else { return }
+                // Always stop the spinner, even if the full-res load failed — keep the
+                // thumbnail rather than swallowing the failure with the spinner running.
+                self.activityIndicator.stopAnimating()
+                guard let image = image else { return }
+
+                if cacheType == .memory {
+                    self.imageView.image = image
+                } else {
+                    UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
                         self.imageView.image = image
-                    } else {
-                        UIView.transition(with: self.imageView, duration: 0.3, options: .transitionCrossDissolve) {
-                            self.imageView.image = image
-                        }
                     }
                 }
-            } else {
-                self.activityIndicator.stopAnimating()
             }
         }
     }

--- a/Permanent/Modules/FileOperations/ViewController/FileDetailsViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FileDetailsViewController.swift
@@ -204,8 +204,16 @@ class FileDetailsViewController: BaseViewController<FilePreviewViewModel> {
     }
     
     @objc func closeButtonAction(_ sender: Any) {
-        dismiss(animated: false) {
-            self.delegate?.filePreviewNavigationControllerWillClose(self, hasChanges: (self.navigationController as? FilePreviewNavigationController)?.hasChanges ?? false)
+        // Hand off to the delegate (the preview pager), which dismisses the whole
+        // presentation chain in one animated transition. Dismissing this details modal
+        // here first (animated: false) would briefly reveal the fullscreen preview
+        // underneath before it too gets dismissed — a visible flash.
+        let hasChanges = (self.navigationController as? FilePreviewNavigationController)?.hasChanges ?? false
+        if let delegate = delegate {
+            delegate.filePreviewNavigationControllerWillClose(self, hasChanges: hasChanges)
+        } else {
+            // No delegate wired — still ensure the modal closes rather than getting stuck.
+            dismiss(animated: true)
         }
     }
 

--- a/Permanent/Modules/FileOperations/ViewController/FilePreviewListViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FilePreviewListViewController.swift
@@ -23,19 +23,36 @@ class FilePreviewListViewController: BaseViewController<FilesViewModel> {
     var nextFile: FileModel?
     var nextTitle: String?
     var hasChanges: Bool = false
-        
+
+    // Info (details) and share/more both lead to network-dependent screens — disabled offline.
+    private weak var infoBarButton: UIBarButtonItem?
+    private weak var shareBarButton: UIBarButtonItem?
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         title = currentFile.name
 
         extendedLayoutIncludesOpaqueBars = true
         edgesForExtendedLayout = .all
-        
+
         setupPageVC()
         setupNavigationBar()
-        
+
         NotificationCenter.default.addObserver(self, selector: #selector(onDidUpdateData(_:)), name: .filePreviewVMDidSaveData, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onReachabilityChanged), name: ReachabilityManager.reachabilityDidChangeNotifName, object: nil)
+    }
+
+    @objc private func onReachabilityChanged() {
+        updateNetworkDependentButtons()
+    }
+
+    /// Details (info) shows record-backed metadata and the share menu performs network
+    /// actions — neither works offline, so disable both when there's no connection.
+    private func updateNetworkDependentButtons() {
+        let connected = ReachabilityManager.shared.isConnected
+        infoBarButton?.isEnabled = connected
+        shareBarButton?.isEnabled = connected
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -100,6 +117,10 @@ class FilePreviewListViewController: BaseViewController<FilesViewModel> {
         let infoButton = UIBarButtonItem(image: .info, style: .plain, target: self, action: #selector(infoButtonAction(_:)))
         infoButton.accessibilityIdentifier = "filePreviewInfoButton"
         navigationItem.rightBarButtonItems = [shareButton, infoButton]
+
+        infoBarButton = infoButton
+        shareBarButton = shareButton
+        updateNetworkDependentButtons()
         
         let leftButtonImage: UIImage!
         leftButtonImage = UIImage(systemName: "xmark", withConfiguration: UIImage.SymbolConfiguration(weight: .regular))
@@ -240,9 +261,17 @@ extension FilePreviewListViewController: FilePreviewNavigationControllerDelegate
         if hasChanges == true {
             self.hasChanges = true
         }
-        
-        dismiss(animated: true) {
-            (self.navigationController as? FilePreviewNavigationController)?.filePreviewNavDelegate?.filePreviewNavigationControllerWillClose(self, hasChanges: self.hasChanges)
+
+        // Called when the details screen closes. The details modal is still presented on
+        // top of this preview pager, so dismiss from our presenter (the file list) to tear
+        // down both in a single animation — details slides away straight to the file list,
+        // without the preview flashing in between. (When this pager is closed directly, its
+        // own closeButtonAction handles dismissal instead.)
+        let fileListDelegate = (self.navigationController as? FilePreviewNavigationController)?.filePreviewNavDelegate
+        let changes = self.hasChanges
+        let presenter = presentingViewController ?? self
+        presenter.dismiss(animated: true) {
+            fileListDelegate?.filePreviewNavigationControllerWillClose(self, hasChanges: changes)
         }
     }
     

--- a/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
@@ -67,6 +67,7 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
+        stopObservingPlayerItem()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -77,19 +78,55 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         styleNavBar()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if pendingAudioReveal {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                self?.startAudioBlurRevealIfPossible()
+            }
+        }
     }
     
     var imagePreviewVC: ImagePreviewViewController?
     
     func loadVM() {
         guard recordLoaded == false else { return }
+        imageStateOverlay.isImageContent = file.type == .image
 
         if isViewLoaded {
             activityIndicator.startAnimating()
-            if let url = URL(string: file.preferredThumbnailURL) {
-                thumbnailImageView.sd_setImage(with: url)
+            if file.type == .audio {
+                // Audio goes straight from black + spinner to the blurred QuickTime
+                // artwork (loadAudio) — no neutral glow, and no thumbnail either
+                // (it is a file-type icon, not content).
+                thumbnailImageView.isHidden = true
+            } else {
+                if let url = URL(string: file.preferredThumbnailURL) {
+                    thumbnailImageView.sd_setImage(with: url) { [weak self] image, _, _, _ in
+                        guard let self = self, self.file.type != .image else { return }
+                        self.previewBlurAvailable = image != nil
+                        self.imageStateOverlay.setSourceImage(image)
+                    }
+                }
+                if file.type != .image {
+                    // Videos show the blurred-frame placeholder from the first frame; other
+                    // non-image files load behind the neutral placeholder (logo + loader,
+                    // S5 style), since document thumbnails are file-type icons and blurring
+                    // an icon reads as a glowing blob. FileModel.type is unreliable for
+                    // videos, so the filename extension is consulted too — loadVideo
+                    // remains the authoritative upgrade for anything missed here.
+                    activityIndicator.stopAnimating()
+                    if isLikelyVideoFile {
+                        imageStateOverlay.render(.loadingFullRes(hasThumbnail: file.preferredThumbnailURL != nil))
+                    } else {
+                        imageStateOverlay.render(.loadingFullRes(hasThumbnail: false))
+                    }
+                }
             }
         }
 
@@ -125,9 +162,7 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
                     if self?.file.type == .image {
                         self?.viewModel?.imageLoadDidFail(error: nil)
                     } else {
-                        self?.thumbnailImageView.isHidden = true
-                        self?.errorLabel.isHidden = false
-                        self?.retryButton.isHidden = false
+                        self?.showPreviewLoadFailure()
                     }
                 }
             })
@@ -151,7 +186,7 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
             imageStateOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
         imageStateOverlay.onRetryTapped = { [weak self] in
-            self?.retryImageLoad()
+            self?.retryPreviewLoad()
         }
     }
 
@@ -161,14 +196,39 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
                 self?.imageStateOverlay.render(state)
             }
         }
-        if let state = viewModel?.imagePreviewState {
+        // Non-image types drive the overlay directly (the VM state machine stays .idle
+        // for them) — syncing it here would hide the placeholder rendered in loadVM.
+        if file.type == .image, let state = viewModel?.imagePreviewState {
             imageStateOverlay.render(state)
         }
     }
 
-    private func retryImageLoad() {
-        guard file.type == .image, viewModel?.retryRequested() == true else { return }
-        resumeImageLoad()
+    private func retryPreviewLoad() {
+        if file.type == .image {
+            guard viewModel?.retryRequested() == true else { return }
+            resumeImageLoad()
+            return
+        }
+        // Non-image: the offline card stays until connectivity returns (S7 behaviour);
+        // tapping it while still offline is a no-op. When online, re-run the load.
+        guard ReachabilityManager.shared.isConnected else { return }
+        nonImageAwaitingReconnect = false
+        imageStateOverlay.render(.idle)
+        recordLoaded = false
+        loadVM()
+    }
+
+    /// Branded failure/offline card for non-image previews (images run through the view
+    /// model's state machine). Offline shows the "You're offline" card and waits for
+    /// reconnect to auto-retry; an online failure shows the tap-to-retry card. Replaces
+    /// the generic storyboard errorLabel/retryButton for video/audio/document previews.
+    private func showPreviewLoadFailure() {
+        activityIndicator.stopAnimating()
+        thumbnailImageView.isHidden = true
+        let connected = ReachabilityManager.shared.isConnected
+        nonImageAwaitingReconnect = !connected
+        imageStateOverlay.render(connected ? .failed(hasThumbnail: previewBlurAvailable)
+                                           : .offline(hasThumbnail: previewBlurAvailable))
     }
 
     private func resumeImageLoad() {
@@ -186,8 +246,12 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     }
 
     @objc private func onReachabilityChanged(_ notification: Notification) {
-        guard file.type == .image, viewModel?.connectivityRestored() == true else { return }
-        resumeImageLoad()
+        if file.type == .image {
+            guard viewModel?.connectivityRestored() == true else { return }
+            resumeImageLoad()
+        } else if nonImageAwaitingReconnect, ReachabilityManager.shared.isConnected {
+            retryPreviewLoad()
+        }
     }
 
     func initUI() {
@@ -294,8 +358,7 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         } else if file.type == .image {
             self.viewModel?.imageLoadDidFail(error: nil)
         } else {
-            self.errorLabel.isHidden = false
-            self.retryButton.isHidden = false
+            self.showPreviewLoadFailure()
         }
 
         if recordLoaded != true {
@@ -469,7 +532,14 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
                     pdfView.autoScales = true
 
                     pdfView.translatesAutoresizingMaskIntoConstraints = false
-                    view.addSubview(pdfView)
+                    // Insert behind the loading overlay (like image/video/web) so the
+                    // overlay's fade-out cross-dissolves into the document. addSubview
+                    // would place it on top, hiding the fade and snapping the spinner away.
+                    view.insertSubview(pdfView, at: 0)
+                    // Hide the storyboard thumbnail (loaded with the doc's 256px preview in
+                    // loadVM) — otherwise it floats on top of the scrolling document, since
+                    // pdfView now sits at the back. Matches how the image path hides it.
+                    thumbnailImageView.isHidden = true
 
                     pdfView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
                     pdfView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
@@ -477,63 +547,242 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
                     pdfView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
 
                     pdfView.document = document
+                    imageStateOverlay.render(.loaded)
+
+                    // autoScales leaves the document scrolled partway down the first page;
+                    // jump to the top of page 1 once the document view has laid out.
+                    DispatchQueue.main.async {
+                        guard let firstPage = document.page(at: 0) else { return }
+                        pdfView.layoutDocumentView()
+                        let pageHeight = firstPage.bounds(for: pdfView.displayBox).height
+                        pdfView.go(to: PDFDestination(page: firstPage, at: CGPoint(x: 0, y: pageHeight)))
+                    }
+                }
+            } else {
+                DispatchQueue.main.async { [self] in
+                    showPreviewLoadFailure()
                 }
             }
         }
     }
         
     func loadVideo(withURL url: URL, contentType: String) {
+        // file.type from the listing is unreliable (often .miscellaneous), so the
+        // blurred placeholder is rendered here, where the record type is authoritative.
+        showVideoLoadingPlaceholder()
+        #if DEBUG
+        // --slowImageLoad also postpones the video player, keeping the blurred
+        // placeholder observable on fast networks.
+        if debugFullResDelay > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + debugFullResDelay) { [weak self] in
+                self?.loadAV(withURL: url, contentType: contentType)
+            }
+            return
+        }
+        #endif
         loadAV(withURL: url, contentType: contentType)
+    }
+
+    private var isLikelyVideoFile: Bool {
+        if file.type == .video { return true }
+        let name = file.uploadFileName.isEmpty ? file.name : file.uploadFileName
+        let videoExtensions = ["mp4", "mov", "m4v", "avi", "mkv", "3gp", "webm", "mts"]
+        return videoExtensions.contains((name as NSString).pathExtension.lowercased())
+    }
+
+    private func showVideoLoadingPlaceholder() {
+        let thumbnail = thumbnailImageView.image ?? imagePreviewVC?.imageView.image
+        previewBlurAvailable = thumbnail != nil
+        imageStateOverlay.setSourceImage(thumbnail)
+        imageStateOverlay.render(.loadingFullRes(hasThumbnail: thumbnail != nil))
+        activityIndicator.stopAnimating()
+    }
+
+    /// Initial play affordance over the embedded player — its own controls stay
+    /// hidden until the first tap, leaving the video looking like a still image.
+    /// Dark circular backdrop matches the state card (black @ 32%) for contrast
+    /// over bright footage.
+    private lazy var videoPlayButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "play.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: 28, weight: .medium)), for: .normal)
+        button.tintColor = .white
+        button.backgroundColor = UIColor.black.withAlphaComponent(0.32)
+        button.layer.cornerRadius = 36
+        button.accessibilityIdentifier = "videoPlayButton"
+        button.addTarget(self, action: #selector(playVideoTapped(_:)), for: .touchUpInside)
+        return button
+    }()
+
+    private func showVideoPlayButton() {
+        guard videoPlayButton.superview == nil else { return }
+        view.addSubview(videoPlayButton)
+        NSLayoutConstraint.activate([
+            videoPlayButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            videoPlayButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            videoPlayButton.widthAnchor.constraint(equalToConstant: 72),
+            videoPlayButton.heightAnchor.constraint(equalToConstant: 72)
+        ])
+    }
+
+    @objc private func playVideoTapped(_ sender: UIButton) {
+        videoPlayButton.removeFromSuperview()
+        videoPlayer?.player?.play()
     }
     
     func loadAudio(withURL url: URL, contentType: String) {
         loadAV(withURL: url, contentType: contentType)
-        
+        // Audio has no frames for isReadyForDisplay. Its "content" is the player's
+        // built-in QuickTime artwork: keep it hidden behind an opaque cover, snapshot
+        // it through the cover, show the snapshot blurred (same blur-to-sharp story
+        // as photos), then drop the cover as the blur fades out — the artwork is
+        // never visible sharp before the blur.
+        audioRevealStarted = false
+        let cover = UIView()
+        cover.backgroundColor = .black
+        cover.frame = view.bounds
+        cover.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        if let playerView = videoPlayer?.view {
+            view.insertSubview(cover, aboveSubview: playerView)
+        }
+        audioCover = cover
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            self?.startAudioBlurRevealIfPossible()
+        }
+
         let playButton = UIButton(type: .custom)
         playButton.translatesAutoresizingMaskIntoConstraints = false
-        playButton.setImage(UIImage(named: "play.circle"), for: .normal)
+        playButton.setImage(UIImage(systemName: "play.fill", withConfiguration: UIImage.SymbolConfiguration(pointSize: 28, weight: .medium)), for: .normal)
         playButton.tintColor = .white
+        // Lighter circle than the video affordance — the audio backdrop is always black.
+        playButton.backgroundColor = UIColor.white.withAlphaComponent(0.25)
+        playButton.layer.cornerRadius = 36
         playButton.addTarget(self, action: #selector(playAudioFile(_:)), for: .touchUpInside)
-        
+
         overlayView.translatesAutoresizingMaskIntoConstraints = false
-        overlayView.backgroundColor = .black
+        overlayView.backgroundColor = .clear
+        overlayView.isHidden = true   // revealed together with the sharp artwork
         view.addSubview(overlayView)
         overlayView.addSubview(playButton)
-        
+
         NSLayoutConstraint.activate([
             overlayView.leadingAnchor.constraint(equalTo: thumbnailImageView.leadingAnchor, constant: 0),
             overlayView.trailingAnchor.constraint(equalTo: thumbnailImageView.trailingAnchor, constant: 0),
             overlayView.topAnchor.constraint(equalTo: thumbnailImageView.topAnchor, constant: 0),
             overlayView.bottomAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: 0),
             playButton.centerXAnchor.constraint(equalTo: overlayView.centerXAnchor),
-            playButton.centerYAnchor.constraint(equalTo: overlayView.centerYAnchor)
+            playButton.centerYAnchor.constraint(equalTo: overlayView.centerYAnchor),
+            playButton.widthAnchor.constraint(equalToConstant: 72),
+            playButton.heightAnchor.constraint(equalToConstant: 72)
         ])
     }
     
     func loadAV(withURL url: URL, contentType: String) {
         let asset = AVURLAsset(url: url)
         let playerItem = AVPlayerItem(asset: asset)
-        
+
         let player = AVPlayer(playerItem: playerItem)
         videoPlayer = AVPlayerViewController()
         videoPlayer!.player = player
-        
+
         self.playerItem = playerItem
-        
+        startObservingPlayerItem(playerItem)
+
         addChild(videoPlayer!)
         videoPlayer!.view.frame = view.bounds.insetBy(dx: 0, dy: 60)
         videoPlayer!.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.insertSubview(videoPlayer!.view, at: 0)
         videoPlayer!.didMove(toParent: self)
-        
+
+        // The blurred placeholder stays up while the player prepares. isReadyForDisplay
+        // tracks the moment the first video frame can render — the same moment the
+        // player's own loading indicator goes away — unlike status/likelyToKeepUp,
+        // which both fire mid-buffering. It never fires for audio-only items.
+        readyForDisplayObservation = videoPlayer!.observe(\.isReadyForDisplay, options: [.initial, .new]) { [weak self] playerVC, _ in
+            guard playerVC.isReadyForDisplay else { return }
+            DispatchQueue.main.async {
+                self?.imageStateOverlay.render(.loaded)
+                // AVPlayerViewController offers no public API to surface its control
+                // overlay without a tap (verified: showsPlaybackControls toggling and
+                // muted play/pause nudges do nothing on iOS 26) — show our own play
+                // affordance instead; the native controls take over once playback starts.
+                self?.showVideoPlayButton()
+            }
+        }
+        // If playback starts through the player's own controls, drop our affordance.
+        timeControlObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
+            guard player.timeControlStatus != .paused else { return }
+            DispatchQueue.main.async {
+                self?.videoPlayButton.removeFromSuperview()
+            }
+        }
+
         activityIndicator.stopAnimating()
         thumbnailImageView.isHidden = true
+    }
+
+    private var isObservingPlayerItem = false
+    private var readyForDisplayObservation: NSKeyValueObservation?
+    private var timeControlObservation: NSKeyValueObservation?
+    private var audioCover: UIView?
+    private var pendingAudioReveal = false
+    private var audioRevealStarted = false
+    /// Whether a blurred thumbnail/frame is available to show behind the failure/offline card.
+    private var previewBlurAvailable = false
+    /// A non-image preview is parked in the offline state, awaiting reconnect to auto-retry.
+    private var nonImageAwaitingReconnect = false
+
+    /// Snapshots the player's QuickTime artwork and runs the blur-to-sharp reveal.
+    /// drawHierarchy(afterScreenUpdates: true) moves windowless views into a temporary
+    /// window — forbidden for child VC views and a crash — so for pages the pager
+    /// preloaded offscreen, the reveal waits for viewDidAppear.
+    private func startAudioBlurRevealIfPossible() {
+        // Both the loadAudio timer and the viewDidAppear deferred path can call this;
+        // run the reveal exactly once to avoid a double snapshot / re-blur flicker.
+        guard let playerView = videoPlayer?.view, audioCover != nil, !audioRevealStarted else { return }
+        guard playerView.window != nil else {
+            pendingAudioReveal = true
+            return
+        }
+        pendingAudioReveal = false
+        audioRevealStarted = true
+
+        let snapshot = UIGraphicsImageRenderer(bounds: playerView.bounds).image { _ in
+            playerView.drawHierarchy(in: playerView.bounds, afterScreenUpdates: true)
+        }
+        imageStateOverlay.setSourceImage(snapshot)
+        imageStateOverlay.render(.loadingFullRes(hasThumbnail: true))
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) { [weak self] in
+            guard let self = self else { return }
+            self.audioCover?.removeFromSuperview()
+            self.audioCover = nil
+            self.imageStateOverlay.render(.loaded)
+            self.overlayView.isHidden = false
+        }
+    }
+
+    private func startObservingPlayerItem(_ item: AVPlayerItem) {
+        stopObservingPlayerItem()
+        item.addObserver(self, forKeyPath: #keyPath(AVPlayerItem.status), options: [.new], context: &playerItemContext)
+        isObservingPlayerItem = true
+    }
+
+    private func stopObservingPlayerItem() {
+        readyForDisplayObservation?.invalidate()
+        readyForDisplayObservation = nil
+        timeControlObservation?.invalidate()
+        timeControlObservation = nil
+        guard isObservingPlayerItem, let item = playerItem else { return }
+        item.removeObserver(self, forKeyPath: #keyPath(AVPlayerItem.status), context: &playerItemContext)
+        isObservingPlayerItem = false
     }
 
     
     @objc func playAudioFile(_ sender: UIButton) {
         overlayView.isHidden = true
-        
+        imageStateOverlay.render(.loaded)
+
         videoPlayer?.entersFullScreenWhenPlaybackBegins = true
         videoPlayer?.player?.play()
     }
@@ -546,11 +795,17 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     }
     
     func removeVideoPlayer() {
+        stopObservingPlayerItem()
+        videoPlayButton.removeFromSuperview()
+        audioCover?.removeFromSuperview()
+        audioCover = nil
         videoPlayer?.player?.replaceCurrentItem(with: nil)
-        
+
         videoPlayer?.willMove(toParent: nil)
         videoPlayer?.view.removeFromSuperview()
         videoPlayer?.removeFromParent()
+        videoPlayer = nil
+        playerItem = nil
     }
     
     // MARK: - Actions
@@ -669,23 +924,29 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
             return
         }
-        
-        activityIndicator.stopAnimating()
-        thumbnailImageView.isHidden = true
-        
+
+        let status: AVPlayerItem.Status?
         if keyPath == #keyPath(AVPlayerItem.status) {
-            let status: AVPlayerItem.Status
             if let statusNumber = change?[.newKey] as? NSNumber {
-                status = AVPlayerItem.Status(rawValue: statusNumber.intValue)!
+                status = AVPlayerItem.Status(rawValue: statusNumber.intValue)
             } else {
                 status = .unknown
             }
-            
+        } else {
+            status = nil
+        }
+
+        // AVPlayerItem.status KVO may be delivered on a background thread; hop to main
+        // before touching any UIKit state.
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.activityIndicator.stopAnimating()
+            self.thumbnailImageView.isHidden = true
+
             if status == .failed {
-                self.errorLabel.isHidden = false
-                self.retryButton.isHidden = false
-                
-                removeVideoPlayer()
+                self.stopObservingPlayerItem()
+                self.removeVideoPlayer()
+                self.showPreviewLoadFailure()
             }
         }
     }
@@ -881,16 +1142,12 @@ extension FilePreviewViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         activityIndicator.stopAnimating()
         thumbnailImageView.isHidden = true
+        imageStateOverlay.render(.loaded)
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        activityIndicator.stopAnimating()
-        thumbnailImageView.isHidden = true
-        
-        self.errorLabel.isHidden = false
-        self.retryButton.isHidden = false
-        
         webView.removeFromSuperview()
+        showPreviewLoadFailure()
     }
 }
 

--- a/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
@@ -43,15 +43,19 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     }
     
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
-    
+
+    let imageStateOverlay = ImagePreviewStateOverlayView()
+
     var recordLoadedCB: ((FilePreviewViewController) -> Void)?
     var closeAction: (() -> Void)?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         initUI()
+        setupImageStateOverlay()
         NotificationCenter.default.addObserver(self, selector: #selector(onDidUpdateShares(_:)), name: ShareLinkViewModel.didUpdateSharesNotifName, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(onDidUpdateShares(_:)), name: ShareItemViewModel.didUpdateSharesNotifName, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onReachabilityChanged(_:)), name: ReachabilityManager.reachabilityDidChangeNotifName, object: nil)
         
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [])
@@ -81,37 +85,109 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     
     func loadVM() {
         guard recordLoaded == false else { return }
-        
+
         if isViewLoaded {
             activityIndicator.startAnimating()
             if let url = URL(string: file.preferredThumbnailURL) {
                 thumbnailImageView.sd_setImage(with: url)
             }
         }
-        
+
         if viewModel == nil || viewModel?.recordVO == nil {
             viewModel = FilePreviewViewModel(file: file)
-            
-            if file.type == .image, let thumbnailURLString = file.preferredThumbnailURL {
-                loadThumbnailPreview(urlString: thumbnailURLString)
+            bindImagePreviewState()
+
+            if file.type == .image {
+                var thumbnailURL = file.preferredThumbnailURL
+                #if DEBUG
+                if debugForceNoThumbnail { thumbnailURL = nil }
+                #endif
+                let canLoad = viewModel?.startImageLoad(hasThumbnail: thumbnailURL != nil) ?? true
+                guard canLoad else {
+                    // Offline (S7): show whatever the cache has under the blur, but start no network load.
+                    activityIndicator.stopAnimating()
+                    if let thumbnailURLString = thumbnailURL {
+                        loadThumbnailPreview(urlString: thumbnailURLString, cacheOnly: true)
+                    }
+                    return
+                }
+                if let thumbnailURLString = thumbnailURL {
+                    loadThumbnailPreview(urlString: thumbnailURLString)
+                }
             }
-            
+
             viewModel?.getRecord(file: file, then: { [weak self] record in
                 if record != nil {
                     self?.loadRecord()
                 } else {
                     self?.activityIndicator.stopAnimating()
-                    self?.thumbnailImageView.isHidden = true
-                    
-                    self?.errorLabel.isHidden = false
-                    self?.retryButton.isHidden = false
+
+                    if self?.file.type == .image {
+                        self?.viewModel?.imageLoadDidFail(error: nil)
+                    } else {
+                        self?.thumbnailImageView.isHidden = true
+                        self?.errorLabel.isHidden = false
+                        self?.retryButton.isHidden = false
+                    }
                 }
             })
         } else if file.type == .image, let thumbnailURLString = file.preferredThumbnailURL {
+            bindImagePreviewState()
             loadThumbnailPreview(urlString: thumbnailURLString)
         } else {
             loadRecord()
         }
+    }
+
+    // MARK: - Image preview state handling (VSP-1768)
+
+    private func setupImageStateOverlay() {
+        imageStateOverlay.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(imageStateOverlay)
+        NSLayoutConstraint.activate([
+            imageStateOverlay.topAnchor.constraint(equalTo: view.topAnchor),
+            imageStateOverlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            imageStateOverlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageStateOverlay.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        imageStateOverlay.onRetryTapped = { [weak self] in
+            self?.retryImageLoad()
+        }
+    }
+
+    private func bindImagePreviewState() {
+        viewModel?.onImagePreviewStateChanged = { [weak self] state in
+            DispatchQueue.main.async {
+                self?.imageStateOverlay.render(state)
+            }
+        }
+        if let state = viewModel?.imagePreviewState {
+            imageStateOverlay.render(state)
+        }
+    }
+
+    private func retryImageLoad() {
+        guard file.type == .image, viewModel?.retryRequested() == true else { return }
+        resumeImageLoad()
+    }
+
+    private func resumeImageLoad() {
+        if viewModel?.recordVO == nil {
+            viewModel?.getRecord(file: file, then: { [weak self] record in
+                if record != nil {
+                    self?.loadRecord()
+                } else {
+                    self?.viewModel?.imageLoadDidFail(error: nil)
+                }
+            })
+        } else {
+            loadRecord()
+        }
+    }
+
+    @objc private func onReachabilityChanged(_ notification: Notification) {
+        guard file.type == .image, viewModel?.connectivityRestored() == true else { return }
+        resumeImageLoad()
     }
 
     func initUI() {
@@ -215,41 +291,48 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
             default:
                 self.loadMisc(withURL: downloadURL)
             }
+        } else if file.type == .image {
+            self.viewModel?.imageLoadDidFail(error: nil)
         } else {
             self.errorLabel.isHidden = false
             self.retryButton.isHidden = false
         }
-        
+
         if recordLoaded != true {
             recordLoaded = true
         }
     }
     
     /// Loads the 256px thumbnail into the zoomable image preview as a quick placeholder.
-    private func loadThumbnailPreview(urlString: String) {
+    /// With `cacheOnly` set, no network request is made (used while offline — S7).
+    private func loadThumbnailPreview(urlString: String, cacheOnly: Bool = false) {
         guard let url = URL(string: urlString) else { return }
-        
+
         let previewVC = ImagePreviewViewController()
         previewVC.delegate = self
         self.imagePreviewVC = previewVC
-        
+
         addChild(previewVC)
         previewVC.view.frame = view.bounds
         previewVC.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.insertSubview(previewVC.view, at: 0)
         previewVC.didMove(toParent: self)
-        
-        previewVC.imageView.sd_setImage(with: url) { [weak self] _, error, _, _ in
+
+        previewVC.imageView.sd_setImage(with: url, placeholderImage: nil, options: cacheOnly ? [.fromCacheOnly] : []) { [weak self] _, error, _, _ in
             guard let self = self else { return }
             self.activityIndicator.stopAnimating()
             self.thumbnailImageView.isHidden = true
-            
+
             if error != nil {
-                self.errorLabel.isHidden = false
-                self.retryButton.isHidden = false
-                self.removeImagePreviewVC()
+                if !cacheOnly {
+                    self.viewModel?.imageLoadDidFail(error: error)
+                }
             } else {
                 previewVC.newImageLoaded()
+                self.imageStateOverlay.setSourceImage(previewVC.imageView.image)
+                if !cacheOnly {
+                    self.viewModel?.thumbnailDidLoad()
+                }
             }
         }
     }
@@ -268,9 +351,13 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
             placeholderImage: previewVC.imageView.image,
             options: [.avoidAutoSetImage, .retryFailed],
             progress: nil
-        ) { [weak previewVC] image, _, cacheType, _ in
-            guard let previewVC = previewVC, let image = image else { return }
-            
+        ) { [weak self, weak previewVC] image, error, cacheType, _ in
+            guard let previewVC = previewVC, let image = image, error == nil else {
+                // Full-res failed (S6) — keep the thumbnail beneath the blur so retry can reuse it.
+                self?.viewModel?.imageLoadDidFail(error: error)
+                return
+            }
+
             if cachedFromMemory || cacheType == .memory {
                 // Cached in memory — swap immediately, no animation needed
                 previewVC.imageView.image = image
@@ -283,6 +370,7 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
                     previewVC.newImageLoaded()
                 }
             }
+            self?.viewModel?.fullResDidLoad()
         }
     }
     
@@ -293,9 +381,48 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         imagePreviewVC = nil
     }
     
+    #if DEBUG
+    /// QA hook: launch with `--slowImageLoad=5` to delay the full-res upgrade by N seconds,
+    /// making the blur + spinner loading state observable on fast networks.
+    private var debugFullResDelay: TimeInterval {
+        guard let arg = CommandLine.arguments.first(where: { $0.hasPrefix("--slowImageLoad=") }),
+              let seconds = Double(arg.split(separator: "=").last ?? "") else { return 0 }
+        return seconds
+    }
+
+    /// QA hook: launch with `--failFullResOnce` to make the first full-res load attempt fail,
+    /// exercising S6 (load failed) and, after tap-to-retry, S8 → success.
+    private static var debugFailFullResConsumed = false
+    private var debugShouldFailFullRes: Bool {
+        guard CommandLine.arguments.contains("--failFullResOnce"), !Self.debugFailFullResConsumed else { return false }
+        Self.debugFailFullResConsumed = true
+        return true
+    }
+
+    /// QA hook: launch with `--forceNoThumbnail` to pretend the record has no 256px thumbnail,
+    /// exercising S5 (neutral placeholder + spinner).
+    var debugForceNoThumbnail: Bool {
+        CommandLine.arguments.contains("--forceNoThumbnail")
+    }
+    #endif
+
     func loadImage(withURL url: URL) {
         if imagePreviewVC != nil {
             // Image preview already showing thumbnail — upgrade to full-res
+            #if DEBUG
+            if debugShouldFailFullRes {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                    self?.viewModel?.imageLoadDidFail(error: NSError(domain: "QA.failFullResOnce", code: -1))
+                }
+                return
+            }
+            if debugFullResDelay > 0 {
+                DispatchQueue.main.asyncAfter(deadline: .now() + debugFullResDelay) { [weak self] in
+                    self?.upgradeToFullResolution(urlString: url.absoluteString)
+                }
+                return
+            }
+            #endif
             upgradeToFullResolution(urlString: url.absoluteString)
         } else {
             // No preview yet (e.g. record already loaded) — load directly
@@ -309,19 +436,28 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
             view.insertSubview(previewVC.view, at: 0)
             previewVC.didMove(toParent: self)
             
-            previewVC.imageView.sd_setImage(with: url) { [weak self] _, error, _, _ in
-                guard let self = self else { return }
-                self.activityIndicator.stopAnimating()
-                self.thumbnailImageView.isHidden = true
-                
-                if error != nil {
-                    self.errorLabel.isHidden = false
-                    self.retryButton.isHidden = false
-                    self.removeImagePreviewVC()
-                } else {
-                    previewVC.newImageLoaded()
+            let startDirectLoad = { [weak self, weak previewVC] in
+                guard let previewVC = previewVC else { return }
+                previewVC.imageView.sd_setImage(with: url, placeholderImage: nil, options: [.retryFailed]) { _, error, _, _ in
+                    guard let self = self else { return }
+                    self.activityIndicator.stopAnimating()
+                    self.thumbnailImageView.isHidden = true
+
+                    if error != nil {
+                        self.viewModel?.imageLoadDidFail(error: error)
+                    } else {
+                        previewVC.newImageLoaded()
+                        self.viewModel?.fullResDidLoad()
+                    }
                 }
             }
+            #if DEBUG
+            if debugFullResDelay > 0 {
+                DispatchQueue.main.asyncAfter(deadline: .now() + debugFullResDelay, execute: startDirectLoad)
+                return
+            }
+            #endif
+            startDirectLoad()
         }
     }
     

--- a/Permanent/Modules/FileOperations/Views/ImagePreviewStateOverlayView.swift
+++ b/Permanent/Modules/FileOperations/Views/ImagePreviewStateOverlayView.swift
@@ -1,0 +1,250 @@
+//
+//  ImagePreviewStateOverlayView.swift
+//  Permanent
+//
+//  Created by Lucian Cerbu on 12.06.2026.
+//
+
+import UIKit
+import SwiftUI
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+/// Full-screen overlay rendering the image preview loading / failure states (VSP-1768, Figma node 24502-17330).
+/// The blur is a gaussian-blurred copy of the thumbnail, aspect-fitted like the photo beneath,
+/// so letterbox areas around the image stay black (per design); it never touches the image itself.
+class ImagePreviewStateOverlayView: UIView {
+    var onRetryTapped: (() -> Void)?
+
+    private let blurredImageView = UIImageView()
+    private let noThumbnailBackground = UIView()
+    private let logoImageView = UIImageView()
+    private let messageCard = UIView()
+    private let iconImageView = UIImageView()
+    private let messageLabel = UILabel()
+    // Gradient loader composited with the `screen` blend mode per the Figma component
+    // (Circles/Spinner-Two-Circles uses mix-blend-screen), which lightens it against
+    // the blurred photo beneath — reads as the "semi-transparent white" loader from S2.
+    private let spinnerHost = UIHostingController(rootView: GradientSemiCirclesLoaderView(frameWidth: 48, frameHeight: 48))
+
+    private var sourceImage: UIImage?
+    private var spinnerDelayWorkItem: DispatchWorkItem?
+
+    /// The loader appears only when the full image hasn't arrived within this interval (S2).
+    static let spinnerAppearanceDelay: TimeInterval = 0.5
+    /// Blur + loader fade-out duration once the full image is rendered (S3/S4).
+    static let fadeOutDuration: TimeInterval = 0.5
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+
+    private func setupUI() {
+        isHidden = true
+
+        noThumbnailBackground.backgroundColor = UIColor(white: 0.88, alpha: 1)
+        noThumbnailBackground.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(noThumbnailBackground)
+
+        logoImageView.contentMode = .scaleAspectFit
+        logoImageView.translatesAutoresizingMaskIntoConstraints = false
+        noThumbnailBackground.addSubview(logoImageView)
+        Self.blurred(UIImage(named: "logo_preview")) { [weak self] blurredLogo in
+            self?.logoImageView.image = blurredLogo
+        }
+
+        blurredImageView.contentMode = .scaleAspectFit
+        blurredImageView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(blurredImageView)
+
+        spinnerHost.view.backgroundColor = .clear
+        spinnerHost.view.layer.compositingFilter = "screenBlendMode"
+        spinnerHost.view.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(spinnerHost.view)
+
+        messageCard.backgroundColor = UIColor.black.withAlphaComponent(0.32)
+        messageCard.layer.cornerRadius = 24
+        messageCard.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(messageCard)
+
+        iconImageView.tintColor = .white
+        iconImageView.contentMode = .scaleAspectFit
+        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+
+        messageLabel.textColor = .white
+        messageLabel.numberOfLines = 0
+        messageLabel.textAlignment = .center
+
+        let cardStack = UIStackView(arrangedSubviews: [iconImageView, messageLabel])
+        cardStack.axis = .vertical
+        cardStack.alignment = .center
+        cardStack.spacing = 24
+        cardStack.translatesAutoresizingMaskIntoConstraints = false
+        messageCard.addSubview(cardStack)
+
+        NSLayoutConstraint.activate([
+            noThumbnailBackground.topAnchor.constraint(equalTo: topAnchor),
+            noThumbnailBackground.bottomAnchor.constraint(equalTo: bottomAnchor),
+            noThumbnailBackground.leadingAnchor.constraint(equalTo: leadingAnchor),
+            noThumbnailBackground.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            logoImageView.centerXAnchor.constraint(equalTo: noThumbnailBackground.centerXAnchor),
+            logoImageView.centerYAnchor.constraint(equalTo: noThumbnailBackground.centerYAnchor),
+            logoImageView.widthAnchor.constraint(equalTo: noThumbnailBackground.widthAnchor, multiplier: 0.66),
+            logoImageView.heightAnchor.constraint(equalTo: logoImageView.widthAnchor, multiplier: 0.75),
+
+            blurredImageView.topAnchor.constraint(equalTo: topAnchor),
+            blurredImageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            blurredImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            blurredImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            spinnerHost.view.centerXAnchor.constraint(equalTo: centerXAnchor),
+            spinnerHost.view.centerYAnchor.constraint(equalTo: centerYAnchor),
+            spinnerHost.view.widthAnchor.constraint(equalToConstant: 48),
+            spinnerHost.view.heightAnchor.constraint(equalToConstant: 48),
+
+            messageCard.centerXAnchor.constraint(equalTo: centerXAnchor),
+            messageCard.centerYAnchor.constraint(equalTo: centerYAnchor),
+            messageCard.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, constant: -48),
+
+            iconImageView.widthAnchor.constraint(equalToConstant: 24),
+            iconImageView.heightAnchor.constraint(equalToConstant: 24),
+
+            cardStack.topAnchor.constraint(equalTo: messageCard.topAnchor, constant: 32),
+            cardStack.bottomAnchor.constraint(equalTo: messageCard.bottomAnchor, constant: -32),
+            cardStack.leadingAnchor.constraint(equalTo: messageCard.leadingAnchor, constant: 32),
+            cardStack.trailingAnchor.constraint(equalTo: messageCard.trailingAnchor, constant: -32)
+        ])
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(overlayTapped))
+        addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func overlayTapped() {
+        onRetryTapped?()
+    }
+
+    /// Sets the image the blur is generated from (the loaded thumbnail). The blurred copy
+    /// is aspect-fitted like the photo, so the blur covers exactly the photo's on-screen rect.
+    func setSourceImage(_ image: UIImage?) {
+        guard image !== sourceImage else { return }
+        sourceImage = image
+        guard let image = image else {
+            blurredImageView.image = nil
+            return
+        }
+        Self.blurred(image) { [weak self] blurredImage in
+            guard self?.sourceImage === image else { return }
+            self?.blurredImageView.image = blurredImage
+        }
+    }
+
+    func render(_ state: ImagePreviewState) {
+        spinnerDelayWorkItem?.cancel()
+        spinnerDelayWorkItem = nil
+
+        switch state {
+        case .idle, .loadingThumbnail:
+            layer.removeAllAnimations()
+            alpha = 1
+            isHidden = true
+
+        case .loaded:
+            // S3/S4: full image is beneath — fade the blur and loader out together (ease-out).
+            guard !isHidden else { break }
+            UIView.animate(withDuration: Self.fadeOutDuration, delay: 0, options: [.curveEaseOut, .beginFromCurrentState]) {
+                self.alpha = 0
+            } completion: { _ in
+                self.isHidden = true
+                self.alpha = 1
+            }
+
+        case .loadingFullRes(let hasThumbnail):
+            showOverlay()
+            blurredImageView.isHidden = !hasThumbnail
+            noThumbnailBackground.isHidden = hasThumbnail
+            messageCard.isHidden = true
+            // S2: the loader appears only when the full image hasn't arrived within 500 ms,
+            // so fast loads never flash a spinner.
+            spinnerHost.view.isHidden = true
+            let workItem = DispatchWorkItem { [weak self] in
+                guard let self = self else { return }
+                self.spinnerHost.view.alpha = 0
+                self.spinnerHost.view.isHidden = false
+                UIView.animate(withDuration: 0.2) {
+                    self.spinnerHost.view.alpha = 1
+                }
+            }
+            spinnerDelayWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.spinnerAppearanceDelay, execute: workItem)
+
+        case .failed(let hasThumbnail):
+            showOverlay()
+            blurredImageView.isHidden = !hasThumbnail
+            noThumbnailBackground.isHidden = hasThumbnail
+            spinnerHost.view.isHidden = true
+            showCard(icon: "arrow.clockwise", message: "\(String.couldntLoadImage)\n\(String.tapToRetry)")
+
+        case .offline(let hasThumbnail):
+            showOverlay()
+            blurredImageView.isHidden = !hasThumbnail
+            noThumbnailBackground.isHidden = hasThumbnail
+            spinnerHost.view.isHidden = true
+            showCard(icon: "wifi.slash", message: "\(String.youreOffline)\n\(String.connectToLoadFullQuality)")
+        }
+    }
+
+    private func showOverlay() {
+        layer.removeAllAnimations()
+        alpha = 1
+        isHidden = false
+        spinnerHost.view.alpha = 1
+    }
+
+    /// Gaussian-blurs an image off the main thread, clamping the edges so the blur
+    /// doesn't fade to transparent at the borders.
+    private static func blurred(_ image: UIImage?, radius: Double = 24, completion: @escaping (UIImage?) -> Void) {
+        guard let image = image, let ciImage = CIImage(image: image) else {
+            completion(nil)
+            return
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+            let filter = CIFilter.gaussianBlur()
+            filter.inputImage = ciImage.clampedToExtent()
+            filter.radius = Float(radius)
+
+            let context = CIContext()
+            guard let output = filter.outputImage,
+                  let cgImage = context.createCGImage(output, from: ciImage.extent) else {
+                DispatchQueue.main.async { completion(image) }
+                return
+            }
+            let result = UIImage(cgImage: cgImage, scale: image.scale, orientation: image.imageOrientation)
+            DispatchQueue.main.async { completion(result) }
+        }
+    }
+
+    private func showCard(icon: String, message: String) {
+        iconImageView.image = UIImage(systemName: icon, withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .regular))
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = 24
+        paragraphStyle.maximumLineHeight = 24
+        paragraphStyle.alignment = .center
+        messageLabel.attributedText = NSAttributedString(
+            string: message,
+            attributes: [
+                .font: UIFont(name: "Usual-Regular", size: 14) ?? UIFont.systemFont(ofSize: 14),
+                .foregroundColor: UIColor.white,
+                .paragraphStyle: paragraphStyle
+            ]
+        )
+        messageCard.isHidden = false
+    }
+}

--- a/Permanent/Modules/FileOperations/Views/ImagePreviewStateOverlayView.swift
+++ b/Permanent/Modules/FileOperations/Views/ImagePreviewStateOverlayView.swift
@@ -47,6 +47,7 @@ class ImagePreviewStateOverlayView: UIView {
 
     private func setupUI() {
         isHidden = true
+        accessibilityIdentifier = "imagePreviewStateOverlay"
 
         noThumbnailBackground.backgroundColor = UIColor(white: 0.88, alpha: 1)
         noThumbnailBackground.translatesAutoresizingMaskIntoConstraints = false
@@ -80,6 +81,7 @@ class ImagePreviewStateOverlayView: UIView {
         messageLabel.textColor = .white
         messageLabel.numberOfLines = 0
         messageLabel.textAlignment = .center
+        messageLabel.accessibilityIdentifier = "imagePreviewStateMessage"
 
         let cardStack = UIStackView(arrangedSubviews: [iconImageView, messageLabel])
         cardStack.axis = .vertical

--- a/Permanent/Modules/FileOperations/Views/ImagePreviewStateOverlayView.swift
+++ b/Permanent/Modules/FileOperations/Views/ImagePreviewStateOverlayView.swift
@@ -15,6 +15,9 @@ import CoreImage.CIFilterBuiltins
 /// so letterbox areas around the image stay black (per design); it never touches the image itself.
 class ImagePreviewStateOverlayView: UIView {
     var onRetryTapped: (() -> Void)?
+    /// Selects the noun in the failed-load copy: "Couldn't load image" for photos,
+    /// "Couldn't load file" for video/audio/documents.
+    var isImageContent = true
 
     private let blurredImageView = UIImageView()
     private let noThumbnailBackground = UIView()
@@ -29,6 +32,10 @@ class ImagePreviewStateOverlayView: UIView {
 
     private var sourceImage: UIImage?
     private var spinnerDelayWorkItem: DispatchWorkItem?
+    /// Resting opacity of the loader. Over photos the screen blend already makes it read
+    /// as soft/translucent at full alpha; on the light neutral background screen blend
+    /// vanishes, so a reduced alpha gives the same melted-into-the-glow look instead.
+    private var spinnerTargetAlpha: CGFloat = 1
 
     /// The loader appears only when the full image hasn't arrived within this interval (S2).
     static let spinnerAppearanceDelay: TimeInterval = 0.5
@@ -54,9 +61,11 @@ class ImagePreviewStateOverlayView: UIView {
         addSubview(noThumbnailBackground)
 
         logoImageView.contentMode = .scaleAspectFit
+        logoImageView.alpha = 0.7
         logoImageView.translatesAutoresizingMaskIntoConstraints = false
         noThumbnailBackground.addSubview(logoImageView)
-        Self.blurred(UIImage(named: "logo_preview")) { [weak self] blurredLogo in
+        // Soft edges: the logo glow must melt into the background, not end in a rectangle.
+        Self.blurred(UIImage(named: "logo_preview"), softEdges: true) { [weak self] blurredLogo in
             self?.logoImageView.image = blurredLogo
         }
 
@@ -129,6 +138,20 @@ class ImagePreviewStateOverlayView: UIView {
     }
 
     @objc private func overlayTapped() {
+        // Acknowledge the tap with a quick press animation on the card — gives the user
+        // visual feedback even when the retry can't proceed (e.g. still offline) or fails
+        // again immediately.
+        if !messageCard.isHidden {
+            UIView.animate(withDuration: 0.12, delay: 0, options: [.allowUserInteraction], animations: {
+                self.messageCard.transform = CGAffineTransform(scaleX: 0.94, y: 0.94)
+                self.messageCard.alpha = 0.6
+            }, completion: { _ in
+                UIView.animate(withDuration: 0.12, delay: 0, options: [.allowUserInteraction], animations: {
+                    self.messageCard.transform = .identity
+                    self.messageCard.alpha = 1
+                })
+            })
+        }
         onRetryTapped?()
     }
 
@@ -171,6 +194,7 @@ class ImagePreviewStateOverlayView: UIView {
             showOverlay()
             blurredImageView.isHidden = !hasThumbnail
             noThumbnailBackground.isHidden = hasThumbnail
+            updateSpinnerBlend(overPhoto: hasThumbnail)
             messageCard.isHidden = true
             // S2: the loader appears only when the full image hasn't arrived within 500 ms,
             // so fast loads never flash a spinner.
@@ -180,7 +204,7 @@ class ImagePreviewStateOverlayView: UIView {
                 self.spinnerHost.view.alpha = 0
                 self.spinnerHost.view.isHidden = false
                 UIView.animate(withDuration: 0.2) {
-                    self.spinnerHost.view.alpha = 1
+                    self.spinnerHost.view.alpha = self.spinnerTargetAlpha
                 }
             }
             spinnerDelayWorkItem = workItem
@@ -191,7 +215,8 @@ class ImagePreviewStateOverlayView: UIView {
             blurredImageView.isHidden = !hasThumbnail
             noThumbnailBackground.isHidden = hasThumbnail
             spinnerHost.view.isHidden = true
-            showCard(icon: "arrow.clockwise", message: "\(String.couldntLoadImage)\n\(String.tapToRetry)")
+            let failedTitle = isImageContent ? String.couldntLoadImage : String.couldntLoadFile
+            showCard(icon: "arrow.clockwise", message: "\(failedTitle)\n\(String.tapToRetry)")
 
         case .offline(let hasThumbnail):
             showOverlay()
@@ -206,24 +231,39 @@ class ImagePreviewStateOverlayView: UIView {
         layer.removeAllAnimations()
         alpha = 1
         isHidden = false
-        spinnerHost.view.alpha = 1
+        spinnerHost.view.alpha = spinnerTargetAlpha
     }
 
-    /// Gaussian-blurs an image off the main thread, clamping the edges so the blur
-    /// doesn't fade to transparent at the borders.
-    private static func blurred(_ image: UIImage?, radius: Double = 24, completion: @escaping (UIImage?) -> Void) {
+    /// Over photo blur the loader uses screen blending (per the Figma component) at full
+    /// alpha — the blend keeps it soft. On the light neutral background screen blending
+    /// vanishes, so the loader instead drops to a lower alpha to melt into the logo glow,
+    /// matching the translucent feel of the photo loader.
+    private func updateSpinnerBlend(overPhoto: Bool) {
+        spinnerHost.view.layer.compositingFilter = overPhoto ? "screenBlendMode" : nil
+        spinnerTargetAlpha = overPhoto ? 1 : 0.5
+        spinnerHost.view.alpha = spinnerTargetAlpha
+    }
+
+    // CIContext creation is expensive (~100-300 ms); share one across blurs so the
+    // placeholder appears within a frame or two of the thumbnail.
+    private static let blurContext = CIContext()
+
+    /// Gaussian-blurs an image off the main thread. With `softEdges` false the edges are
+    /// clamped so the blur stays full-bleed (photo placeholders); with `softEdges` true the
+    /// blur fades out into transparency beyond the original bounds (logo glow).
+    private static func blurred(_ image: UIImage?, radius: Double = 24, softEdges: Bool = false, completion: @escaping (UIImage?) -> Void) {
         guard let image = image, let ciImage = CIImage(image: image) else {
             completion(nil)
             return
         }
         DispatchQueue.global(qos: .userInitiated).async {
             let filter = CIFilter.gaussianBlur()
-            filter.inputImage = ciImage.clampedToExtent()
+            filter.inputImage = softEdges ? ciImage : ciImage.clampedToExtent()
             filter.radius = Float(radius)
 
-            let context = CIContext()
+            let renderRect = softEdges ? ciImage.extent.insetBy(dx: -2 * radius, dy: -2 * radius) : ciImage.extent
             guard let output = filter.outputImage,
-                  let cgImage = context.createCGImage(output, from: ciImage.extent) else {
+                  let cgImage = blurContext.createCGImage(output, from: renderRect) else {
                 DispatchQueue.main.async { completion(image) }
                 return
             }
@@ -233,6 +273,9 @@ class ImagePreviewStateOverlayView: UIView {
     }
 
     private func showCard(icon: String, message: String) {
+        // Reset any leftover press-animation transform/alpha before showing.
+        messageCard.transform = .identity
+        messageCard.alpha = 1
         iconImageView.image = UIImage(systemName: icon, withConfiguration: UIImage.SymbolConfiguration(pointSize: 16, weight: .regular))
 
         let paragraphStyle = NSMutableParagraphStyle()

--- a/Permanent/Resources/Assets/Localization/en.lproj/Localizable.strings
+++ b/Permanent/Resources/Assets/Localization/en.lproj/Localizable.strings
@@ -199,6 +199,7 @@
 
 /// Full screen image preview states (VSP-1768)
 "CouldntLoadImage" = "Couldn't load image.";
+"CouldntLoadFile" = "Couldn't load file.";
 "TapToRetry" = "Tap to Retry.";
 "YoureOffline" = "You're offline.";
 "ConnectToLoadFullQuality" = "Connect to load full quality.";

--- a/Permanent/Resources/Assets/Localization/en.lproj/Localizable.strings
+++ b/Permanent/Resources/Assets/Localization/en.lproj/Localizable.strings
@@ -196,3 +196,9 @@
 "ErrorUnknown" = "Some unknown error has occured. Please try again.";
 "ErrorServer" = "Server error has occured. Please try again.";
 "DownloadCancelled" = "Download cancelled";
+
+/// Full screen image preview states (VSP-1768)
+"CouldntLoadImage" = "Couldn't load image.";
+"TapToRetry" = "Tap to Retry.";
+"YoureOffline" = "You're offline.";
+"ConnectToLoadFullQuality" = "Connect to load full quality.";

--- a/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
@@ -9,47 +9,137 @@ import UIKit
 import WebKit
 import AVKit
 
+enum ImagePreviewState: Equatable {
+    case idle
+    case loadingThumbnail
+    case loadingFullRes(hasThumbnail: Bool)   // S5 when hasThumbnail == false; S8 reuses this after retry
+    case loaded
+    case failed(hasThumbnail: Bool)           // S6, or the S5 failure variant when no thumbnail exists
+    case offline(hasThumbnail: Bool)          // S7
+}
+
 class FilePreviewViewModel: ViewModelInterface {
+    static let maxRecordFetchAttempts = 3
+
     let file: FileModel
     var name: String
     var publicURL: URL?
-    
+
     var recordVO: RecordVO?
     var isEditable: Bool {
         return file.permissions.contains(.edit)
     }
-    
+
     weak var delegate: FilePreviewNavigationControllerDelegate?
-    
+
     var downloader: DownloadManagerGCD? = nil
-    
+
     let tagsRepository: TagsRepository
-    
-    init(file: FileModel, tagsRepository: TagsRepository = TagsRepository()) {
+    let reachability: ReachabilityProviding
+
+    var onImagePreviewStateChanged: ((ImagePreviewState) -> Void)?
+    private(set) var imagePreviewState: ImagePreviewState = .idle {
+        didSet {
+            guard oldValue != imagePreviewState else { return }
+            onImagePreviewStateChanged?(imagePreviewState)
+        }
+    }
+
+    private var recordFetchAttempts = 0
+
+    init(file: FileModel, tagsRepository: TagsRepository = TagsRepository(), reachability: ReachabilityProviding = ReachabilityManager.shared) {
         self.tagsRepository = tagsRepository
+        self.reachability = reachability
         self.file = file
         name = file.name
     }
-    
+
+    // MARK: - Image preview state transitions
+
+    private var stateHasThumbnail: Bool {
+        switch imagePreviewState {
+        case .loadingFullRes(let hasThumbnail), .failed(let hasThumbnail), .offline(let hasThumbnail):
+            return hasThumbnail
+        case .loadingThumbnail, .loaded:
+            return true
+        case .idle:
+            return false
+        }
+    }
+
+    /// Returns false when offline: the caller should not start any network load.
+    @discardableResult
+    func startImageLoad(hasThumbnail: Bool) -> Bool {
+        guard reachability.isConnected else {
+            imagePreviewState = .offline(hasThumbnail: hasThumbnail)
+            return false
+        }
+        imagePreviewState = hasThumbnail ? .loadingThumbnail : .loadingFullRes(hasThumbnail: false)
+        return true
+    }
+
+    func thumbnailDidLoad() {
+        imagePreviewState = .loadingFullRes(hasThumbnail: true)
+    }
+
+    func fullResDidLoad() {
+        imagePreviewState = .loaded
+    }
+
+    func imageLoadDidFail(error: Error?) {
+        guard imagePreviewState != .loaded else { return }
+        if reachability.isConnected {
+            imagePreviewState = .failed(hasThumbnail: stateHasThumbnail)
+        } else {
+            imagePreviewState = .offline(hasThumbnail: stateHasThumbnail)
+        }
+    }
+
+    /// Returns true when the caller should restart the failed load (S8). While still offline it keeps the offline state and returns false (S7).
+    func retryRequested() -> Bool {
+        guard reachability.isConnected else {
+            imagePreviewState = .offline(hasThumbnail: stateHasThumbnail)
+            return false
+        }
+        recordFetchAttempts = 0
+        imagePreviewState = .loadingFullRes(hasThumbnail: stateHasThumbnail)
+        return true
+    }
+
+    /// Returns true when the caller should resume loading after connectivity came back while in the offline state.
+    func connectivityRestored() -> Bool {
+        guard case .offline = imagePreviewState, reachability.isConnected else { return false }
+        return retryRequested()
+    }
+
+    // MARK: - Record fetching
+
     func getRecord(file: FileModel, then handler: @escaping (RecordVO?) -> Void) {
         let downloadInfo = FileDownloadInfoVM(
             fileType: file.type,
             folderLinkId: file.folderLinkId,
             parentFolderLinkId: file.parentFolderLinkId
         )
-        
+
         downloader = DownloadManagerGCD()
         downloader?.getRecord(downloadInfo) { [weak self] (record, error) in
             self?.onRecordCallback(file: file, record: record, error: error, then: handler)
         }
     }
-    
+
     func onRecordCallback(file: FileModel, record: RecordVO?, error: Error?, then handler: @escaping (RecordVO?) -> Void) {
         if record != nil && error == nil {
+            recordFetchAttempts = 0
             recordVO = record
-            
+
             handler(record)
         } else {
+            recordFetchAttempts += 1
+            guard recordFetchAttempts < Self.maxRecordFetchAttempts, reachability.isConnected else {
+                recordFetchAttempts = 0
+                handler(nil)
+                return
+            }
             getRecord(file: file, then: handler)
         }
     }

--- a/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
@@ -115,6 +115,14 @@ class FilePreviewViewModel: ViewModelInterface {
     // MARK: - Record fetching
 
     func getRecord(file: FileModel, then handler: @escaping (RecordVO?) -> Void) {
+        #if DEBUG
+        // QA hook: launch with `--failRecordLoad` to simulate a failed record fetch
+        // (e.g. a real-device offline open), exercising the failure/offline preview card.
+        if CommandLine.arguments.contains("--failRecordLoad") {
+            handler(nil)
+            return
+        }
+        #endif
         let downloadInfo = FileDownloadInfoVM(
             fileType: file.type,
             folderLinkId: file.folderLinkId,

--- a/PermanentTests/AccountDeleteViewModelTests.swift
+++ b/PermanentTests/AccountDeleteViewModelTests.swift
@@ -44,29 +44,18 @@ final class AccountDeleteViewModelTests: XCTestCase {
     }
 
     // MARK: - Delete Account Tests
-
-    func testDeleteAccount_WithNoSession_ReturnsFalse() {
-        let viewModel = AccountDeleteViewModel()
-        let expectation = expectation(description: "deleteAccount completion called")
-
-        viewModel.deleteAccount { success in
-            XCTAssertFalse(success, "deleteAccount should return false when there is no active session")
-            expectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 2.0)
-    }
-
-    func testDeleteAccount_WithNoSession_CallsCompletionSynchronously() {
-        let viewModel = AccountDeleteViewModel()
-        var completionCalled = false
-
-        viewModel.deleteAccount { _ in
-            completionCalled = true
-        }
-
-        XCTAssertTrue(completionCalled, "Completion should be called immediately when session is nil (guard returns early)")
-    }
+    //
+    // DO NOT call viewModel.deleteAccount() from a unit test. It is NOT mockable:
+    // it reads AuthenticationManager.shared.session and hits the real
+    // /account/delete endpoint via APIRequestDispatcher(). These tests assumed no
+    // active session (so deleteAccount would early-return false), but the session
+    // persists in the shared keychain across runs — if any account is logged in on
+    // the test host, running them DELETES that real account on the backend.
+    //
+    // Safe coverage requires making AccountDeleteViewModel injectable (a session
+    // provider + dispatcher seam, like FilePreviewViewModel's ReachabilityProviding)
+    // and asserting against a mock. Until then, the delete path is left untested
+    // here rather than risk destroying a live account.
 
     // MARK: - ViewModelInterface Default Methods Tests
 

--- a/PermanentTests/FilePreviewViewModelTests.swift
+++ b/PermanentTests/FilePreviewViewModelTests.swift
@@ -186,3 +186,200 @@ final class FilePreviewViewModelTests: XCTestCase {
         XCTAssertEqual(vm.publicURL?.absoluteString, "https://example.com/file")
     }
 }
+
+// MARK: - Image preview state machine (VSP-1768)
+
+private final class MockReachability: ReachabilityProviding {
+    var isConnected: Bool
+
+    init(isConnected: Bool = true) {
+        self.isConnected = isConnected
+    }
+}
+
+extension FilePreviewViewModelTests {
+
+    private func makeImageVM(isConnected: Bool = true) -> (FilePreviewViewModel, MockReachability) {
+        let reachability = MockReachability(isConnected: isConnected)
+        let vm = FilePreviewViewModel(file: FileModel.mockFile(), reachability: reachability)
+        return (vm, reachability)
+    }
+
+    func testStartImageLoad_WithThumbnail_EntersLoadingThumbnail() {
+        let (vm, _) = makeImageVM()
+
+        XCTAssertTrue(vm.startImageLoad(hasThumbnail: true))
+        XCTAssertEqual(vm.imagePreviewState, .loadingThumbnail)
+    }
+
+    func testStartImageLoad_NoThumbnail_EntersLoadingFullResWithoutThumbnail() {
+        let (vm, _) = makeImageVM()
+
+        XCTAssertTrue(vm.startImageLoad(hasThumbnail: false))
+        XCTAssertEqual(vm.imagePreviewState, .loadingFullRes(hasThumbnail: false))
+    }
+
+    func testStartImageLoad_Offline_EntersOfflineState_AndBlocksLoading() {
+        let (vm, _) = makeImageVM(isConnected: false)
+
+        XCTAssertFalse(vm.startImageLoad(hasThumbnail: true))
+        XCTAssertEqual(vm.imagePreviewState, .offline(hasThumbnail: true))
+    }
+
+    func testThumbnailDidLoad_TransitionsToLoadingFullRes() {
+        let (vm, _) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: true)
+
+        vm.thumbnailDidLoad()
+
+        XCTAssertEqual(vm.imagePreviewState, .loadingFullRes(hasThumbnail: true))
+    }
+
+    func testFullResDidLoad_TransitionsToLoaded() {
+        let (vm, _) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: true)
+        vm.thumbnailDidLoad()
+
+        vm.fullResDidLoad()
+
+        XCTAssertEqual(vm.imagePreviewState, .loaded)
+    }
+
+    func testImageLoadDidFail_Online_EntersFailedState_PreservingHasThumbnail() {
+        let (vm, _) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: true)
+        vm.thumbnailDidLoad()
+
+        vm.imageLoadDidFail(error: nil)
+
+        XCTAssertEqual(vm.imagePreviewState, .failed(hasThumbnail: true))
+    }
+
+    func testImageLoadDidFail_Online_NoThumbnail_KeepsHasThumbnailFalse() {
+        let (vm, _) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: false)
+
+        vm.imageLoadDidFail(error: nil)
+
+        XCTAssertEqual(vm.imagePreviewState, .failed(hasThumbnail: false))
+    }
+
+    func testImageLoadDidFail_Offline_EntersOfflineState() {
+        let (vm, reachability) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: true)
+        vm.thumbnailDidLoad()
+        reachability.isConnected = false
+
+        vm.imageLoadDidFail(error: nil)
+
+        XCTAssertEqual(vm.imagePreviewState, .offline(hasThumbnail: true))
+    }
+
+    func testImageLoadDidFail_AfterLoaded_IsIgnored() {
+        let (vm, _) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: true)
+        vm.fullResDidLoad()
+
+        vm.imageLoadDidFail(error: nil)
+
+        XCTAssertEqual(vm.imagePreviewState, .loaded)
+    }
+
+    func testRetryRequested_Online_EntersLoadingFullRes_ReturnsTrue() {
+        let (vm, _) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: true)
+        vm.thumbnailDidLoad()
+        vm.imageLoadDidFail(error: nil)
+
+        XCTAssertTrue(vm.retryRequested())
+        XCTAssertEqual(vm.imagePreviewState, .loadingFullRes(hasThumbnail: true))
+    }
+
+    func testRetryRequested_StillOffline_StaysOffline_ReturnsFalse() {
+        let (vm, _) = makeImageVM(isConnected: false)
+        vm.startImageLoad(hasThumbnail: true)
+
+        XCTAssertFalse(vm.retryRequested())
+        XCTAssertEqual(vm.imagePreviewState, .offline(hasThumbnail: true))
+    }
+
+    func testConnectivityRestored_FromOffline_ResumesLoading() {
+        let (vm, reachability) = makeImageVM(isConnected: false)
+        vm.startImageLoad(hasThumbnail: true)
+        reachability.isConnected = true
+
+        XCTAssertTrue(vm.connectivityRestored())
+        XCTAssertEqual(vm.imagePreviewState, .loadingFullRes(hasThumbnail: true))
+    }
+
+    func testConnectivityRestored_WhenNotOffline_DoesNothing() {
+        let (vm, _) = makeImageVM()
+        vm.startImageLoad(hasThumbnail: true)
+        vm.fullResDidLoad()
+
+        XCTAssertFalse(vm.connectivityRestored())
+        XCTAssertEqual(vm.imagePreviewState, .loaded)
+    }
+
+    func testStateChangeClosure_FiresOnlyOnDistinctStates() {
+        let (vm, _) = makeImageVM()
+        var observedStates: [ImagePreviewState] = []
+        vm.onImagePreviewStateChanged = { observedStates.append($0) }
+
+        vm.startImageLoad(hasThumbnail: true)
+        vm.thumbnailDidLoad()
+        vm.thumbnailDidLoad()
+        vm.fullResDidLoad()
+
+        XCTAssertEqual(observedStates, [.loadingThumbnail, .loadingFullRes(hasThumbnail: true), .loaded])
+    }
+
+    /// Regression test for the former infinite retry loop: repeated record-fetch
+    /// failures must stop after maxRecordFetchAttempts and report nil to the caller.
+    func testOnRecordCallback_RepeatedErrors_StopsAfterCapAndCallsHandlerWithNil() {
+        final class GetRecordSpyViewModel: FilePreviewViewModel {
+            var getRecordCallCount = 0
+            override func getRecord(file: FileModel, then handler: @escaping (RecordVO?) -> Void) {
+                getRecordCallCount += 1
+            }
+        }
+
+        let vm = GetRecordSpyViewModel(file: FileModel.mockFile(), reachability: MockReachability(isConnected: true))
+        let error = NSError(domain: "test", code: -1)
+        var handlerCalled = false
+        var handlerRecord: RecordVO? = RecordVO(recordVO: nil)
+        let handler: (RecordVO?) -> Void = { record in
+            handlerCalled = true
+            handlerRecord = record
+        }
+
+        // Failures below the cap retry by re-calling getRecord, never the handler.
+        vm.onRecordCallback(file: FileModel.mockFile(), record: nil, error: error, then: handler)
+        XCTAssertEqual(vm.getRecordCallCount, 1)
+        XCTAssertFalse(handlerCalled)
+
+        vm.onRecordCallback(file: FileModel.mockFile(), record: nil, error: error, then: handler)
+        XCTAssertEqual(vm.getRecordCallCount, 2)
+        XCTAssertFalse(handlerCalled)
+
+        // The attempt that reaches the cap stops retrying and surfaces nil.
+        vm.onRecordCallback(file: FileModel.mockFile(), record: nil, error: error, then: handler)
+        XCTAssertEqual(vm.getRecordCallCount, 2)
+        XCTAssertTrue(handlerCalled)
+        XCTAssertNil(handlerRecord)
+    }
+
+    func testOnRecordCallback_Offline_FailsImmediately() {
+        let (vm, _) = makeImageVM(isConnected: false)
+        var handlerCalled = false
+        var handlerRecord: RecordVO? = RecordVO(recordVO: nil)
+
+        vm.onRecordCallback(file: FileModel.mockFile(), record: nil, error: NSError(domain: "test", code: -1)) { record in
+            handlerCalled = true
+            handlerRecord = record
+        }
+
+        XCTAssertTrue(handlerCalled)
+        XCTAssertNil(handlerRecord)
+    }
+}

--- a/PermanentUITests/FilePreviewStateUITests.swift
+++ b/PermanentUITests/FilePreviewStateUITests.swift
@@ -1,0 +1,130 @@
+//
+//  FilePreviewStateUITests.swift
+//  PermanentUITests
+//
+//  Created by Lucian Cerbu on 12.06.2026.
+//
+
+import XCTest
+
+/// UI tests for the full screen image preview loading / failure states (VSP-1768).
+/// The states are driven deterministically through the DEBUG-only launch arguments
+/// handled by FilePreviewViewController and AppDelegate.
+class FilePreviewStateUITests: BaseUITestCase {
+
+    override func setUpWithError() throws {
+        // Launch arguments must be appended before BaseUITestCase launches the app.
+        if name.contains("LoadFailed") {
+            app.launchArguments.append("--failFullResOnce")
+        } else if name.contains("Offline") {
+            app.launchArguments.append("--forceOffline")
+        }
+        try super.setUpWithError()
+    }
+
+    /// S6 → S8 → S4: the first full-res load fails and shows the retry card;
+    /// tapping it retries and the image eventually renders without the overlay.
+    func testImagePreviewLoadFailedShowsRetryAndRecovers() throws {
+        let accountEmail = uiTestCredentials.username
+        let accountPassword = uiTestCredentials.password
+
+        let loginPage = LoginPage(app: app, testCase: self)
+        loginPage.login(username: accountEmail, password: accountPassword)
+
+        let privateFilesPage = PrivateFilesPage(app: app, testCase: self)
+        privateFilesPage.waitForExistence()
+
+        // Seed: aaa_-prefixed folder + one uploaded photo.
+        let folderName = "aaa_state_\(UUID().uuidString.prefix(6))"
+        privateFilesPage.createNewFolder(name: folderName)
+        privateFilesPage.enterFolder(named: folderName)
+
+        privateFilesPage.enterPhotoLibrary()
+
+        let photoLibraryPage = PhotoLibraryPage(app: app, testCase: self)
+        photoLibraryPage.waitForExistence()
+        photoLibraryPage.uploadFirstPhoto()
+
+        privateFilesPage.processUpload()
+        privateFilesPage.tapFirstFileCell()
+
+        let previewPage = FilePreviewPage(app: app)
+        previewPage.waitForExistence()
+
+        // --failFullResOnce makes the first full-res attempt fail → S6.
+        previewPage.waitForLoadFailedState()
+
+        // Tap to retry → S8 → the second attempt succeeds → overlay disappears (S4).
+        previewPage.tapRetry()
+        previewPage.waitForImageLoaded()
+
+        previewPage.close()
+        privateFilesPage.waitForExistence()
+
+        // Cleanup: delete the photo + the folder.
+        privateFilesPage.deleteFirstElementFromFolder()
+        privateFilesPage.emptyFolderTest()
+        privateFilesPage.goBack()
+        privateFilesPage.deleteElement(named: folderName)
+
+        privateFilesPage.toggleRightSideMenu()
+        let rightSideMenu = RightSideMenuPage(app: app, testCase: self, accountEmail: accountEmail)
+        rightSideMenu.waitForExistence()
+        rightSideMenu.logOut()
+        sleep(2)
+        loginPage.waitForExistence()
+    }
+
+    /// S7: while offline, opening an image shows the offline card and tapping it
+    /// does not start a load — the card stays until connectivity returns.
+    func testImagePreviewOfflineStateBlocksLoading() throws {
+        let accountEmail = uiTestCredentials.username
+        let accountPassword = uiTestCredentials.password
+
+        let loginPage = LoginPage(app: app, testCase: self)
+        loginPage.login(username: accountEmail, password: accountPassword)
+
+        let privateFilesPage = PrivateFilesPage(app: app, testCase: self)
+        privateFilesPage.waitForExistence()
+
+        let folderName = "aaa_state_\(UUID().uuidString.prefix(6))"
+        privateFilesPage.createNewFolder(name: folderName)
+        privateFilesPage.enterFolder(named: folderName)
+
+        privateFilesPage.enterPhotoLibrary()
+
+        let photoLibraryPage = PhotoLibraryPage(app: app, testCase: self)
+        photoLibraryPage.waitForExistence()
+        photoLibraryPage.uploadFirstPhoto()
+
+        privateFilesPage.processUpload()
+        privateFilesPage.tapFirstFileCell()
+
+        let previewPage = FilePreviewPage(app: app)
+        previewPage.waitForExistence()
+
+        // --forceOffline makes the viewer treat the device as offline → S7.
+        // (Real network stays up, so login/upload above and cleanup below still work.)
+        previewPage.waitForOfflineState()
+
+        // Tapping while offline must not start a load — the offline card stays.
+        previewPage.tapRetry()
+        sleep(2)
+        previewPage.waitForOfflineState()
+
+        previewPage.close()
+        privateFilesPage.waitForExistence()
+
+        privateFilesPage.deleteFirstElementFromFolder()
+        privateFilesPage.emptyFolderTest()
+        privateFilesPage.goBack()
+        privateFilesPage.deleteElement(named: folderName)
+
+        privateFilesPage.toggleRightSideMenu()
+        let rightSideMenu = RightSideMenuPage(app: app, testCase: self, accountEmail: accountEmail)
+        rightSideMenu.waitForExistence()
+        rightSideMenu.logOut()
+        sleep(2)
+        loginPage.waitForExistence()
+    }
+}

--- a/PermanentUITests/Pages/FilePreviewPage.swift
+++ b/PermanentUITests/Pages/FilePreviewPage.swift
@@ -20,6 +20,12 @@ class FilePreviewPage {
     var shareButton: XCUIElement {
         app.buttons["filePreviewShareButton"]
     }
+    var stateOverlay: XCUIElement {
+        app.otherElements["imagePreviewStateOverlay"]
+    }
+    var stateMessage: XCUIElement {
+        app.staticTexts["imagePreviewStateMessage"]
+    }
 
     init(app: XCUIApplication) {
         self.app = app
@@ -42,5 +48,33 @@ class FilePreviewPage {
         XCTAssertTrue(closeButton.waitForExistence(timeout: 10))
         closeButton.tap()
         sleep(2)
+    }
+
+    // MARK: - Image preview states (VSP-1768)
+
+    /// Waits for the S6 "load failed" card.
+    func waitForLoadFailedState() {
+        XCTAssertTrue(stateMessage.waitForExistence(timeout: 15))
+        XCTAssertTrue(stateMessage.label.contains("Couldn't load image."))
+    }
+
+    /// Waits for the S7 offline card.
+    func waitForOfflineState() {
+        XCTAssertTrue(stateMessage.waitForExistence(timeout: 15))
+        XCTAssertTrue(stateMessage.label.contains("You're offline."))
+    }
+
+    /// Taps the overlay, which triggers the retry action.
+    func tapRetry() {
+        XCTAssertTrue(stateOverlay.waitForExistence(timeout: 5))
+        stateOverlay.tap()
+    }
+
+    /// Waits until the loading/error overlay is gone — the image rendered fully (S4).
+    func waitForImageLoaded(timeout: TimeInterval = 20) {
+        let gone = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: gone, object: stateMessage)
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: timeout), .completed,
+                       "Expected the state overlay message to disappear once the full image loaded")
     }
 }


### PR DESCRIPTION
Both VSP-1768, VSP-1753 tickets were implemented: Branded loading, failure & offline states for all preview types.