### PR TITLE
VSP-1789: route Copy through the idempotent Stela V2 copies endpoint

### DIFF
--- a/Permanent/App/AppDelegate.swift
+++ b/Permanent/App/AppDelegate.swift
@@ -424,6 +424,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #if STAGING_ENVIRONMENT
             // Staging: verbose logging incl. capped request/response bodies.
             NetworkLogger.enableLogging()
+        #elseif DEBUG
+            // TEMP(VSP-1770 · Stela migration): verbose logging for DEBUG builds that point
+            // at PRODUCTION, so a prod-scheme Xcode run shows whether a call went V1 or V2
+            // while the migration is being verified. Deliberately DEBUG-only: Release
+            // (TestFlight / App Store) still takes the errors-only branch below, so real
+            // users never pay the body-stringify cost and no user data reaches their logs.
+            // REMOVE this branch once the epic ships — grep TEMP(VSP-1770).
+            NetworkLogger.enableLogging()
         #else
             // Production: errors only, never bodies — the previous enableLogging() here
             // stringified every full response body on the main thread in App Store builds.

--- a/Permanent/Common/Base/UIKitViews/FABView.swift
+++ b/Permanent/Common/Base/UIKitViews/FABView.swift
@@ -14,6 +14,16 @@ class FABView: UIView {
     fileprivate var arrowView: UIImageView!
     
     weak var delegate: FABViewDelegate?
+
+    /// True while `setVisibility(hidden: false)`'s slide-in is in flight, so a repeat call
+    /// (e.g. the next `updateFABViewVisibility()` when a folder fetch lands) leaves the
+    /// running animation alone instead of cutting it short. Exposed for tests.
+    private(set) var isAnimatingIn = false
+
+    /// The throwaway snapshot currently sliding out (see `setVisibility`), kept only so a
+    /// show that interrupts the exit can remove it.
+    private weak var exitSnapshot: UIView?
+
     var showsChecklistButton: Bool = false {
         didSet {
             checklistImageView.isHidden = !showsChecklistButton
@@ -164,8 +174,88 @@ class FABView: UIView {
         memberChecklistBanner.layer.shadowOffset = CGSize(width: -2, height: 0)
     }
     
+    // MARK: - Visibility
+
+    /// Single entry point for showing/hiding the FAB (plus button + checklist sub-button).
+    ///
+    /// Showing SLIDES the buttons up from below the screen edge, which is how they read as
+    /// arriving from the bottom-right corner they live in. This matters now that the FAB is
+    /// genuinely hidden while the user picks a copy/move paste destination: before that it
+    /// stayed on screen throughout, so there was no transition at all and every show path was
+    /// a bare `isHidden = false`.
+    ///
+    /// Hiding is immediate and resets `transform`, so an interrupted slide can never leave the
+    /// FAB parked off-screen. `isHidden` is assigned synchronously in every branch, so callers
+    /// (and tests) can read it back straight after the call.
+    func setVisibility(hidden: Bool, animated: Bool = true) {
+        if hidden {
+            isAnimatingIn = false
+            guard !isHidden else { return }
+
+            // `isHidden` is set IMMEDIATELY — callers (and tests) treat it as the synchronous
+            // source of truth, and a hidden view can't animate anyway. To still show motion on
+            // the way out, slide a throwaway snapshot down past the bottom edge. That keeps the
+            // exit symmetrical with the slide-in without deferring `isHidden` behind an
+            // animation, which would have made every reader stale for a quarter second.
+            if animated, let superview = superview, let snapshot = snapshotView(afterScreenUpdates: false) {
+                snapshot.frame = frame
+                superview.addSubview(snapshot)
+                exitSnapshot = snapshot
+                let slide = offscreenSlideDistance
+                UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseIn], animations: {
+                    snapshot.transform = CGAffineTransform(translationX: 0, y: slide)
+                }, completion: { _ in
+                    snapshot.removeFromSuperview()
+                })
+            }
+
+            isHidden = true
+            transform = .identity
+            return
+        }
+
+        // Coming back while the exit snapshot is still sliding: drop it, or two FABs are
+        // briefly on screen moving in opposite directions.
+        exitSnapshot?.removeFromSuperview()
+        exitSnapshot = nil
+
+        // A slide is already running: let it finish untouched. This branch is load-bearing —
+        // `updateFABViewVisibility()` fires again a few hundred ms later when the post-paste
+        // folder refetch lands, and re-asserting the transform there cut the animation short,
+        // which is why the buttons appeared to snap into place.
+        if isAnimatingIn { return }
+
+        guard isHidden else {
+            transform = .identity // already on screen; nothing to animate
+            return
+        }
+
+        guard animated else {
+            isHidden = false
+            transform = .identity
+            return
+        }
+
+        isAnimatingIn = true
+        transform = CGAffineTransform(translationX: 0, y: offscreenSlideDistance)
+        isHidden = false
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseOut, .beginFromCurrentState]) {
+            self.transform = .identity
+        } completion: { [weak self] _ in
+            self?.isAnimatingIn = false
+        }
+    }
+
+    /// How far down to park the FAB so it starts fully below its container's bottom edge.
+    /// Falls back to the view's own height when it has no superview (e.g. in unit tests),
+    /// which keeps the maths harmless rather than producing a wild offset.
+    private var offscreenSlideDistance: CGFloat {
+        guard let superview = superview else { return bounds.height }
+        return max(superview.bounds.maxY - frame.minY, bounds.height)
+    }
+
     // MARK: - Actions
