### PR TITLE
Fix crash from force-unwrapping the implicitly-unwrapped `account`

### DIFF
--- a/Permanent/Common/Files/ViewModel/FilesViewModel.swift
+++ b/Permanent/Common/Files/ViewModel/FilesViewModel.swift
@@ -156,7 +156,7 @@ class FilesViewModel: NSObject, ViewModelInterface {
     }
     
     func showMemberChecklist(_ completionBlock: @escaping ((Bool?) -> Void)) {
-        guard let accountId: Int = PermSession.currentSession?.account.accountID else {
+        guard let accountId: Int = PermSession.currentSession?.account?.accountID else {
             completionBlock(nil)
             return
         }

--- a/Permanent/Common/Managers/Upload/UploadManager.swift
+++ b/Permanent/Common/Managers/Upload/UploadManager.swift
@@ -189,7 +189,7 @@ class UploadManager {
         logger.debug("Preparing to upload \(files.count, privacy: .public) files with total size: \(filesSize, privacy: .public) bytes")
 
         // Call AccountAPI and figure if there's enough space left
-        guard let accountId: Int = PermSession.currentSession?.account.accountID else {
+        guard let accountId: Int = PermSession.currentSession?.account?.accountID else {
             logger.error("🔼 No active session found")
             DispatchQueue.main.async { completion?(false) }
             return
@@ -308,7 +308,7 @@ class UploadManager {
         // upload User A's files into User B's archive (the server might
         // accept the call with the new bearer token but the folderLinkId
         // belongs to User A).
-        if let currentAccountId = PermSession.currentSession?.account.accountID {
+        if let currentAccountId = PermSession.currentSession?.account?.accountID {
             let ownerKey = Constants.Keys.StorageKeys.uploadQueueOwnerAccountIdKey
             if let ownerAccountId = UserDefaults.standard.object(forKey: ownerKey) as? Int,
                ownerAccountId != currentAccountId,

--- a/Permanent/Modules/Archives/ViewModel/ArchivesViewModel.swift
+++ b/Permanent/Modules/Archives/ViewModel/ArchivesViewModel.swift
@@ -26,7 +26,7 @@ class ArchivesViewModel: ViewModelInterface {
     }
     
     func getAccountInfo(_ completionBlock: @escaping ((AccountVOData?, Error?) -> Void)) {
-        guard let accountId: Int = PermSession.currentSession?.account.accountID else {
+        guard let accountId: Int = PermSession.currentSession?.account?.accountID else {
             completionBlock(nil, APIError.unknown)
             return
         }
@@ -99,7 +99,7 @@ class ArchivesViewModel: ViewModelInterface {
     }
     
     func getAccountArchives(_ completionBlock: @escaping (([ArchiveVO]?, Error?) -> Void) ) {
-        guard let accountId: Int = PermSession.currentSession?.account.accountID else {
+        guard let accountId: Int = PermSession.currentSession?.account?.accountID else {
             completionBlock(nil, APIError.unknown)
             return
         }

--- a/Permanent/Modules/LegacyPlanning/Views/Banner/BannerType.swift
+++ b/Permanent/Modules/LegacyPlanning/Views/Banner/BannerType.swift
@@ -46,7 +46,7 @@ extension BannerType {
 extension BannerType {
     
     func getKey() -> String? {
-        guard let accountId: Int = PermSession.currentSession?.account.accountID else {
+        guard let accountId: Int = PermSession.currentSession?.account?.accountID else {
             return nil
         }
         return "\(self.rawValue).\(accountId)"

--- a/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareArchivesFromPastSharesViewModel.swift
+++ b/Permanent/Modules/Shares/SwiftUIViews/ViewModels/ShareArchivesFromPastSharesViewModel.swift
@@ -76,7 +76,7 @@ final class ShareArchivesFromPastSharesViewModel: ObservableObject {
     }
 
     func fetchArchives(completion: (() -> Void)? = nil) {
-        guard let accountId = PermSession.currentSession?.account.accountID,
+        guard let accountId = PermSession.currentSession?.account?.accountID,
               let archiveId = AuthenticationManager.shared.session?.selectedArchive?.archiveID else {
             completion?()
             return


### PR DESCRIPTION
PermSession.account is declared `var account: AccountVOData!` (an implicitly-unwrapped optional), so `currentSession?.account.accountID` guards the session but still force-unwraps `account` — crashing whenever a session exists with a nil account. UploadManager.refreshQueue() hit this on its 30-second timer against a partial session (surfaced as a fatal error in the unit-test run at UploadManager.swift:311).