-    
+
     @objc
     func fabAction() {
         delegate?.didTap()

--- a/Permanent/Common/Constants/Constants.swift
+++ b/Permanent/Common/Constants/Constants.swift
@@ -22,10 +22,13 @@ enum FeatureFlags {
     /// every screen) and the upload dedupe listing. V1 remains an automatic failsafe on
     /// every gated path except publish (owned-records-only by gate), so OFF is always
     /// safe. Changing it requires an app release (no Remote Config).
-    // Enabled for DEBUG/dev builds (staging via Permanent-DEV) so the Stela V2 path is exercised
-    // there; production/Release stays on V1 until the release `let` is flipped for rollout.
+    // ON only for Debug builds that ALSO point at STAGING (Permanent-DEV scheme), so the
+    // V2 path is exercised there. Gating on DEBUG alone was not enough: running the
+    // production scheme from Xcode is still a Debug build, which silently sent V2 calls
+    // against the PROD API — prod must stay on the legacy endpoints (in every build)
+    // until the rollout flips the Release `let`. Tests may still set the var directly.
     #if DEBUG
-    static var useStelaNavigation = true
+    static var useStelaNavigation = APIEnvironment.defaultEnv == .staging
     #else
     static let useStelaNavigation = false
     #endif

--- a/Permanent/Common/Files/ViewModel/FilesViewModel.swift
+++ b/Permanent/Common/Files/ViewModel/FilesViewModel.swift
@@ -258,6 +258,83 @@ class FilesViewModel: NSObject, ViewModelInterface {
     /// Empty array → no polling.
     static let thumbnailPollIntervals: [TimeInterval] = [3, 6, 12, 24]
 
+    /// Cadence of the post-paste/post-upload thumbnail poll (MainViewController.
+    /// scheduleNextThumbnailPoll). The server processes fresh copies SLOWLY — on staging
+    /// even the access-copy thumbnail can take minutes — so poll gently but persistently.
+    static let thumbnailPollInterval: TimeInterval = 10
+    /// Hard cap on consecutive polls (~5 minutes at 10s) so a folder whose records
+    /// legitimately never produce a thumbnail can't refetch forever.
+    static let thumbnailPollMaxRuns = 30
+
+    /// Cadence used while the pasted rows themselves are still MISSING. That's a
+    /// read-after-write race against the server's commit, which usually clears within a
+    /// second — polling it at `thumbnailPollInterval` made a pasted file take ~10s to show up.
+    static let pastedItemsPollInterval: TimeInterval = 1
+    /// How many polls stay on the fast cadence before falling back to the slow one, so a row
+    /// that never arrives doesn't hammer the server (5 × 1s ≈ 5s of quick re-checks).
+    static let pastedItemsFastRuns = 5
+
+    /// Cadence while an item is mid copy/move (`status` "copying"/"moving"). Those items are
+    /// not tappable until the server finishes, and a V1 folder copy takes tens of seconds —
+    /// staging-measured: the copied folder row appeared 9s after the request and only flipped
+    /// to "ok" 15s later. Polling that at `thumbnailPollInterval` left the folder
+    /// un-enterable long enough to look broken; polling it at `pastedItemsPollInterval` would
+    /// hammer the server for the whole copy.
+    static let transientStatePollInterval: TimeInterval = 2
+
+    /// True while any listed item is still being processed server-side: mid copy/move
+    /// (`thumbStatus` .copying/.moving), or a RECORD with no thumbnail source at all —
+    /// the fresh-Stela-copy shape (create-record-copy returns null thumbUrl* and its
+    /// access-copy 256 lands minutes later). Gates the thumbnail poll: while true the
+    /// folder keeps refetching every `thumbnailPollInterval`, bounded by
+    /// `thumbnailPollMaxRuns`; once everything settles the chain ends.
+    var hasItemsAwaitingProcessing: Bool {
+        hasItemsInTransientState || viewModels.contains { file in
+            !file.type.isFolder && (file.thumbnailURL ?? "").isEmpty
+        }
+    }
+
+    /// True while a listed item is mid copy/move server-side (`status` "copying"/"moving").
+    /// Such items are deliberately NOT tappable (`FileModel.canBeAccessed`), so this is a
+    /// wait the user is actively blocked on — and it clears in seconds to tens of seconds,
+    /// unlike the thumbnail wait, which takes minutes. Drives the middle poll cadence.
+    var hasItemsInTransientState: Bool {
+        viewModels.contains { $0.thumbStatus == .copying || $0.thumbStatus == .moving }
+    }
+
+    /// How many items the destination folder must list before a paste counts as landed, and
+    /// the folder that expectation belongs to. A relocate is committed ASYNCHRONOUSLY
+    /// server-side, so the refetch fired straight after it can still return the PRE-paste
+    /// listing. `hasItemsAwaitingProcessing` cannot detect that: it inspects the items that
+    /// ARE listed, and a MOVED record arrives with its thumbnails already in place — so for a
+    /// move the item count is the only signal that works. Keyed to the folder id, so
+    /// navigating elsewhere makes the expectation inert.
+    private(set) var expectedItemCount: Int?
+    private(set) var expectedItemCountFolderId: Int?
+
+    /// Records "this folder must reach `viewModels.count + pastedItems.count` items".
+    /// MUST be called BEFORE the post-paste refetch — the baseline is the pre-paste count.
+    func expectPastedItems(_ pastedItems: [FileModel], destination: FileModel) {
+        guard !pastedItems.isEmpty, destination.folderId == currentFolder?.folderId else {
+            clearPastedItemsExpectation()
+            return
+        }
+        expectedItemCount = viewModels.count + pastedItems.count
+        expectedItemCountFolderId = destination.folderId
+    }
+
+    func clearPastedItemsExpectation() {
+        expectedItemCount = nil
+        expectedItemCountFolderId = nil
+    }
+
+    /// True while the folder that received a paste still lists fewer items than expected.
+    var isAwaitingPastedItems: Bool {
+        guard let expected = expectedItemCount,
+              expectedItemCountFolderId == currentFolder?.folderId else { return false }
+        return viewModels.count < expected
+    }
+
     func updateTimerCount() {
         timerRunCount += 1
         if timerRunCount >= Self.thumbnailPollIntervals.count {
@@ -270,7 +347,24 @@ class FilesViewModel: NSObject, ViewModelInterface {
         if timer != nil {
             timer?.invalidate()
             timerRunCount = 0
+            clearPastedItemsExpectation() // a manual pull-to-refresh cancels the settle chain
         }
+    }
+
+    /// Injection seam for the single-record Stela V2 copy (VSP-1789), mirroring
+    /// `childrenFetchV2Request`. Tests pin the partition + aggregation policy without a
+    /// dispatcher by returning per-record success/failure. Production leaves it nil.
+    var copyRecordV2Request: ((_ recordId: String, _ destinationFolderId: String, _ completion: @escaping (Bool) -> Void) -> Void)?
+
+    /// A record is eligible for the idempotent Stela V2 copy (POST /records/{id}/copies)
+    /// only when the flag is on, it is a SAVED record (not a folder — there is no V2
+    /// folder-copy route), and it lives in the CURRENT archive. A foreign/shared record
+    /// would be rejected on the bearer-only V2 call, so it stays on V1 (same gate as
+    /// `FilePreviewViewModel.canPublishViaStelaCopy`). Internal so tests can pin it.
+    func isEligibleForStelaCopy(_ file: FileModel) -> Bool {
+        guard usesStelaNavigation, !file.type.isFolder, file.recordId > 0,
+              let currentArchiveId = currentArchive?.archiveID else { return false }
+        return file.archiveId > 0 && file.archiveId == currentArchiveId
     }
 
     func relocate(files: [FileModel]?, to destination: FileModel, then handler: @escaping ServerResponse) {
@@ -278,7 +372,102 @@ class FilesViewModel: NSObject, ViewModelInterface {
             handler(.error(message: "No files selected".localized()))
             return
         }
-        
+
+        // VSP-1789: the COPY action prefers the idempotent Stela V2 copy endpoint for
+        // own-archive records. The legacy V1 copy is NOT idempotent — a failed copy can
+        // orphan invisible files that keep consuming the member's storage. V2 copy has NO
+        // V1 failsafe (a mis-read success would silently duplicate the copy), so it is
+        // flag-SELECT per record: eligible records go V2, while folders and foreign
+        // records (no V2 route) stay on the V1 batch. MOVE is untouched.
+        //
+        // A non-positive destination folderId (e.g. a degenerate getPublicRoot result whose
+        // folderVO carries a nil folderID) is NOT a valid V2 target — since copy has no V1
+        // failsafe, posting "-1" would just fail. Route the whole copy through V1 in that
+        // case, mirroring the `folderId > 0` guard on the FilePreview/FileDetails publish path.
+        if fileAction == .copy, destination.folderId > 0 {
+            let v2Records = files.filter { isEligibleForStelaCopy($0) }
+            if !v2Records.isEmpty {
+                let v1Rest = files.filter { !isEligibleForStelaCopy($0) }
+                copyViaStela(v2Records: v2Records, v1Rest: v1Rest, to: destination, then: handler)
+                return
+            }
+        }
+
+        performV1Relocate(files: files, to: destination, then: handler)
+    }
+
+    /// Copies `v2Records` one at a time through Stela V2 and `v1Rest` through the V1 batch,
+    /// aggregating into one `ServerResponse` (`.success` only if EVERY copy succeeded).
+    /// V2 copies run serially and best-effort — a single failure never aborts the rest, and
+    /// there is NO V2→V1 fallback (copy is not idempotent). Serial execution also avoids a
+    /// data race on `errors`. The caller refetches the destination afterwards, so a partial
+    /// success still reflects the true server state. Clears selection on the main thread.
+    private func copyViaStela(v2Records: [FileModel], v1Rest: [FileModel], to destination: FileModel, then handler: @escaping ServerResponse) {
+        let destinationFolderId = String(destination.folderId)
+        Task {
+            var errors: [String] = []
+
+            for record in v2Records {
+                let succeeded: Bool = await withCheckedContinuation { continuation in
+                    self.copyRecordViaStelaV2(recordId: String(record.recordId), destinationFolderId: destinationFolderId) {
+                        continuation.resume(returning: $0)
+                    }
+                }
+                if !succeeded { errors.append("Unknown error") }
+            }
+
+            if !v1Rest.isEmpty {
+                let v1Error: String? = await withCheckedContinuation { continuation in
+                    self.performV1Relocate(files: v1Rest, to: destination) { status in
+                        if case .error(let message) = status {
+                            continuation.resume(returning: message ?? "Unknown error")
+                        } else {
+                            continuation.resume(returning: nil)
+                        }
+                    }
+                }
+                if let v1Error { errors.append(v1Error) }
+            }
+
+            await MainActor.run {
+                self.selectedFiles = []
+                self.fileAction = .none
+                handler(errors.isEmpty ? .success : .error(message: errors.joined(separator: "\n")))
+            }
+        }
+    }
+
+    /// Single-record Stela V2 copy (POST /records/{id}/copies). Uses the injected seam in
+    /// tests; otherwise calls the endpoint. `true` iff the server returned JSON success.
+    private func copyRecordViaStelaV2(recordId: String, destinationFolderId: String, completion: @escaping (Bool) -> Void) {
+        if let injected = copyRecordV2Request {
+            injected(recordId, destinationFolderId, completion)
+            return
+        }
+        let apiOperation = APIOperation(RecordV2Endpoint.copyRecord(recordId: recordId, destinationFolderId: destinationFolderId))
+        apiOperation.execute(in: APIRequestDispatcher()) { result in
+            if case .json = result {
+                completion(true)
+            } else {
+                completion(false)
+            }
+        }
+    }
+
+    /// Injection seam for the V1 relocate batch (copy/move), so tests can exercise the
+    /// copy partition + move routing without a dispatcher. Production leaves it nil.
+    var relocateV1Request: ((_ files: [FileModel], _ destination: FileModel, _ completion: @escaping ServerResponse) -> Void)?
+
+    private func performV1Relocate(files: [FileModel], to destination: FileModel, then handler: @escaping ServerResponse) {
+        if let injected = relocateV1Request {
+            injected(files, destination) { [weak self] status in
+                self?.selectedFiles = []
+                self?.fileAction = .none
+                handler(status)
+            }
+            return
+        }
+
         let fileGroup = DispatchGroup()
         var errors: [String] = []
 
@@ -349,8 +538,15 @@ class FilesViewModel: NSObject, ViewModelInterface {
 
     func publish(files: [FileModel], then handler: @escaping ServerResponse) {
         fileAction = .copy
-        guard let archiveNbr = currentArchive?.archiveNbr else { return }
-        
+        guard let archiveNbr = currentArchive?.archiveNbr else {
+            // Always complete (and clear the copy state) so the caller's spinner is
+            // dismissed. A bare `return` here previously stranded MainViewController's
+            // spinner (it only hides it in the handler) with fileAction stuck at .copy.
+            fileAction = .none
+            handler(.error(message: .errorMessage))
+            return
+        }
+
         getPublicRoot(archiveNbr: archiveNbr, then: { status in
             switch status {
             case .success(let folder):

--- a/Permanent/Common/Models/Data/FolderV2Models.swift
+++ b/Permanent/Common/Models/Data/FolderV2Models.swift
@@ -178,16 +178,37 @@ struct FolderChildV2Data: Model {
     // Resolve the flat (record) field first, then the nested (folder) field.
     var resolvedParentFolderId: String? { parentFolderId ?? parentFolder?.id }
     var resolvedParentFolderLinkId: String? { parentFolderLinkId ?? parentFolder?.folderLinkId }
-    // `thumbnailUrls.256` is the Archivematica access-copy thumbnail — a tiny 48x48 that comes
-    // back BLANK for HEIC (its HEIC→JPEG thumbnail generation produces nothing). It must NOT be
-    // used as the 256 source, or the preview blurs a blank image into a white loading square for
-    // every HEIC. Only a real flat `thumbnail256` counts; otherwise callers fall through to the
-    // Permanent `.thumb.wNNN` renditions (resolvedThumb200/500/…).
+    // `thumbnailUrls.256` is the Archivematica access-copy thumbnail — small, and BLANK for
+    // HEIC (its HEIC→JPEG thumbnail generation produces nothing). It must NOT be preferred
+    // over the Permanent `.thumb.wNNN` renditions, and never used for HEIC (white square).
+    // But it IS a valid LAST resort for the list/grid slots (VSP-1566 lineage: use a 256
+    // thumb over nothing): a Stela COPY (POST /records/{id}/copies) currently gets NO
+    // `.thumb.wNNN` renditions at all (backend gap) — the access copy is the only
+    // thumbnail a fresh copy has, so without this fallback copies render as permanent
+    // placeholders. The 256 blur slot keeps flat `thumbnail256` only (preview behavior
+    // unchanged; a copy's preview blur comes through the 200 slot instead).
     var resolvedThumb256: String? { thumbnail256 }
-    var resolvedThumb200: String? { thumbUrl200 ?? thumbnailUrls?.url200 }
-    var resolvedThumb500: String? { thumbUrl500 ?? thumbnailUrls?.url500 }
+    var resolvedThumb200: String? { thumbUrl200 ?? thumbnailUrls?.url200 ?? accessCopyThumb256 }
+    var resolvedThumb500: String? { thumbUrl500 ?? thumbnailUrls?.url500 ?? accessCopyThumb256 }
     var resolvedThumb1000: String? { thumbUrl1000 ?? thumbnailUrls?.url1000 }
     var resolvedThumb2000: String? { thumbUrl2000 ?? thumbnailUrls?.url2000 }
+
+    /// The Archivematica access-copy thumbnail, HEIC-guarded: nil for HEIC originals
+    /// (their access copies are blank — the July white-square bug), the real small
+    /// thumbnail for everything else.
+    private var accessCopyThumb256: String? {
+        guard !isHEICOriginal, let url = thumbnailUrls?.url256, !url.isEmpty else { return nil }
+        return url
+    }
+
+    /// True when the ORIGINAL file is HEIC/HEIF — detected from `files[]` (the original's
+    /// granular `type`), with the upload/download filename extension as fallback for
+    /// listings that omit `files`.
+    var isHEICOriginal: Bool {
+        if files?.originalFileIsHEIC == true { return true }
+        let name = (uploadFileName ?? downloadName ?? "").lowercased()
+        return name.hasSuffix(".heic") || name.hasSuffix(".heif")
+    }
 
     /// Returns the best available thumbnail URL (flat for records, nested for folders)
     var bestThumbnailURL: String? {
@@ -228,6 +249,20 @@ struct FileV2Data: Model {
     let format: String?
     let fileUrl: String?
     let downloadUrl: String?
+}
+
+extension Array where Element == FileV2Data {
+    /// True when the ORIGINAL upload (format `file.format.original`) is HEIC/HEIF — the
+    /// type whose Archivematica access-copy thumbnail comes back blank. Used to exclude
+    /// `thumbnailUrls.256` from the thumbnail fallbacks for those files only (see
+    /// FolderChildV2Data.resolvedThumb200 / RecordV2Data.preferredThumbnailURL).
+    var originalFileIsHEIC: Bool {
+        contains { file in
+            guard (file.format ?? "").contains("original") else { return false }
+            let type = (file.type ?? "").lowercased()
+            return type.contains("heic") || type.contains("heif")
+        }
+    }
 }
 
 struct PaginationV2: Model {

--- a/Permanent/Common/Models/Data/RecordV2Models.swift
+++ b/Permanent/Common/Models/Data/RecordV2Models.swift
@@ -69,7 +69,25 @@ extension RecordV2Data {
     }
 
     var preferredThumbnailURL: String? {
-        resolvedThumbnail256 ?? nonEmpty(thumbUrl500) ?? nonEmpty(thumbUrl200) ?? nonEmpty(thumbUrl1000) ?? nonEmpty(thumbUrl2000)
+        // Access copy LAST: a Stela copy (POST /records/{id}/copies) gets no `.thumb.wNNN`
+        // renditions (backend gap), so the HEIC-guarded access-copy thumbnail is the only
+        // one it has. Real renditions always win when present.
+        resolvedThumbnail256 ?? nonEmpty(thumbUrl500) ?? nonEmpty(thumbUrl200) ?? nonEmpty(thumbUrl1000) ?? nonEmpty(thumbUrl2000) ?? accessCopyThumb256
+    }
+
+    /// The Archivematica access-copy thumbnail, HEIC-guarded (blank for HEIC originals).
+    /// Mirrors FolderChildV2Data.accessCopyThumb256.
+    private var accessCopyThumb256: String? {
+        guard !isHEICOriginal, let url = nonEmpty(thumbnailUrls?.url256) else { return nil }
+        return url
+    }
+
+    /// True when the ORIGINAL file is HEIC/HEIF — `files[]` granular type first, filename
+    /// extension fallback. Mirrors FolderChildV2Data.isHEICOriginal.
+    var isHEICOriginal: Bool {
+        if files?.originalFileIsHEIC == true { return true }
+        let name = (uploadFileName ?? downloadName ?? "").lowercased()
+        return name.hasSuffix(".heic") || name.hasSuffix(".heif")
     }
 }
 

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -102,10 +102,10 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
                     
                     if let queueUploadCount = self?.viewModel?.queueItemsForCurrentFolder.count,
                         queueUploadCount == 0 {
-                        // Kick the exponential-backoff thumbnail poll chain.
-                        // Server-side thumbnail processing typically completes
-                        // within ~45 s; we re-fetch the folder at 3 / 6 / 12 / 24
-                        // s offsets to surface thumbURL fields as they land.
+                        // Kick the thumbnail poll chain: refetch the folder every 10s
+                        // until the new upload's server-side thumbnails land (the chain
+                        // stops on its own once the items settle — see
+                        // scheduleNextThumbnailPoll).
                         self?.viewModel?.timerRunCount = 0
                         self?.scheduleNextThumbnailPoll()
                     }
@@ -332,7 +332,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
             return
         }
 
-        fabView.isHidden = true
+        fabView.setVisibility(hidden: true)
 
         guard floatingActionIsland == nil else { return }
 
@@ -400,7 +400,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         }
         rightItems.append(FloatingActionImageItem(image: closeImage) { [weak self] vc, item in
             self?.dismissFloatingActionIsland()
-            self?.fabView.isHidden = false
+            self?.fabView.setVisibility(hidden: false)
 
             self?.viewModel?.selectedFiles = []
             self?.viewModel?.fileAction = .none
@@ -432,12 +432,19 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     func updateFABViewVisibility() {
         // Update FAB view visibility based on current archive permissions
         guard let viewModel = viewModel else { return }
-        
+
         let hasCreatePermission = viewModel.archivePermissions.contains(.create)
         let hasUploadPermission = viewModel.archivePermissions.contains(.upload)
+        // Hide the create/upload FAB (and its checklist sub-button) while picking a copy/move
+        // destination — you're choosing where to paste, not adding new files here. Otherwise
+        // the FAB reappears on every navigation during paste mode.
         let shouldShowFAB = hasCreatePermission && hasUploadPermission && !viewModel.isPickingImage
-        
-        fabView.isHidden = !shouldShowFAB
+            && !viewModel.isSelectingDestination
+
+        // setVisibility fades the buttons back in (see FABView). Hiding them for paste mode
+        // created a real hide→show transition that previously never happened — the FAB used
+        // to stay on screen throughout, so an instant reveal now reads as a pop-in.
+        fabView.setVisibility(hidden: !shouldShowFAB)
     }
     
     func resetCollectionViewState() {
@@ -483,8 +490,8 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
                 self?.dismissFloatingActionIsland({ [weak self] in
                     self?.viewModel?.fileAction = FileAction.copy
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .copy)
-                    
-                    self?.fabView.isHidden = false
+
+                    // FAB stays hidden in paste-destination mode (see updateFABViewVisibility).
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -500,12 +507,12 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
                     self?.viewModel?.fileAction = FileAction.move
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .move)
 
-                    self?.fabView.isHidden = false
+                    // FAB stays hidden in paste-destination mode (see updateFABViewVisibility).
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
                     }
-                    
+
                     self?.viewModel?.isSelecting = false
                     self?.setupBottomActionSheet()
                 })
@@ -625,7 +632,10 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     @objc
     private func selectButtonWasPressed(_ sender: UIButton) {
         guard let viewModel = viewModel else { return }
-        fabView.isHidden = true
+        // Can't (re)enter multi-select while choosing a paste destination — that mode owns
+        // the fixed relocate selection. Belt-and-suspenders with hiding the button below.
+        guard !viewModel.isSelectingDestination else { return }
+        fabView.setVisibility(hidden: true)
         if !backButton.isHidden {
             backButton.isUserInteractionEnabled = false
             backButton.layer.opacity = 0.3
@@ -648,7 +658,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     
     @objc
     private func clearButtonWasPressed(_ sender: UIButton) {
-        fabView.isHidden = false
+        fabView.setVisibility(hidden: false)
         if !backButton.isHidden {
             backButton.isUserInteractionEnabled = true
             backButton.layer.opacity = 1
@@ -980,7 +990,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
                 DispatchQueue.main.async {
                     self.showErrorAlert(message: .deleteError) {
                         self.refreshCurrentFolder()
-                        self.fabView.isHidden = false
+                        self.fabView.setVisibility(hidden: false)
                     }
                 }
             }
@@ -1018,33 +1028,80 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         if !isInvalidDestination || viewModel?.fileAction != .move {
             floatingActionIsland?.showActivityIndicator()
             viewModel?.relocate(files: files, to: destination, then: { status in
-                self.floatingActionIsland?.hideActivityIndicator()
-                
                 switch status {
                 case .success:
                     // Refetch instead of inserting the SOURCE models: a copy creates a
                     // NEW record server-side, so the inserted row would carry the
                     // ORIGINAL's ids — deleting/renaming "the copy" would hit the
                     // original record (data loss). A move can change link ids too.
-                    self.floatingActionIsland?.showDoneCheckmark() {
-                        self.dismissFloatingActionIsland({ [weak self] in
-                            self?.fabView?.isHidden = false
-                            self?.viewModel?.isSelectingDestination = false
+                    //
+                    // The paste is committed ASYNCHRONOUSLY, so the first refetch can come
+                    // back without the new rows. Keep the island's SPINNER up until they are
+                    // actually on screen and only then show the ✓ — flashing "done" over a
+                    // list that still looks unchanged reads as "nothing happened".
+                    self.viewModel?.expectPastedItems(files, destination: destination)
+                    self.settlePastedItems(attemptsLeft: MainViewController.pastedItemsSettleAttempts) { [weak self] in
+                        self?.floatingActionIsland?.hideActivityIndicator()
+                        self?.floatingActionIsland?.showDoneCheckmark() {
+                            self?.dismissFloatingActionIsland({ [weak self] in
+                                self?.fabView?.setVisibility(hidden: false)
+                                self?.viewModel?.isSelectingDestination = false
+                                // Fully exit selection mode: the single-file "⋯ → Copy" entry
+                                // keeps isSelecting on through the paste, and without this
+                                // reset the list re-renders with checkboxes after pasting.
+                                self?.viewModel?.isSelecting = false
 
-                            self?.refreshCurrentFolder(shouldDisplaySpinner: false)
-                        })
+                                // Hand any remaining wait (a copy's thumbnails, or rows that
+                                // still haven't surfaced) to the background poll.
+                                self?.viewModel?.timerRunCount = 0
+                                self?.scheduleNextThumbnailPoll()
+                            })
+                        }
                     }
 
                 case .error(_):
+                    self.floatingActionIsland?.hideActivityIndicator()
                     self.dismissFloatingActionIsland()
                     self.showErrorAlert(message: .relocateError) {
                         self.refreshCurrentFolder()
-                        self.fabView?.isHidden = false
+                        self.fabView?.setVisibility(hidden: false)
                         self.viewModel?.isSelectingDestination = false
                     }
                 }
             })
         }
+    }
+
+    /// How many times a successful paste re-fetches the destination, waiting for the pasted
+    /// rows to surface, before it gives up and completes anyway (the background poll keeps
+    /// looking). At `pastedItemsPollInterval` apiece this bounds the spinner to ~10s: record
+    /// copies land on the first attempt, but a V1 FOLDER copy is far slower — staging-measured
+    /// at 9s before its row even appeared, which a shorter ceiling gave up on, showing ✓ over
+    /// a destination that didn't contain the folder yet.
+    private static let pastedItemsSettleAttempts = 10
+
+    /// Refetches the destination folder until the rows a paste added are listed, then calls
+    /// `completion`. The server commits a relocate asynchronously, so attempt 1 often comes
+    /// back without them. Always completes — on success, on giving up, or if the user
+    /// navigated away (the expectation is keyed to its folder, so it reads as settled).
+    private func settlePastedItems(attemptsLeft: Int, then completion: @escaping () -> Void) {
+        refreshCurrentFolder(shouldDisplaySpinner: false, silenceErrors: true, then: { [weak self] in
+            guard let self = self, let viewModel = self.viewModel else {
+                completion()
+                return
+            }
+            guard viewModel.isAwaitingPastedItems, attemptsLeft > 0 else {
+                completion() // rows are on screen (or we've waited long enough)
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + FilesViewModel.pastedItemsPollInterval) { [weak self] in
+                guard let self = self else {
+                    completion()
+                    return
+                }
+                self.settlePastedItems(attemptsLeft: attemptsLeft - 1, then: completion)
+            }
+        })
     }
 
     func publish(file: FileModel) {
@@ -1124,9 +1181,24 @@ extension MainViewController: UICollectionViewDelegateFlowLayout, UICollectionVi
         guard let viewModel = viewModel else { return }
         
         let file = viewModel.fileForRowAt(indexPath: indexPath)
-        
+
         guard file.fileStatus == .synced && (file.thumbnailURL != nil || file.canBeAccessed) else { return }
-        
+
+        // While picking a copy/move destination the list is navigation-only: tap a folder to
+        // enter it (to choose where to paste). Items cannot be (re)selected here — the
+        // selection set is fixed to the items being relocated until the user pastes/cancels,
+        // so a tap only drills into an eligible folder and does nothing on anything else.
+        if viewModel.isSelectingDestination {
+            guard file.type.isFolder, !(viewModel.selectedFiles?.contains(file) ?? false) else { return }
+            viewModel.v2NavigationTarget = file
+            let navigateParams: NavigateMinParams = (file.archiveNo, file.folderLinkId, nil)
+            navigateToFolder(withParams: navigateParams, backNavigation: false, then: {
+                self.backButton.isHidden = false
+                self.directoryLabel.text = file.name
+            })
+            return
+        }
+
         if viewModel.isSelecting {
             if let index = viewModel.selectedFiles?.firstIndex(of: file) {
                 viewModel.selectedFiles?.remove(at: index)
@@ -1197,6 +1269,10 @@ extension MainViewController: UICollectionViewDelegateFlowLayout, UICollectionVi
                 headerView.leftButtonAction = nil
             }
             
+            // Reset the reused header's Select button to visible; a previous dequeue may
+            // have hidden it for a paste-destination section (see below).
+            headerView.rightButton.isHidden = false
+
             if viewModel?.hasCancelButton(forSection: section) == true {
                 headerView.rightButtonTitle = "Cancel All".localized()
                 headerView.rightButtonAction = { [weak self] header in self?.cancelAllUploadsAction(UIButton()) }
@@ -1206,7 +1282,11 @@ extension MainViewController: UICollectionViewDelegateFlowLayout, UICollectionVi
                 } else {
                     headerView.rightButtonTitle = (viewModel?.isSelectingDestination ?? false) ? nil : "Select".localized()
                 }
-                
+                // A title-less button still occupies a tappable area, so in paste-destination
+                // mode hide it outright — otherwise tapping where "Select" used to be silently
+                // re-enters multi-select and lets items be reselected instead of navigating.
+                headerView.rightButton.isHidden = viewModel?.isSelectingDestination ?? false
+
                 headerView.rightButtonAction = { [weak self] header in self?.selectButtonWasPressed(UIButton())}
                 headerView.clearButtonAction = { [weak self] header in self?.clearButtonWasPressed(UIButton())}
             }
@@ -1224,21 +1304,56 @@ extension MainViewController: UICollectionViewDelegateFlowLayout, UICollectionVi
     
     @objc
     private func timerActions() {
-        pullToRefreshAction()
-        viewModel?.updateTimerCount()
-        // If we still have steps in the backoff chain, schedule the next one.
-        scheduleNextThumbnailPoll()
+        // Re-arm only AFTER the refetch commits: the gate reads `viewModels`, so scheduling
+        // before the response lands tests the PREVIOUS generation of the list and can end the
+        // chain a poll early. Calls refreshCurrentFolder directly rather than
+        // pullToRefreshAction, whose invalidateTimer() exists so a MANUAL pull cancels the
+        // chain — a chain-driven refresh must not cancel itself.
+        refreshCurrentFolder(shouldDisplaySpinner: false, silenceErrors: true, then: { [weak self] in
+            self?.scheduleNextThumbnailPoll()
+        })
     }
 
-    /// Schedules the next thumbnail-poll fire using the backoff interval at
-    /// `timerRunCount`. No-op once the chain is exhausted (the previous
-    /// `updateTimerCount` call already invalidated the timer in that case).
+    /// Polls the current folder every `thumbnailPollInterval` (10s — the server processes
+    /// pasted copies slowly; staging thumbnails can take minutes) while any listed item is
+    /// still awaiting server-side processing. The chain stops on its own when the folder
+    /// settles or the run cap (~5 min) is hit; navigation invalidates the pending fire,
+    /// and a manual pull-to-refresh cancels the chain via invalidateTimer.
     private func scheduleNextThumbnailPoll() {
         guard let viewModel = viewModel else { return }
-        let step = viewModel.timerRunCount
-        guard step < FilesViewModel.thumbnailPollIntervals.count else { return }
-        let interval = FilesViewModel.thumbnailPollIntervals[step]
+        guard viewModel.hasItemsAwaitingProcessing || viewModel.isAwaitingPastedItems else {
+            viewModel.timerRunCount = 0 // settled — leave the counter fresh for the next kick
+            viewModel.clearPastedItemsExpectation()
+            return
+        }
+        guard viewModel.timerRunCount < FilesViewModel.thumbnailPollMaxRuns else {
+            viewModel.clearPastedItemsExpectation() // gave up waiting; don't re-arm on the next kick
+            return
+        }
+        viewModel.timerRunCount += 1
+        // Three different waits, three cadences — matched to how long each actually takes:
+        //   • rows still MISSING: a read-after-write race against the server's commit,
+        //     usually gone in ~1s (bounded, so a row that never arrives stops hammering);
+        //   • item mid copy/move: not tappable until the server finishes, seconds to tens
+        //     of seconds for a folder copy;
+        //   • everything else: the thumbnail settle, which genuinely takes minutes.
+        let isRaceForMissingRows = viewModel.isAwaitingPastedItems
+            && viewModel.timerRunCount <= FilesViewModel.pastedItemsFastRuns
+        let interval: TimeInterval
+        if isRaceForMissingRows {
+            interval = FilesViewModel.pastedItemsPollInterval
+        } else if viewModel.hasItemsInTransientState {
+            interval = FilesViewModel.transientStatePollInterval
+        } else {
+            interval = FilesViewModel.thumbnailPollInterval
+        }
+        // Never stack chains: kill any pending fire before scheduling the next one.
+        viewModel.timer?.invalidate()
         viewModel.timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
+            // Clear BEFORE refetching: the fired timer must read as "no pending chain",
+            // or pullToRefreshAction→invalidateTimer would zero the run count on every
+            // fire and the chain could never terminate (confirmed review finding).
+            self?.viewModel?.timer = nil
             self?.timerActions()
         }
     }
@@ -1604,7 +1719,7 @@ extension MainViewController: FABActionSheetDelegate {
                             DispatchQueue.main.async {
                                 self?.showErrorAlert(message: .deleteError) {
                                     self?.refreshCurrentFolder()
-                                    self?.fabView.isHidden = false
+                                    self?.fabView.setVisibility(hidden: false)
                                 }
                             }
                         }
@@ -1651,7 +1766,7 @@ extension MainViewController: FABActionSheetDelegate {
                         self?.deleteFile(self?.viewModel?.selectedFiles)
                         
                         self?.dismissFloatingActionIsland()
-                        self?.fabView.isHidden = false
+                        self?.fabView.setVisibility(hidden: false)
                         self?.clearButtonWasPressed(UIButton())
                     }, positiveButtonColor: .brightRed,
                     cancelButtonColor: .primary,
@@ -1678,8 +1793,8 @@ extension MainViewController: FABActionSheetDelegate {
                 self?.dismissFloatingActionIsland({ [weak self] in
                     self?.viewModel?.fileAction = FileAction.move
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .move)
-                    
-                    self?.fabView.isHidden = false
+
+                    // FAB stays hidden in paste-destination mode (see updateFABViewVisibility).
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -1696,9 +1811,13 @@ extension MainViewController: FABActionSheetDelegate {
             menuItems.append(FileMenuViewModel.MenuItem(type: .copy, action: { [weak self] in
                 self?.dismissFloatingActionIsland({ [weak self] in
                     self?.viewModel?.fileAction = FileAction.copy
+                    // Leave selection mode BEFORE building the paste island (parity with
+                    // the Move item below) — otherwise checkboxes stay up through paste
+                    // mode and reappear after the paste completes.
+                    self?.viewModel?.isSelecting = false
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .copy)
-                    
-                    self?.fabView.isHidden = false
+
+                    // FAB stays hidden in paste-destination mode (see updateFABViewVisibility).
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -1736,7 +1855,7 @@ extension MainViewController: FABActionSheetDelegate {
                                 self?.viewModel?.removeSyncedFiles(files)
                                 self?.refreshCollectionView()
                                 self?.dismissFloatingActionIsland()
-                                self?.fabView.isHidden = false
+                                self?.fabView.setVisibility(hidden: false)
                                 self?.clearButtonWasPressed(UIButton())
                             }
 
@@ -1745,7 +1864,7 @@ extension MainViewController: FABActionSheetDelegate {
                                 self?.showErrorAlert(message: .deleteError) {
                                     self?.refreshCurrentFolder()
                                     self?.dismissFloatingActionIsland()
-                                    self?.fabView.isHidden = false
+                                    self?.fabView.setVisibility(hidden: false)
                                     self?.clearButtonWasPressed(UIButton())
                                 }
                             }
@@ -1890,7 +2009,7 @@ extension MainViewController: FABActionSheetDelegate {
         self.present(hostingController, animated: true, completion: nil)
         
         self.dismissFloatingActionIsland()
-        self.fabView.isHidden = false
+        self.fabView.setVisibility(hidden: false)
         self.clearButtonWasPressed(UIButton())
         
         // Add a way to call the completion block when the view is dismissed.

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -185,7 +185,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             }
 
             self.fileActionBottomView.isHidden = true
-            self.fabView.isHidden = true
+            self.fabView.setVisibility(hidden: true)
             self.backButton.isHidden = true
             self.directoryLabel.text = "Shares".localized()
             self.collectionView.setContentOffset(.zero, animated: false)
@@ -280,7 +280,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             return
         }
         
-        fabView.isHidden = true
+        fabView.setVisibility(hidden: true)
         
         guard floatingActionIsland == nil else { return }
         
@@ -319,8 +319,8 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         }
         rightItems.append(FloatingActionImageItem(image: closeImage) { [weak self] vc, item in
             self?.dismissFloatingActionIsland()
-            self?.fabView.isHidden = false
-            
+            self?.fabView.setVisibility(hidden: false)
+
             self?.viewModel?.selectedFiles = []
             self?.viewModel?.fileAction = .none
             self?.viewModel?.isSelectingDestination = false
@@ -353,7 +353,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self?.viewModel?.fileAction = FileAction.copy
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .copy)
                     
-                    self?.fabView.isHidden = false
+                    self?.fabView.setVisibility(hidden: false)
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -370,7 +370,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self?.viewModel?.fileAction = FileAction.move
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .move)
                     
-                    self?.fabView.isHidden = false
+                    self?.fabView.setVisibility(hidden: false)
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -418,14 +418,16 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             })
         })
 
-        if currentFolderPermissions?.contains(.create) == true && currentFolderPermissions?.contains(.upload) == true {
-            fabView.isHidden = false
-        } else {
-            fabView.isHidden = true
-        }
-        if !fileActionBottomView.isHidden {
-            fabView.isHidden = true
-        }
+        var shouldShowFAB = currentFolderPermissions?.contains(.create) == true
+            && currentFolderPermissions?.contains(.upload) == true
+        if !fileActionBottomView.isHidden { shouldShowFAB = false }
+        // Hide the create/upload FAB (and its checklist sub-button) while picking a copy/move
+        // destination — you're choosing where to paste, not adding new files here.
+        if viewModel?.isSelectingDestination == true { shouldShowFAB = false }
+
+        // setVisibility fades the buttons back in (see FABView) — hiding them for paste mode
+        // created a real hide→show transition that used to not exist.
+        fabView.setVisibility(hidden: !shouldShowFAB)
     }
 
     private func performChangeArchive(withArchiveId archiveId: Int, archiveNbr: String, completion: @escaping (Bool) -> Void) {
@@ -584,7 +586,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         
         self.directoryLabel.text = "Shares".localized()
         self.backButton.isHidden = true
-        self.fabView.isHidden = true
+        self.fabView.setVisibility(hidden: true)
         self.fileActionBottomView.isHidden = true
         
         viewModel?.shareListType = listType
@@ -651,7 +653,10 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
     @objc
     private func selectButtonWasPressed(_ sender: UIButton) {
         guard let viewModel = viewModel else { return }
-        fabView.isHidden = true
+        // Can't (re)enter multi-select while choosing a paste destination — that mode owns
+        // the fixed relocate selection. Belt-and-suspenders with hiding the button below.
+        guard !viewModel.isSelectingDestination else { return }
+        fabView.setVisibility(hidden: true)
         if !backButton.isHidden {
             backButton.isUserInteractionEnabled = false
             backButton.layer.opacity = 0.3
@@ -674,7 +679,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
     
     @objc
     private func clearButtonWasPressed(_ sender: UIButton) {
-        fabView.isHidden = false
+        fabView.setVisibility(hidden: false)
         if !backButton.isHidden {
             backButton.isUserInteractionEnabled = true
             backButton.layer.opacity = 1
@@ -954,7 +959,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                         self?.deleteFile(self?.viewModel?.selectedFiles)
                         
                         self?.dismissFloatingActionIsland()
-                        self?.fabView.isHidden = false
+                        self?.fabView.setVisibility(hidden: false)
                         self?.clearButtonWasPressed(UIButton())
                     }, positiveButtonColor: .brightRed,
                     cancelButtonColor: .primary,
@@ -969,7 +974,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self?.viewModel?.fileAction = FileAction.move
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .move)
                     
-                    self?.fabView.isHidden = false
+                    self?.fabView.setVisibility(hidden: false)
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -1012,7 +1017,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                                 self?.viewModel?.removeSyncedFiles(files)
                                 self?.refreshCollectionView()
                                 self?.dismissFloatingActionIsland()
-                                self?.fabView.isHidden = false
+                                self?.fabView.setVisibility(hidden: false)
                                 self?.clearButtonWasPressed(UIButton())
                             }
                             
@@ -1159,7 +1164,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
             showSpinner()
         }
         
-        fabView.isHidden = true
+        fabView.setVisibility(hidden: true)
 
         let runRequest: (@escaping ServerResponse) -> Void = getSharesRequest ?? { [weak self] handler in
             self?.viewModel?.getShares(then: handler)
@@ -1268,8 +1273,11 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     // original record (data loss). A move can change link ids too.
                     self.floatingActionIsland?.showDoneCheckmark() {
                         self.dismissFloatingActionIsland({ [weak self] in
-                            self?.fabView?.isHidden = false
+                            self?.fabView?.setVisibility(hidden: false)
                             self?.viewModel?.isSelectingDestination = false
+                            // Fully exit selection mode after the paste (parity with
+                            // MainViewController) — otherwise checkboxes can reappear.
+                            self?.viewModel?.isSelecting = false
 
                             self?.refreshCurrentFolder(shouldDisplaySpinner: false)
                         })
@@ -1565,9 +1573,23 @@ extension SharesViewController: UICollectionViewDelegateFlowLayout, UICollection
         guard let viewModel = viewModel else { return }
         
         let file = viewModel.fileForRowAt(indexPath: indexPath)
-        
+
         guard file.fileStatus == .synced && (file.thumbnailURL != nil || file.canBeAccessed) else { return }
-        
+
+        // Paste-destination mode is navigation-only (same rationale as MainViewController):
+        // tap a folder to drill into it; items can't be (re)selected while the relocate
+        // selection is fixed to the items being copied/moved.
+        if viewModel.isSelectingDestination {
+            guard file.type.isFolder, !(viewModel.selectedFiles?.contains(file) ?? false) else { return }
+            viewModel.v2NavigationTarget = file
+            let navigateParams: NavigateMinParams = (file.archiveNo, file.folderLinkId, nil)
+            navigateToFolder(withParams: navigateParams, backNavigation: false, then: {
+                self.backButton.isHidden = false
+                self.directoryLabel.text = file.name
+            })
+            return
+        }
+
         if viewModel.isSelecting {
             if let index = viewModel.selectedFiles?.firstIndex(of: file) {
                 viewModel.selectedFiles?.remove(at: index)
@@ -1576,7 +1598,7 @@ extension SharesViewController: UICollectionViewDelegateFlowLayout, UICollection
             }
             self.refreshCollectionView()
         } else {
-            
+
             if file.type.isFolder {
                 // Seed the V2 forward-nav target so Stela drill-in engages and its children
                 // inherit this folder's accessRole (see SharedFilesViewModel.v2ChildContext).
@@ -1616,6 +1638,10 @@ extension SharesViewController: UICollectionViewDelegateFlowLayout, UICollection
                 headerView.leftButtonAction = nil
             }
             
+            // Reset the reused header's Select button to visible; a previous dequeue may
+            // have hidden it for a paste-destination section (see below).
+            headerView.rightButton.isHidden = false
+
             if viewModel?.hasCancelButton(forSection: section) == true {
                 headerView.rightButtonTitle = "Cancel All".localized()
                 headerView.rightButtonAction = { [weak self] header in self?.cancelAllUploadsAction(UIButton()) }
@@ -1627,7 +1653,11 @@ extension SharesViewController: UICollectionViewDelegateFlowLayout, UICollection
                         headerView.rightButtonTitle = (viewModel?.isSelectingDestination ?? false) ? nil : "Select".localized()
                     }
                 }
-                
+                // A title-less button still occupies a tappable area, so in paste-destination
+                // mode hide it outright — otherwise tapping where "Select" used to be silently
+                // re-enters multi-select and lets items be reselected instead of navigating.
+                headerView.rightButton.isHidden = viewModel?.isSelectingDestination ?? false
+
                 headerView.rightButtonAction = { [weak self] header in self?.selectButtonWasPressed(UIButton()) }
                 headerView.clearButtonAction = { [weak self] header in self?.clearButtonWasPressed(UIButton())}
             }
@@ -1738,7 +1768,7 @@ extension SharesViewController: SharedFileActionSheetDelegate {
         self.present(hostingController, animated: true, completion: nil)
         
         self.dismissFloatingActionIsland()
-        self.fabView.isHidden = false
+        self.fabView.setVisibility(hidden: false)
         self.clearButtonWasPressed(UIButton())
         
         hostingController.rootView.dismissAction = { hasUpdates in
@@ -2003,6 +2033,6 @@ extension SharesViewController: UIDocumentPickerDelegate {
 extension SharesViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         // Show FAB buttons when menu is dismissed
-        fabView.isHidden = false
+        fabView.setVisibility(hidden: false)
     }
 }

--- a/PermanentTests/FilesViewModelTests.swift
+++ b/PermanentTests/FilesViewModelTests.swift
@@ -916,6 +916,533 @@ final class FilesViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
+    // MARK: - VSP-1789: Stela V2 copy routing (POST /records/{id}/copies)
+    // COPY routes own-archive records through the idempotent V2 endpoint (NO V1 failsafe —
+    // copy is not idempotent), while folders, foreign records, and MOVE stay on V1.
+
+    /// A saved record child in the current (mock) archive — the eligible shape for V2 copy.
+    /// Built via the V2 decode path (the convenience init discards its recordId, so identity
+    /// would be lost). Omitting `folderId` while carrying `recordId` keeps `isFolder` false.
+    private func makeV2Record(recordId: Int = 100, archiveId: Int = 1) -> FileModel {
+        let json = """
+        { "items": [ { "recordId": "\(recordId)", "archiveId": "\(archiveId)", "displayName": "r\(recordId)",
+          "type": "type.record.image", "status": "ok", "folderLinkId": "1" } ] }
+        """
+        return FileModel(model: decodeChildren(json)!.items![0], permissions: [.read], accessRole: .viewer)
+    }
+
+    /// Runs `body` with a session whose selected archive is the mock (archiveID 1) and the
+    /// Stela flag ON, restoring both afterwards.
+    private func withStelaSessionArchive(_ body: () -> Void) {
+        let previousSession = AuthenticationManager.shared.session
+        let session = PermSession(token: "test_token")
+        session.selectedArchive = ArchiveVOData.mock() // archiveID 1
+        AuthenticationManager.shared.session = session
+        FeatureFlags.useStelaNavigation = true
+        defer {
+            AuthenticationManager.shared.session = previousSession
+            FeatureFlags.useStelaNavigation = false
+        }
+        body()
+    }
+
+    func testIsEligibleForStelaCopy_Matrix() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            XCTAssertTrue(vm.isEligibleForStelaCopy(makeV2Record(recordId: 100, archiveId: 1)),
+                          "own-archive saved record with the flag on is eligible")
+            XCTAssertFalse(vm.isEligibleForStelaCopy(makeV2FolderTarget()),
+                           "folders have no V2 copy route")
+            XCTAssertFalse(vm.isEligibleForStelaCopy(makeV2Record(recordId: 100, archiveId: 999)),
+                           "a foreign-archive record would be rejected on the bearer-only V2 copy")
+            XCTAssertFalse(vm.isEligibleForStelaCopy(makeV2Record(recordId: 0, archiveId: 1)),
+                           "an unsaved record (recordId 0) is not eligible")
+        }
+    }
+
+    func testIsEligibleForStelaCopy_FlagOff_False() {
+        let previousSession = AuthenticationManager.shared.session
+        let session = PermSession(token: "test_token")
+        session.selectedArchive = ArchiveVOData.mock()
+        AuthenticationManager.shared.session = session
+        FeatureFlags.useStelaNavigation = false
+        defer { AuthenticationManager.shared.session = previousSession }
+
+        XCTAssertFalse(MyFilesViewModel().isEligibleForStelaCopy(makeV2Record()),
+                       "flag off keeps every record on V1")
+    }
+
+    func testIsEligibleForStelaCopy_BaseViewModelNeverStela() {
+        withStelaSessionArchive {
+            // Base FilesViewModel returns usesStelaNavigation == false regardless of the flag.
+            XCTAssertFalse(FilesViewModel().isEligibleForStelaCopy(makeV2Record()),
+                           "workspaces that never opt into Stela keep copy on V1")
+        }
+    }
+
+    func testRelocate_Copy_AllEligible_RoutesToV2AndSucceeds() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .copy
+            var copied: [(record: String, destination: String)] = []
+            vm.copyRecordV2Request = { recordId, destinationFolderId, completion in
+                copied.append((recordId, destinationFolderId))
+                completion(true)
+            }
+            vm.relocateV1Request = { _, _, _ in XCTFail("all files eligible → the V1 batch must not run") }
+
+            let files = [makeV2Record(recordId: 1, archiveId: 1), makeV2Record(recordId: 2, archiveId: 1)]
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: files, to: makeV2FolderTarget(folderId: 10)) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            XCTAssertEqual(status, .success)
+            XCTAssertEqual(copied.map { $0.record }, ["1", "2"], "each record copied via V2, serially in order")
+            XCTAssertEqual(Set(copied.map { $0.destination }), ["10"], "into the destination folderId")
+            XCTAssertEqual(vm.fileAction, .none, "the action resets after a copy")
+            XCTAssertTrue(vm.selectedFiles?.isEmpty ?? false, "the selection clears after a copy")
+        }
+    }
+
+    func testRelocate_Copy_V2Failure_ReportsErrorAndNeverFallsBackToV1() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .copy
+            var v1Called = false
+            vm.copyRecordV2Request = { _, _, completion in completion(false) }
+            vm.relocateV1Request = { _, _, completion in v1Called = true; completion(.success) }
+
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: [makeV2Record(recordId: 1, archiveId: 1)], to: makeV2FolderTarget()) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            if case .error = status {} else { XCTFail("a V2 copy failure must surface as an error") }
+            XCTAssertFalse(v1Called, "copy is not idempotent — a failed V2 copy must NOT retry on V1")
+        }
+    }
+
+    func testRelocate_Copy_Mixed_RecordViaV2_FolderViaV1_Aggregates() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .copy
+            var v2Records: [String] = []
+            var v1Files: [FileModel] = []
+            vm.copyRecordV2Request = { recordId, _, completion in v2Records.append(recordId); completion(true) }
+            vm.relocateV1Request = { files, _, completion in v1Files = files; completion(.success) }
+
+            let record = makeV2Record(recordId: 7, archiveId: 1)
+            let folder = makeV2FolderTarget(folderId: 20)
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: [record, folder], to: makeV2FolderTarget(folderId: 10)) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            XCTAssertEqual(status, .success)
+            XCTAssertEqual(v2Records, ["7"], "the record is copied via V2")
+            XCTAssertEqual(v1Files.map { $0.folderId }, [20], "the folder falls to the V1 batch (no V2 folder-copy route)")
+        }
+    }
+
+    func testRelocate_Copy_Mixed_V1FolderFails_FailsWholeCopy() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .copy
+            vm.copyRecordV2Request = { _, _, completion in completion(true) }
+            vm.relocateV1Request = { _, _, completion in completion(.error(message: "boom")) }
+
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: [makeV2Record(recordId: 7, archiveId: 1), makeV2FolderTarget(folderId: 20)],
+                        to: makeV2FolderTarget(folderId: 10)) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            if case .error = status {} else { XCTFail("a V1 batch failure must fail the aggregated copy") }
+        }
+    }
+
+    func testRelocate_Move_NeverUsesStelaV2() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .move
+            vm.copyRecordV2Request = { _, _, _ in XCTFail("MOVE must never touch the V2 copy endpoint") }
+            var v1Files: [FileModel] = []
+            vm.relocateV1Request = { files, _, completion in v1Files = files; completion(.success) }
+
+            let record = makeV2Record(recordId: 7, archiveId: 1) // eligible if it were a copy
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: [record], to: makeV2FolderTarget(folderId: 10)) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            XCTAssertEqual(status, .success)
+            XCTAssertEqual(v1Files.map { $0.recordId }, [7], "even an own-archive record moves via V1")
+        }
+    }
+
+    func testRelocate_Copy_MultipleRecords_FirstFails_RestStillAttempted_AggregatesError() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .copy
+            var attempted: [String] = []
+            vm.copyRecordV2Request = { recordId, _, completion in
+                attempted.append(recordId)
+                completion(recordId != "1") // the first record fails; the rest succeed
+            }
+            vm.relocateV1Request = { _, _, _ in XCTFail("all records eligible → the V1 batch must not run") }
+
+            let files = [makeV2Record(recordId: 1, archiveId: 1),
+                         makeV2Record(recordId: 2, archiveId: 1),
+                         makeV2Record(recordId: 3, archiveId: 1)]
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: files, to: makeV2FolderTarget(folderId: 10)) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            XCTAssertEqual(attempted, ["1", "2", "3"],
+                           "best-effort: a failed copy must NOT abort the remaining records")
+            if case .error = status {} else { XCTFail("any single failure makes the aggregate an error") }
+        }
+    }
+
+    func testRelocate_Copy_AllIneligible_RoutesToV1Only() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .copy
+            vm.copyRecordV2Request = { _, _, _ in XCTFail("no eligible records → V2 must not run") }
+            var v1Files: [FileModel] = []
+            vm.relocateV1Request = { files, _, completion in v1Files = files; completion(.success) }
+
+            let folders = [makeV2FolderTarget(folderId: 20), makeV2FolderTarget(folderId: 21)]
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: folders, to: makeV2FolderTarget(folderId: 10)) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            XCTAssertEqual(status, .success)
+            XCTAssertEqual(v1Files.map { $0.folderId }, [20, 21],
+                           "an all-folder copy under the flag still falls entirely to the V1 batch")
+        }
+    }
+
+    func testRelocate_Copy_Mixed_V2RecordFails_V1FolderSucceeds_FailsWholeCopy() {
+        withStelaSessionArchive {
+            let vm = MyFilesViewModel()
+            vm.fileAction = .copy
+            vm.copyRecordV2Request = { _, _, completion in completion(false) }
+            var v1Ran = false
+            vm.relocateV1Request = { _, _, completion in v1Ran = true; completion(.success) }
+
+            let exp = expectation(description: "completion")
+            var status: RequestStatus?
+            vm.relocate(files: [makeV2Record(recordId: 7, archiveId: 1), makeV2FolderTarget(folderId: 20)],
+                        to: makeV2FolderTarget(folderId: 10)) { status = $0; exp.fulfill() }
+            wait(for: [exp], timeout: 1.0)
+
+            if case .error = status {} else {
+                XCTFail("a failed V2 record must not be masked by a successful V1 folder batch")
+            }
+            XCTAssertTrue(v1Ran, "the V1 folder batch still runs alongside the failed V2 record")
+        }
+    }
+
+    // MARK: - VSP-1789: copy thumbnails — HEIC-guarded access-copy 256 as last resort
+    // A Stela copy gets NO .thumb.wNNN renditions (backend gap, staging-captured
+    // 2026-07-24): thumbUrl* all null; its ONLY thumb is the access-copy
+    // thumbnailUrls.256. Non-HEIC listings must fall back to it (else copies are
+    // permanent placeholders); HEIC must never use it (blank — white-square bug).
+
+    func testV2CopyShape_ListSlotsFallBackToAccessCopy256_NonHEIC() {
+        let json = """
+        { "items": [ { "recordId": "89647", "displayName": "frog", "type": "type.record.image",
+          "status": "status.generic.ok", "folderLinkId": "137782",
+          "uploadFileName": "a-long-frog-3840x2160-green-10125.jpg",
+          "thumbUrl200": null, "thumbUrl500": null,
+          "thumbnailUrls": { "256": "https://cdn.example/access-256.jpg", "200": null },
+          "files": [ { "fileId": "1", "type": "type.file.image.jpg", "format": "file.format.original" } ] } ] }
+        """
+        let child = decodeChildren(json)!.items![0]
+
+        XCTAssertFalse(child.isHEICOriginal)
+        XCTAssertEqual(child.resolvedThumb200, "https://cdn.example/access-256.jpg",
+                       "list slot: the access copy is the only thumb a fresh copy has")
+        XCTAssertEqual(child.resolvedThumb500, "https://cdn.example/access-256.jpg",
+                       "grid slot gets the same last resort")
+        XCTAssertNil(child.resolvedThumb256,
+                     "the 256/blur slot keeps flat thumbnail256 only — preview behavior unchanged")
+    }
+
+    func testV2CopyShape_HEICNeverUsesAccessCopy256() {
+        // files[] granular type is the primary signal…
+        let byType = """
+        { "items": [ { "recordId": "1", "displayName": "heic", "type": "type.record.image",
+          "status": "ok", "folderLinkId": "2",
+          "thumbnailUrls": { "256": "https://cdn.example/access-256.jpg" },
+          "files": [ { "fileId": "1", "type": "type.file.image.heic", "format": "file.format.original" } ] } ] }
+        """
+        let heicByType = decodeChildren(byType)!.items![0]
+        XCTAssertTrue(heicByType.isHEICOriginal)
+        XCTAssertNil(heicByType.resolvedThumb200, "a blank HEIC access copy must never be served")
+
+        // …and the filename extension is the fallback when files[] is absent.
+        let byName = """
+        { "items": [ { "recordId": "1", "displayName": "heic", "type": "type.record.image",
+          "status": "ok", "folderLinkId": "2", "uploadFileName": "IMG_0042.HEIC",
+          "thumbnailUrls": { "256": "https://cdn.example/access-256.jpg" } } ] }
+        """
+        let heicByName = decodeChildren(byName)!.items![0]
+        XCTAssertTrue(heicByName.isHEICOriginal)
+        XCTAssertNil(heicByName.resolvedThumb200)
+    }
+
+    func testV2NormalShape_RealRenditionsBeatAccessCopy256() {
+        let json = """
+        { "items": [ { "recordId": "1", "displayName": "photo", "type": "type.record.image",
+          "status": "ok", "folderLinkId": "2", "uploadFileName": "photo.jpg",
+          "thumbUrl200": "https://cdn.example/w200.jpg", "thumbUrl500": "https://cdn.example/w500.jpg",
+          "thumbnailUrls": { "256": "https://cdn.example/access-256.jpg" },
+          "files": [ { "fileId": "1", "type": "type.file.image.jpg", "format": "file.format.original" } ] } ] }
+        """
+        let child = decodeChildren(json)!.items![0]
+        XCTAssertEqual(child.resolvedThumb200, "https://cdn.example/w200.jpg",
+                       "real renditions keep priority — no quality change for normal uploads")
+        XCTAssertEqual(child.resolvedThumb500, "https://cdn.example/w500.jpg")
+    }
+
+    // MARK: - thumbnail poll gate (hasItemsAwaitingProcessing)
+    // Gates the 10s post-paste/upload folder poll: keep refetching while a record has
+    // no thumbnail source (the fresh-Stela-copy shape) or an item is mid copy/move;
+    // stop as soon as everything settles (bounded separately by thumbnailPollMaxRuns).
+
+    func testHasItemsAwaitingProcessing_FreshCopyWithoutThumb_True() {
+        let json = """
+        { "items": [ { "recordId": "89647", "displayName": "copy", "type": "type.record.image",
+          "status": "status.generic.ok", "folderLinkId": "1", "uploadFileName": "copy.heic" } ] }
+        """
+        let vm = FilesViewModel()
+        vm.viewModels = [FileModel(model: decodeChildren(json)!.items![0], permissions: [.read], accessRole: .viewer)]
+        XCTAssertTrue(vm.hasItemsAwaitingProcessing,
+                      "a record with no thumbnail source is still processing server-side")
+    }
+
+    func testHasItemsAwaitingProcessing_SettledRecordAndFolder_False() {
+        let json = """
+        { "items": [ { "recordId": "1", "displayName": "photo", "type": "type.record.image",
+          "status": "ok", "folderLinkId": "2", "thumbUrl200": "https://cdn.example/w200.jpg" },
+          { "folderId": "3", "displayName": "folder", "type": "private", "status": "ok", "folderLinkId": "4" } ] }
+        """
+        let vm = FilesViewModel()
+        vm.viewModels = decodeChildren(json)!.items!.map { FileModel(model: $0, permissions: [.read], accessRole: .viewer) }
+        XCTAssertFalse(vm.hasItemsAwaitingProcessing,
+                       "a thumbed record and a folder are settled — the poll must stop")
+    }
+
+    func testHasItemsAwaitingProcessing_CopyingStatus_True() {
+        let json = """
+        { "items": [ { "folderId": "5", "displayName": "busy", "type": "private",
+          "status": "copying", "folderLinkId": "6" } ] }
+        """
+        let vm = FilesViewModel()
+        vm.viewModels = [FileModel(model: decodeChildren(json)!.items![0], permissions: [.read], accessRole: .viewer)]
+        XCTAssertTrue(vm.hasItemsAwaitingProcessing, "mid copy/move items keep the poll alive")
+    }
+
+    // MARK: - post-paste settle expectation (isAwaitingPastedItems)
+    // A relocate commits asynchronously server-side, so the refetch right after a paste can
+    // still return the pre-paste listing. hasItemsAwaitingProcessing can't see that (a MOVED
+    // record arrives WITH its thumbnails), so the item count is the only usable signal.
+
+    private func makeVMInFolder(itemCount: Int) -> (MyFilesViewModel, FileModel) {
+        let vm = MyFilesViewModel()
+        let folder = makeV2FolderTarget(folderId: 10)
+        vm.navigationStack.append(folder)
+        vm.viewModels = (0..<itemCount).map { makeV2Record(recordId: $0 + 1, archiveId: 1) }
+        return (vm, folder)
+    }
+
+    func testIsAwaitingPastedItems_TrueUntilTheCountArrives() {
+        let (vm, folder) = makeVMInFolder(itemCount: 3)
+        vm.expectPastedItems([makeV2Record(recordId: 90), makeV2Record(recordId: 91)], destination: folder)
+
+        XCTAssertTrue(vm.isAwaitingPastedItems, "3 listed, 5 expected → still settling")
+
+        vm.viewModels.append(makeV2Record(recordId: 90))
+        XCTAssertTrue(vm.isAwaitingPastedItems, "4 of 5 → a partial refetch keeps polling")
+
+        vm.viewModels.append(makeV2Record(recordId: 91))
+        XCTAssertFalse(vm.isAwaitingPastedItems, "5 of 5 → landed, chain must stop")
+    }
+
+    func testIsAwaitingPastedItems_InertInADifferentFolder() {
+        let (vm, folder) = makeVMInFolder(itemCount: 1)
+        vm.expectPastedItems([makeV2Record(recordId: 90)], destination: folder)
+        XCTAssertTrue(vm.isAwaitingPastedItems)
+
+        vm.navigationStack.append(makeV2FolderTarget(folderId: 99)) // user navigates elsewhere
+        XCTAssertFalse(vm.isAwaitingPastedItems,
+                       "the expectation is keyed to its folder — it must not poll another folder")
+    }
+
+    func testExpectPastedItems_IgnoresEmptyPasteAndForeignDestination() {
+        let (vm, folder) = makeVMInFolder(itemCount: 2)
+
+        vm.expectPastedItems([], destination: folder)
+        XCTAssertFalse(vm.isAwaitingPastedItems, "nothing pasted → nothing to wait for")
+
+        vm.expectPastedItems([makeV2Record(recordId: 90)], destination: makeV2FolderTarget(folderId: 77))
+        XCTAssertFalse(vm.isAwaitingPastedItems, "destination isn't the folder on screen → no expectation")
+    }
+
+    func testInvalidateTimer_ClearsThePasteExpectation() {
+        let (vm, folder) = makeVMInFolder(itemCount: 1)
+        vm.expectPastedItems([makeV2Record(recordId: 90)], destination: folder)
+        vm.timer = Timer(timeInterval: 60, repeats: false) { _ in }
+
+        vm.invalidateTimer() // what a manual pull-to-refresh does
+
+        XCTAssertFalse(vm.isAwaitingPastedItems, "a manual pull cancels the chain and its expectation")
+        XCTAssertEqual(vm.timerRunCount, 0)
+    }
+
+    // MARK: - FAB slide-in contract (FABView.setVisibility)
+    // The FAB is hidden while picking a paste destination, which created a hide→show
+    // transition that never used to exist. It slides up from the bottom edge; a REPEAT show
+    // call (the post-paste folder refetch fires updateFABViewVisibility again a few hundred
+    // ms later) must not cut that animation short — that was the "snaps in" symptom.
+
+    /// FAB in a container, so `offscreenSlideDistance` has a superview to measure against.
+    private func makeHostedFAB() -> FABView {
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        let fab = FABView(frame: CGRect(x: 300, y: 700, width: 64, height: 64))
+        host.addSubview(fab)
+        return fab
+    }
+
+    func testFABSetVisibility_ShowFromHiddenSlidesUpFromBelow() {
+        let fab = makeHostedFAB()
+        fab.setVisibility(hidden: true)
+        XCTAssertTrue(fab.isHidden)
+        XCTAssertEqual(fab.transform, .identity, "hiding resets the transform so it can't be left off-screen")
+
+        fab.setVisibility(hidden: false)
+
+        XCTAssertFalse(fab.isHidden)
+        XCTAssertTrue(fab.isAnimatingIn, "showing from hidden animates")
+        XCTAssertGreaterThan(fab.layer.animation(forKey: "transform")?.duration ?? 0, 0,
+                             "the slide runs as a real transform animation")
+    }
+
+    func testFABSetVisibility_RepeatShowDoesNotRestartOrCutTheSlide() {
+        let fab = makeHostedFAB()
+        fab.setVisibility(hidden: true)
+        fab.setVisibility(hidden: false)
+        XCTAssertTrue(fab.isAnimatingIn)
+
+        fab.setVisibility(hidden: false) // what the post-paste refetch triggers
+
+        XCTAssertTrue(fab.isAnimatingIn, "a redundant show must leave the running slide alone")
+        XCTAssertFalse(fab.isHidden)
+    }
+
+    func testFABSetVisibility_HideStaysSynchronousWhileTheExitAnimates() {
+        let fab = makeHostedFAB()
+        fab.setVisibility(hidden: true)
+        fab.setVisibility(hidden: false)
+        XCTAssertTrue(fab.isAnimatingIn)
+
+        // `isHidden` flips at once even though the exit slides a snapshot away — several
+        // callers (and MainViewController/SharesViewController tests) read it immediately.
+        fab.setVisibility(hidden: true)
+        XCTAssertTrue(fab.isHidden)
+        XCTAssertFalse(fab.isAnimatingIn)
+        XCTAssertEqual(fab.transform, .identity, "the FAB itself is never left translated")
+    }
+
+    func testFABSetVisibility_RedundantHideIsANoOp() {
+        let fab = makeHostedFAB()
+        fab.setVisibility(hidden: true)
+        fab.setVisibility(hidden: true) // e.g. updateFABViewVisibility re-asserting paste mode
+        XCTAssertTrue(fab.isHidden)
+    }
+
+    func testFABSetVisibility_NotAnimatedShowsInstantly() {
+        let fab = makeHostedFAB()
+        fab.setVisibility(hidden: true)
+        fab.setVisibility(hidden: false, animated: false)
+        XCTAssertFalse(fab.isHidden)
+        XCTAssertFalse(fab.isAnimatingIn)
+        XCTAssertEqual(fab.transform, .identity, "no animation → lands in place immediately")
+    }
+
+    // MARK: - poll cadence constants
+    // Two different waits: missing rows are a server-commit race (fast), pending thumbnails
+    // are genuinely slow. Polling a missing row at the slow cadence made a pasted file take
+    // ~10s to appear.
+
+    func testPollCadence_FastForMissingRowsSlowForThumbnails() {
+        XCTAssertLessThan(FilesViewModel.pastedItemsPollInterval, FilesViewModel.thumbnailPollInterval,
+                          "a missing row must be re-checked faster than a pending thumbnail")
+        XCTAssertLessThan(FilesViewModel.pastedItemsFastRuns, FilesViewModel.thumbnailPollMaxRuns,
+                          "the fast phase is a bounded prefix of the chain, not the whole budget")
+    }
+
+    func testPollCadence_TransientStateSitsBetweenTheTwo() {
+        // A copying/moving item blocks tapping and clears in seconds-to-tens-of-seconds:
+        // faster than the thumbnail settle, gentler than the missing-row race.
+        XCTAssertGreaterThan(FilesViewModel.transientStatePollInterval, FilesViewModel.pastedItemsPollInterval)
+        XCTAssertLessThan(FilesViewModel.transientStatePollInterval, FilesViewModel.thumbnailPollInterval)
+    }
+
+    func testHasItemsInTransientState_DetectsCopyingFolderAndFeedsAwaitingProcessing() {
+        // The shape a freshly copied FOLDER arrives in (staging-captured): status "copying",
+        // which makes it non-tappable until the server flips it to "ok".
+        let json = """
+        { "items": [ { "folderId": "49720", "displayName": "22222", "type": "private",
+          "status": "copying", "folderLinkId": "137843", "archiveNumber": "01it-06xd" } ] }
+        """
+        let vm = FilesViewModel()
+        vm.viewModels = [FileModel(model: decodeChildren(json)!.items![0], permissions: [.read], accessRole: .viewer)]
+
+        XCTAssertTrue(vm.hasItemsInTransientState, "a copying folder is still settling")
+        XCTAssertTrue(vm.hasItemsAwaitingProcessing, "…and therefore keeps the poll alive")
+        XCTAssertFalse(vm.viewModels[0].canBeAccessed, "copying items stay non-tappable, as on V1")
+    }
+
+    func testHasItemsInTransientState_FalseOnceSettled() {
+        let json = """
+        { "items": [ { "folderId": "49720", "displayName": "22222", "type": "private",
+          "status": "ok", "folderLinkId": "137843", "archiveNumber": "01it-06xd" } ] }
+        """
+        let vm = FilesViewModel()
+        vm.viewModels = [FileModel(model: decodeChildren(json)!.items![0], permissions: [.read], accessRole: .viewer)]
+
+        XCTAssertFalse(vm.hasItemsInTransientState)
+        XCTAssertFalse(vm.hasItemsAwaitingProcessing, "a settled folder ends the chain")
+    }
+
+    // MARK: - publish edge case
+
+    func testPublish_NoArchive_CompletesWithErrorAndResetsFileAction() {
+        // No session → currentArchive (and archiveNbr) is nil, tripping publish's guard.
+        // Uses the BASE FilesViewModel because its `fileAction` is a real stored property;
+        // MyFilesViewModel's is session-backed and would read `.none` vacuously here.
+        let previousSession = AuthenticationManager.shared.session
+        AuthenticationManager.shared.session = nil
+        defer { AuthenticationManager.shared.session = previousSession }
+
+        let vm = FilesViewModel()
+        let exp = expectation(description: "completion")
+        var status: RequestStatus?
+        vm.publish(files: [makeRecordFile()]) { status = $0; exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        if case .error = status {} else {
+            XCTFail("publish must complete with an error when there is no archive (else the caller's spinner hangs)")
+        }
+        XCTAssertEqual(vm.fileAction, .none, "the guard must reset fileAction so the copy state isn't left stuck")
+    }
+
     // MARK: - delete edge case
 
     func testDelete_NilFiles_ReturnsError() {

--- a/PermanentTests/ShareItemViewModelTests.swift
+++ b/PermanentTests/ShareItemViewModelTests.swift
@@ -1629,6 +1629,57 @@ final class ThumbnailSelectionTests: XCTestCase {
         XCTAssertEqual(record.preferredThumbnailURL, "https://example.com/thumb500.jpg")
     }
 
+    func testRecordV2PreferredThumbnailURL_AccessCopyIsLastResortWhenNoRenditions() throws {
+        // A Stela COPY (POST /records/{id}/copies) gets NO .thumb.wNNN renditions (backend
+        // gap, captured on staging 2026-07-24): thumbUrl200/500/1000/2000 all null and the
+        // ONLY thumb is the access-copy thumbnailUrls.256. For non-HEIC that access copy is
+        // a real image and must be used — otherwise copies render as permanent placeholders.
+        let record = try decode(
+            RecordV2Data.self,
+            from: """
+            {
+              "uploadFileName": "a-long-frog-3840x2160-green-10125.jpg",
+              "thumbUrl200": null,
+              "thumbUrl500": null,
+              "thumbnailUrls": { "256": "https://example.com/access-copy-256.jpg", "200": null },
+              "files": [ { "fileId": "1", "type": "type.file.image.jpg", "format": "file.format.original" } ]
+            }
+            """
+        )
+
+        XCTAssertNil(record.resolvedThumbnail256, "the 256 slot keeps flat thumbnail256 only")
+        XCTAssertEqual(record.preferredThumbnailURL, "https://example.com/access-copy-256.jpg",
+                       "with no renditions, the HEIC-guarded access copy is the last resort")
+    }
+
+    func testRecordV2PreferredThumbnailURL_NeverAccessCopyForHEIC() throws {
+        // HEIC access copies are BLANK (the July white-square bug) — even as a last resort
+        // they must not be used. Detected via files[] granular type or filename extension.
+        let byFilesType = try decode(
+            RecordV2Data.self,
+            from: """
+            {
+              "thumbnailUrls": { "256": "https://example.com/access-copy-256.jpg" },
+              "files": [ { "fileId": "1", "type": "type.file.image.heic", "format": "file.format.original" } ]
+            }
+            """
+        )
+        XCTAssertTrue(byFilesType.isHEICOriginal)
+        XCTAssertNil(byFilesType.preferredThumbnailURL, "a blank HEIC access copy must never be served")
+
+        let byFilename = try decode(
+            RecordV2Data.self,
+            from: """
+            {
+              "uploadFileName": "IMG_0042.HEIC",
+              "thumbnailUrls": { "256": "https://example.com/access-copy-256.jpg" }
+            }
+            """
+        )
+        XCTAssertTrue(byFilename.isHEICOriginal, "filename extension is the fallback signal when files[] is absent")
+        XCTAssertNil(byFilename.preferredThumbnailURL)
+    }
+
     func testRecordV2PreferredThumbnailURL_PrefersTopLevelThumbnail256OverThumbnailUrls256() throws {
         let record = try decode(
             RecordV2Data.self,


### PR DESCRIPTION
Fixes found while testing on staging and prod:

- The flag was gated on #if DEBUG alone, but the production scheme run from Xcode is also a Debug build — it was silently sending V2 calls at the PROD API. Debug now additionally requires staging.
- Copies showed no thumbnail: the backend generates no .thumb.wNNN renditions for a copy (escalated), so the Archivematica access copy in thumbnailUrls."256" is the only one a fresh copy has. Used as a last resort behind the real renditions, excluded for HEIC (blank there).
- Paste flashed "done" before the rows existed. The island keeps its spinner until the destination lists them (~10s cap; a V1 folder copy needs 9s just to create its row), then shows the checkmark.
- The post-paste poll never started — it was armed before the refetch returned, so its gate read the pre-paste list. It now arms from the refresh completion. That chain also could never terminate: each fire went through pullToRefreshAction, whose invalidateTimer zeroed the run count, so the documented 3/6/12/24s backoff refetched every 6s forever.
- Poll now has three cadences: 1s while pasted rows are missing (a read-after-write race), 2s while an item is mid copy/move and not yet tappable, 10s for the thumbnail settle. Count is the only usable signal for a move, since a moved record arrives with its thumbnails.
- Paste-destination mode is navigation-only now: the "Select" button was hidden by nil-ing its title alone, leaving an invisible tappable button that re-entered multi-select. Also hide the create/upload FAB there, and reset isSelecting after the single-file "... > Copy" paste.
- FABView.setVisibility centralises FAB visibility (22 call sites) and slides it down/up instead of snapping; hiding it for paste mode created a transition that never existed before. The exit animates a snapshot so isHidden stays synchronous for its readers.
- publish() returned without invoking its handler when no archive was selected, stranding the caller's spinner.
- TEMP(VSP-1770): DEBUG builds pointed at production log requests, so a prod-scheme run shows V1-vs-V2. Release unchanged. Remove when the epic ships (grep TEMP(VSP-1770)).