### PR TITLE
FilesViewModel.rename gated the V2 path on the flag, a non-folder and a

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ CLAUDE.md
 # AI maturity assessment notes
 .ai-maturity/
 ai-maturity-assessment.md
+
+# graphify knowledge graph output (regenerate with /graphify .)
+graphify-out/

--- a/Permanent/Common/Files/ViewModel/FilesViewModel.swift
+++ b/Permanent/Common/Files/ViewModel/FilesViewModel.swift
@@ -37,9 +37,14 @@ class FilesViewModel: NSObject, ViewModelInterface {
     /// Whether this screen routes folder navigation through the Stela V2 endpoint.
     /// Default OFF (this base class hardcodes `false`). The opted-in workspaces override
     /// this to `FeatureFlags.useStelaNavigation`: `MyFilesViewModel`, `PublicFilesViewModel`
-    /// (via inheritance), and `SearchFilesViewModel`. `SharedFilesViewModel` and everything
-    /// else inherit `false` and stay on V1 (shared listings need per-item permissions the
-    /// V2 path doesn't compute).
+    /// (via inheritance), `SearchFilesViewModel`, `SharedFilesViewModel`, and
+    /// `PublicArchiveViewModel`. Everything else inherits `false` and stays on V1.
+    ///
+    /// The V2 `/children` payload carries no per-child accessRole, so each opted-in
+    /// workspace declares how to stamp one via `v2ChildContext(enteredFolder:)` — the
+    /// archive role by default, inherited-from-the-entered-folder for Shared. The Public
+    /// Gallery instead pins `archivePermissions`/`archiveAccessRole` themselves to
+    /// read-only, so the V1 failsafe cannot disagree with the V2 listing.
     var usesStelaNavigation: Bool { false }
 
     /// The folder a forward V2 navigation is heading into (the tapped item / resolved
@@ -596,7 +601,12 @@ class FilesViewModel: NSObject, ViewModelInterface {
         }
     }
 
-    private func performV1NavigateMin(params: NavigateMinParams, backNavigation: Bool, then handler: @escaping ServerResponse) {
+    /// Overridable (rather than private) so tests can observe that the V1 leg was taken
+    /// without standing up the network — same seam as `MyFilesViewModel.performV1GetRoot`.
+    /// Driving the real request from a unit test is not harmless: on a logged-in simulator
+    /// it carries a Bearer token, and a 401 reply posts `sessionExpiredNotificationName`,
+    /// which logs out asynchronously and clears the session later tests read.
+    func performV1NavigateMin(params: NavigateMinParams, backNavigation: Bool, then handler: @escaping ServerResponse) {
         #if DEBUG
         // Reached either as the primary V1 path (flag off) or as the V2 failsafe.
         FilesViewModel.lastNavigationSource = "v1"
@@ -875,11 +885,45 @@ class FilesViewModel: NSObject, ViewModelInterface {
         }
     }
     
+    /// True when the record belongs to the archive the SESSION currently has selected.
+    ///
+    /// Deliberately reads `AuthenticationManager.shared.session?.selectedArchive` rather
+    /// than `currentArchive`: subclasses override `currentArchive` to mean the archive being
+    /// VIEWED (`PublicArchiveViewModel` returns the foreign archive being browsed), so
+    /// comparing against it would report "own archive" for someone else's records.
+    /// Mirrors `FilePreviewViewModel.isInCurrentArchive`. Indeterminate ownership (no
+    /// session, or an absent `-1` archiveId) answers false, i.e. falls to V1.
+    func isInSessionArchive(_ file: FileModel) -> Bool {
+        guard let sessionArchiveId = AuthenticationManager.shared.session?.selectedArchive?.archiveID else { return false }
+        return file.archiveId > 0 && file.archiveId == sessionArchiveId
+    }
+
+    /// Whether a record rename may take the Stela `PATCH /records/{id}` route.
+    ///
+    /// OWN-ARCHIVE ONLY. `patchRecord` is sent bearer-only — `RecordV2Endpoint` attaches no
+    /// share token — so a shared-with-me record (which lives in a FOREIGN archive) would be
+    /// rejected. The rename itself would still land, because the V2 arm falls back to
+    /// `performV1Rename`, but `patchRecord` is NOT exempt from the 401 handler
+    /// (`ignoreErrors == false`, and `/api/v2/records` is not a non-critical path), so a 401
+    /// would post `sessionExpiredNotificationName` and log the user out for renaming a file
+    /// they were legitimately allowed to rename. Foreign records take V1, whose server-side
+    /// share membership authorizes them.
+    ///
+    /// Extracted from `rename` so both the positive and the negative case are unit-testable
+    /// without issuing a request.
+    func canRenameViaStelaPatch(_ file: FileModel, newName: String) -> Bool {
+        return usesStelaNavigation
+            && !file.type.isFolder          // folder rename has no V2 route
+            && file.recordId > 0
+            && !newName.isEmpty
+            && isInSessionArchive(file)
+    }
+
     func rename(file: FileModel, name: String?, then handler: @escaping ServerResponse) {
-        // Record rename → Stela PATCH /records/{id} (My Files only) with V1 as an automatic
-        // failsafe; renaming to the same name is idempotent so re-applying is harmless.
-        // Folder rename has no V2 route and stays on V1.
-        if usesStelaNavigation, !file.type.isFolder, file.recordId > 0, let newName = name, !newName.isEmpty {
+        // Record rename → Stela PATCH /records/{id} (own archive only) with V1 as an
+        // automatic failsafe; renaming to the same name is idempotent so re-applying is
+        // harmless. Folder rename has no V2 route and stays on V1.
+        if let newName = name, canRenameViaStelaPatch(file, newName: newName) {
             let apiOperation = APIOperation(RecordV2Endpoint.patchRecord(recordId: String(file.recordId), fields: ["displayName": newName]))
             apiOperation.execute(in: APIRequestDispatcher()) { [weak self] result in
                 switch result {
@@ -894,7 +938,9 @@ class FilesViewModel: NSObject, ViewModelInterface {
         performV1Rename(file: file, name: name, then: handler)
     }
 
-    private func performV1Rename(file: FileModel, name: String?, then handler: @escaping ServerResponse) {
+    /// Overridable (rather than private) so a test can observe that the V1 leg was taken
+    /// without issuing a real request — same seam as `performV1NavigateMin`.
+    func performV1Rename(file: FileModel, name: String?, then handler: @escaping ServerResponse) {
         var params: UpdateRecordParams
         var apiOperation: APIOperation
 

--- a/Permanent/Modules/PublicProfile/ViewController/PublicArchiveFileViewController.swift
+++ b/Permanent/Modules/PublicProfile/ViewController/PublicArchiveFileViewController.swift
@@ -66,11 +66,19 @@ class PublicArchiveFileViewController: BaseViewController<PublicArchiveViewModel
         collectionView.register(FileCollectionViewHeaderCell.nib(), forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FileCollectionViewHeaderCell.identifier)
         
         collectionView.refreshControl = refreshControl
-        collectionView.contentInset = UIEdgeInsets(top: 0, left: 6, bottom: 60, right: 6)
+        // The 6pt side gutters belong to the LAYOUT (sectionInset), not to the scroll view
+        // (contentInset). contentInset is re-resolved whenever the view re-enters the
+        // window — e.g. returning from the .fullScreen file preview, which UIKit removes
+        // the presenting view for — and the flow layout can prepare against a momentarily
+        // zero inset. That cached pass lays every row out from x=0, so the grid renders 6pt
+        // to the left with a doubled right margin until a scroll forces re-preparation.
+        // sectionInset is baked into the item frames, so it cannot be lost that way.
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 60, right: 0)
         let flowLayout = UICollectionViewFlowLayout()
         flowLayout.minimumInteritemSpacing = 6
         flowLayout.minimumLineSpacing = 0
         flowLayout.estimatedItemSize = .zero
+        flowLayout.sectionInset = UIEdgeInsets(top: 0, left: 6, bottom: 0, right: 6)
         collectionView.collectionViewLayout = flowLayout
         
         refreshControl.tintColor = .primary
@@ -80,6 +88,11 @@ class PublicArchiveFileViewController: BaseViewController<PublicArchiveViewModel
     func refreshCollectionView() {
         handleTableBackgroundView()
         collectionView.reloadData()
+        #if DEBUG
+        // Surface which navigation path served the current listing so UI parity tests can
+        // confirm a "V2" run actually used Stela (not the silent V1 failsafe). DEBUG-only.
+        collectionView.accessibilityIdentifier = "files-nav-source-\(FilesViewModel.lastNavigationSource)"
+        #endif
     }
     
     func handleTableBackgroundView() {
@@ -256,11 +269,23 @@ extension PublicArchiveFileViewController: UICollectionViewDelegateFlowLayout, U
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        // Horizontal layout: |-6-cell-6-cell-6-|. 6*3/2 = 9
-        // Vertical size: 30 is the height of the title label
-        let gridItemSize = CGSize(width: UIScreen.main.bounds.width / 2 - 9, height: UIScreen.main.bounds.width / 2 + 30)
-        
-        return gridItemSize
+        // Horizontal layout: |-6-cell-6-cell-6-|, derived from the collection view's own
+        // width rather than UIScreen so a narrower container or a re-resolved inset can't
+        // push the two-up fit over the edge and collapse the grid to one column. Flooring
+        // leaves sub-point slack instead of the exact-fit knife edge the old
+        // `UIScreen.main.bounds.width / 2 - 9` produced.
+        // Vertical size: 39 = the old (W/2 + 30) height minus the (W/2 - 9) width.
+        let layout = collectionViewLayout as? UICollectionViewFlowLayout
+        let sideGutters = (layout?.sectionInset.left ?? 6) + (layout?.sectionInset.right ?? 6)
+        let interitem = layout?.minimumInteritemSpacing ?? 6
+        let available = collectionView.bounds.width
+            - collectionView.adjustedContentInset.left
+            - collectionView.adjustedContentInset.right
+            - sideGutters
+            - interitem
+        let width = max(1, (available / 2).rounded(.down))
+
+        return CGSize(width: width, height: width + 39)
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -271,6 +296,9 @@ extension PublicArchiveFileViewController: UICollectionViewDelegateFlowLayout, U
         guard file.fileStatus == .synced && (file.thumbnailURL != nil || file.canBeAccessed) else { return }
         
         if file.type.isFolder {
+            // Seed the V2 navigation target (no-op when Stela nav is off, or when the tapped
+            // item carries no V2 folderId — navigateMin gates on both and falls through to V1).
+            viewModel.v2NavigationTarget = file
             let navigateParams: NavigateMinParams = (file.archiveNo, file.folderLinkId, nil)
             navigateToFolder(withParams: navigateParams, backNavigation: false, then: {
                 self.backButton.isHidden = false

--- a/Permanent/Modules/PublicProfile/ViewModel/PublicArchiveViewModel.swift
+++ b/Permanent/Modules/PublicProfile/ViewModel/PublicArchiveViewModel.swift
@@ -19,8 +19,37 @@ class PublicArchiveViewModel: FilesViewModel {
         }
     }
     
+    /// Enable Stela V2 folder drill-in for the Public Gallery (same switch the other file
+    /// screens use), with the V1 two-step navigation kept as the automatic failsafe. Root
+    /// DISCOVERY stays on V1 `getPublicRoot`: V2 `/archives` is scoped to the caller's
+    /// `callerMembershipRole`, so a foreign archive is never listed and the section-root
+    /// resolver `MyFilesViewModel` uses cannot resolve one. Verified 2026-07-28 against
+    /// staging: `/api/v2/folders/{id}/children` serves a foreign archive's public tree on
+    /// bearer auth (in fact with no auth at all), so the listing itself needs no membership.
+    override var usesStelaNavigation: Bool { FeatureFlags.useStelaNavigation }
+
+    /// The public browser is READ-ONLY, pinned at the archive level so every listing path
+    /// agrees — V2 `/children` (via the base `v2ChildContext`), the V1 `getLeanItems`
+    /// failsafe, and the `navigateMin` folder push all read these two properties.
+    ///
+    /// Pinning only the V2 leg would make the user's capabilities depend on which backend
+    /// happened to serve the listing: `navigateV2` falls back to V1 on any error, so the
+    /// same photo in the same folder would offer "Publish on the web" / "Share to Permanent"
+    /// and editable metadata after a transient V2 failure and not before. Those controls are
+    /// gated on the per-item `permissions` this stamps (`FilePreviewViewController` /
+    /// `FileDetailsViewController` share menus, and `FilePreviewViewModel.isEditable`).
+    ///
+    /// For a FOREIGN archive this changes nothing — `accessRole` comes back null, which
+    /// `AccessRole.roleForValue` already maps to `.viewer` and `ArchiveVOData.permissions()`
+    /// to `[.read]`. It narrows exactly one case: browsing your OWN archive through the
+    /// gallery, where the archive role is owner. That narrowing is deliberate — this screen
+    /// has no write UI of its own, so those affordances only ever arrived incidentally
+    /// through the shared preview component.
+    override var archivePermissions: [Permission] { [.read] }
+    override var archiveAccessRole: AccessRole { .viewer }
+
     override var currentFolderIsRoot: Bool { navigationStack.count == 1 }
-    
+
     override var numberOfSections: Int {
         1
     }
@@ -44,8 +73,18 @@ class PublicArchiveViewModel: FilesViewModel {
     }
     
     func getRoot(then handler: @escaping ServerResponse) {
-        let apiOperation = APIOperation(FilesEndpoint.getPublicRoot(archiveNbr: currentArchive!.archiveNbr!))
-        
+        // `currentArchive` is assigned from the host VC's implicitly-unwrapped `archiveData`,
+        // and `archiveNbr` is optional on the VO — so this pair was two force-unwraps away
+        // from a crash on a screen that can also be entered by deeplink. Surface the same
+        // error the other failure branches do instead (matches the VSP-1787 hardening of
+        // `PublicFilesViewModel.getRoot`).
+        guard let archiveNbr = currentArchive?.archiveNbr else {
+            handler(.error(message: .errorMessage))
+            return
+        }
+
+        let apiOperation = APIOperation(FilesEndpoint.getPublicRoot(archiveNbr: archiveNbr))
+
         apiOperation.execute(in: APIRequestDispatcher()) { result in
             switch result {
             case .json(let response, _):
@@ -69,7 +108,9 @@ class PublicArchiveViewModel: FilesViewModel {
         }
     }
     
-    private func onGetRootSuccess(_ model: GetRootResponse, _ handler: @escaping ServerResponse) {
+    /// Internal (not private) so the V1 → V2 root handoff below is unit-testable without
+    /// standing up the network.
+    func onGetRootSuccess(_ model: GetRootResponse, _ handler: @escaping ServerResponse) {
         guard
             let folderVO = model.results?.first?.data?.first?.folderVO,
             let archiveNo = folderVO.archiveNbr,
@@ -78,7 +119,16 @@ class PublicArchiveViewModel: FilesViewModel {
             handler(.error(message: .errorMessage))
             return
         }
-        
+
+        // Stela has no root-discovery route for a foreign archive, so the V1 getPublicRoot
+        // above stays as the bootstrap. When V2 is on, seed the navigation target with the
+        // public root itself so navigateMin lists it via /folders/{id}/children. The
+        // `folderId > 0` gate in navigateMin rejects a target the V1 payload didn't carry
+        // an id for, which falls through to V1 — so this can only ever add a V2 attempt.
+        if usesStelaNavigation {
+            v2NavigationTarget = FileModel(model: folderVO)
+        }
+
         let params: NavigateMinParams = (archiveNo, folderLinkId, nil)
         navigateMin(params: params, backNavigation: false, then: handler)
     }

--- a/PermanentTests/FilesViewModelTests.swift
+++ b/PermanentTests/FilesViewModelTests.swift
@@ -316,29 +316,35 @@ final class FilesViewModelTests: XCTestCase {
     func testStelaCapability_BaseStaysV1() {
         // The base class hardcodes false: even with the flag forced ON, a bare
         // FilesViewModel (and any subclass that doesn't opt in) must NOT migrate.
+        let prevFlag = FeatureFlags.useStelaNavigation
         FeatureFlags.useStelaNavigation = true
-        defer { FeatureFlags.useStelaNavigation = false }
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
         XCTAssertFalse(FilesViewModel().usesStelaNavigation)
     }
 
     func testStelaCapability_FlagOn_OptedInWorkspacesFollowIt() {
-        // My Files, Public Files, Search, and Shared drill-in deliberately opt in;
-        // the base (and everything inheriting it) stays V1.
+        // My Files, Public Files, Search, Shared drill-in, and the Public Gallery
+        // deliberately opt in; the base (and everything inheriting it) stays V1.
+        let prevFlag = FeatureFlags.useStelaNavigation
         FeatureFlags.useStelaNavigation = true
-        defer { FeatureFlags.useStelaNavigation = false }
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
         XCTAssertTrue(MyFilesViewModel().usesStelaNavigation)
         XCTAssertTrue(PublicFilesViewModel().usesStelaNavigation)
         XCTAssertTrue(SearchFilesViewModel().usesStelaNavigation)
         XCTAssertTrue(SharedFilesViewModel().usesStelaNavigation)
+        XCTAssertTrue(PublicArchiveViewModel().usesStelaNavigation)
         XCTAssertFalse(FilesViewModel().usesStelaNavigation)
     }
 
     func testStelaCapability_FlagOff_EverythingStaysV1() {
+        let prevFlag = FeatureFlags.useStelaNavigation
         FeatureFlags.useStelaNavigation = false
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
         XCTAssertFalse(MyFilesViewModel().usesStelaNavigation)
         XCTAssertFalse(PublicFilesViewModel().usesStelaNavigation)
         XCTAssertFalse(SearchFilesViewModel().usesStelaNavigation)
         XCTAssertFalse(SharedFilesViewModel().usesStelaNavigation)
+        XCTAssertFalse(PublicArchiveViewModel().usesStelaNavigation)
         XCTAssertFalse(FilesViewModel().usesStelaNavigation)
     }
 
@@ -374,6 +380,222 @@ final class FilesViewModelTests: XCTestCase {
     func testV2ChildContext_SharedFailsClosedToViewerWithoutFolder() {
         XCTAssertEqual(SharedFilesViewModel().v2ChildContext(enteredFolder: nil).accessRole, .viewer,
                        "a missing role must fail closed to read-only, never the broader archive role")
+    }
+
+    // MARK: - Public Gallery read-only pin (PublicArchiveViewModel)
+    // The gallery is a read-only browser, pinned at the ARCHIVE level so every listing path
+    // agrees: the V2 `/children` mapping (through the base v2ChildContext), the V1
+    // getLeanItems failsafe, and the navigateMin folder push all read archivePermissions /
+    // archiveAccessRole. Unlike Shared it must NOT inherit the entered folder's role, and it
+    // must NOT use the real archive role — that would hand out write affordances when you
+    // browse your OWN archive here, and only on whichever backend served the listing.
+
+    private func decodeArchive(accessRole: String) -> ArchiveVOData? {
+        let json = "{\"archiveNbr\":\"0001-test\",\"accessRole\":\"\(accessRole)\",\"fullName\":\"Owned Archive\"}"
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? ArchiveVOData.decoder.decode(ArchiveVOData.self, from: data)
+    }
+
+    func testV2ChildContext_PublicGalleryPinsViewerRegardlessOfEnteredFolder() throws {
+        let vm = PublicArchiveViewModel()
+        // Seed an OWNER archive: with `currentArchive` nil the pin is indistinguishable from
+        // the un-pinned base (a nil archive already yields [.read]/.viewer), so every
+        // assertion below would pass even with the override deleted.
+        vm.currentArchive = try XCTUnwrap(decodeArchive(accessRole: AccessRole.owner.apiValue))
+        XCTAssertEqual(AccessRole.roleForValue(vm.currentArchive?.accessRole), .owner,
+                       "precondition: the underlying archive really is owner-level")
+
+        for role in [AccessRole.owner, .manager, .curator, .editor, .contributor, .viewer] {
+            let context = vm.v2ChildContext(enteredFolder: makeV2Folder(role: role))
+            XCTAssertEqual(context.accessRole, .viewer,
+                           "public gallery children must stay read-only even inside a \(role) folder")
+            XCTAssertEqual(context.permissions, [.read],
+                           "public gallery children must carry only .read even inside a \(role) folder")
+        }
+
+        // And with no entered folder at all (the root listing).
+        XCTAssertEqual(vm.v2ChildContext(enteredFolder: nil).accessRole, .viewer)
+        XCTAssertEqual(vm.v2ChildContext(enteredFolder: nil).permissions, [.read])
+    }
+
+    func testV2ChildContext_PublicGalleryIgnoresOwnerArchiveRole() throws {
+        // Browsing YOUR OWN archive through the gallery: the archive carries the owner
+        // role, so an un-pinned gallery would stamp owner permissions onto every child.
+        // This is the one case where the pin actually narrows, and it is deliberate.
+        let ownerArchive = try XCTUnwrap(decodeArchive(accessRole: AccessRole.owner.apiValue))
+        XCTAssertEqual(AccessRole.roleForValue(ownerArchive.accessRole), .owner,
+                       "fixture must really be an owner archive, else this test proves nothing")
+
+        let vm = PublicArchiveViewModel()
+        vm.currentArchive = ownerArchive
+        XCTAssertEqual(vm.currentArchive?.archiveNbr, ownerArchive.archiveNbr,
+                       "sanity: the VM did take the owner archive")
+
+        let context = vm.v2ChildContext(enteredFolder: nil)
+        XCTAssertEqual(context.accessRole, .viewer, "own archive viewed publicly is still read-only")
+        XCTAssertEqual(context.permissions, [.read])
+    }
+
+    func testPublicGallery_ArchiveRolePinnedSoTheV1FailsafeCannotDisagree() throws {
+        // The pin lives on archivePermissions/archiveAccessRole rather than only on
+        // v2ChildContext, because the V1 legs (onGetLeanItemsSuccess / onNavigateMinSuccess)
+        // stamp children from these same two properties. Pinning just the V2 leg would let a
+        // transient V2 failure hand back write affordances the V2 listing withheld.
+        let vm = PublicArchiveViewModel()
+        vm.currentArchive = try XCTUnwrap(decodeArchive(accessRole: AccessRole.owner.apiValue))
+
+        XCTAssertEqual(vm.archiveAccessRole, .viewer,
+                       "the gallery must never expose the owner role, on either backend")
+        XCTAssertEqual(vm.archivePermissions, [.read],
+                       "the gallery must never expose write permissions, on either backend")
+
+        // Guard the specific affordances this protects (FilePreviewViewController /
+        // FileDetailsViewController share menus, FilePreviewViewModel.isEditable).
+        for forbidden in [Permission.edit, .delete, .publish, .share, .ownership, .create, .upload, .move] {
+            XCTAssertFalse(vm.archivePermissions.contains(forbidden),
+                           "\(forbidden) must not be reachable from the public browser")
+        }
+
+        // And the base (non-gallery) behavior is untouched: an owner archive still grants write.
+        let base = FilesViewModel()
+        XCTAssertTrue(ArchiveVOData.permissions(forAccessRole: AccessRole.owner.apiValue).contains(.edit),
+                      "sanity: owner really does imply .edit — else the assertions above are hollow")
+        XCTAssertEqual(base.archiveAccessRole, AccessRole.roleForValue(base.currentArchive?.accessRole),
+                       "the base class must keep deriving its role from the session archive")
+    }
+
+    // MARK: - Record rename: V2 PATCH is own-archive only
+    // `patchRecord` is sent bearer-only (no share token) and is NOT exempt from the 401
+    // force-logout, so attempting it on a FOREIGN (shared-with-me) record risks logging the
+    // user out for a rename they were allowed to make. The rename itself would still land via
+    // the V1 failsafe — the logout is the damage. Foreign records must never reach the V2 leg.
+
+    /// Record built through the V2 decode path, because the convenience `FileModel` init
+    /// hardcodes `archiveId = -1` and archiveId is exactly what the ownership check reads.
+    private func makeV2Record(archiveId: Int, recordId: Int = 500) -> FileModel {
+        let json = """
+        { "items": [ { "recordId": "\(recordId)", "archiveId": "\(archiveId)",
+          "displayName": "photo.jpg", "type": "type.record.image", "status": "status.generic.ok",
+          "folderLinkId": "11", "archiveNumber": "0001-test" } ] }
+        """
+        return FileModel(model: decodeChildren(json)!.items![0], permissions: [.read, .edit], accessRole: .editor)
+    }
+
+    /// Runs `body` with the session pinned to `ArchiveVOData.mock()` (archiveID 1).
+    private func withSessionArchive(_ body: () -> Void) {
+        let previous = AuthenticationManager.shared.session
+        let session = PermSession(token: "test_token")
+        session.selectedArchive = ArchiveVOData.mock()   // archiveID 1
+        AuthenticationManager.shared.session = session
+        defer { AuthenticationManager.shared.session = previous }
+        body()
+    }
+
+    func testIsInSessionArchive_OwnForeignAndIndeterminate() {
+        withSessionArchive {
+            let vm = FilesViewModel()
+            XCTAssertTrue(vm.isInSessionArchive(makeV2Record(archiveId: 1)), "same archive as the session")
+            XCTAssertFalse(vm.isInSessionArchive(makeV2Record(archiveId: 2)), "a foreign archive is not ours")
+            XCTAssertFalse(vm.isInSessionArchive(makeV2Record(archiveId: -1)),
+                           "an absent archiveId is indeterminate and must fail closed")
+        }
+    }
+
+    func testIsInSessionArchive_NoSession_FailsClosed() {
+        let previous = AuthenticationManager.shared.session
+        AuthenticationManager.shared.session = nil
+        defer { AuthenticationManager.shared.session = previous }
+
+        XCTAssertFalse(FilesViewModel().isInSessionArchive(makeV2Record(archiveId: 1)))
+    }
+
+    func testIsInSessionArchive_IgnoresOverriddenCurrentArchive() {
+        // `PublicArchiveViewModel` overrides `currentArchive` to the archive being VIEWED.
+        // The check must read the SESSION's archive, or browsing a foreign public archive
+        // would report its records as "ours".
+        withSessionArchive {
+            let gallery = PublicArchiveViewModel()
+            gallery.currentArchive = ArchiveVOData.mock()   // viewed archive == archiveID 1
+            XCTAssertFalse(gallery.isInSessionArchive(makeV2Record(archiveId: 2)),
+                           "a foreign record stays foreign even when its archive is the one being viewed")
+            XCTAssertTrue(gallery.isInSessionArchive(makeV2Record(archiveId: 1)),
+                          "ownership is decided by the session, not by currentArchive")
+        }
+    }
+
+    func testCanRenameViaStelaPatch_ForeignRecordIsRejected() {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        withSessionArchive {
+            // The reported scenario: Shares → "Shared with me" → editor role → Rename.
+            let shared = SharedFilesViewModel()
+            XCTAssertTrue(shared.usesStelaNavigation, "precondition: Shared opts into the flag")
+            XCTAssertFalse(shared.canRenameViaStelaPatch(makeV2Record(archiveId: 2), newName: "new.jpg"),
+                           "a shared-with-me record must not reach PATCH /records/{id}")
+
+            // Same record on a base workspace — still foreign, still rejected.
+            XCTAssertFalse(MyFilesViewModel().canRenameViaStelaPatch(makeV2Record(archiveId: 2), newName: "new.jpg"))
+        }
+    }
+
+    func testCanRenameViaStelaPatch_OwnRecordIsAllowed() {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        withSessionArchive {
+            XCTAssertTrue(MyFilesViewModel().canRenameViaStelaPatch(makeV2Record(archiveId: 1), newName: "new.jpg"),
+                          "own-archive renames must keep using V2 — the gate must not over-tighten")
+        }
+    }
+
+    func testCanRenameViaStelaPatch_OtherGuardsStillHold() {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        withSessionArchive {
+            let vm = MyFilesViewModel()
+            let own = makeV2Record(archiveId: 1)
+
+            XCTAssertFalse(vm.canRenameViaStelaPatch(own, newName: ""), "an empty name must not be PATCHed")
+            XCTAssertFalse(vm.canRenameViaStelaPatch(makeV2Record(archiveId: 1, recordId: 0), newName: "new.jpg"),
+                           "a record with no id must not be PATCHed")
+            XCTAssertFalse(vm.canRenameViaStelaPatch(makeV2Folder(role: .owner), newName: "new"),
+                           "folder rename has no V2 route")
+
+            FeatureFlags.useStelaNavigation = false
+            XCTAssertFalse(vm.canRenameViaStelaPatch(own, newName: "new.jpg"), "flag off means V1")
+        }
+    }
+
+    /// Observes that `rename` actually consults the gate: a foreign record must reach the V1
+    /// leg SYNCHRONOUSLY. The V2 leg is asynchronous, so a synchronous V1 call proves no
+    /// PATCH was attempted — and nothing touches the network.
+    private final class RenameSpyViewModel: SharedFilesViewModel {
+        var v1RenameCallCount = 0
+        override func performV1Rename(file: FileModel, name: String?, then handler: @escaping ServerResponse) {
+            v1RenameCallCount += 1
+            handler(.success)
+        }
+    }
+
+    func testRename_ForeignRecord_GoesStraightToV1() {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        withSessionArchive {
+            let vm = RenameSpyViewModel()
+            var status: RequestStatus?
+            vm.rename(file: makeV2Record(archiveId: 2), name: "new.jpg") { status = $0 }
+
+            XCTAssertEqual(vm.v1RenameCallCount, 1,
+                           "the V1 leg must run synchronously — a V2 attempt would defer it")
+            XCTAssertEqual(status, .success)
+        }
     }
 
     // MARK: - Batch PATCH fan-out aggregation (patchSequentially seam)

--- a/PermanentTests/NotificationNameAndFileTypeTests.swift
+++ b/PermanentTests/NotificationNameAndFileTypeTests.swift
@@ -48,4 +48,69 @@ final class NotificationNameAndFileTypeTests: XCTestCase {
         let decoded = try JSONDecoder().decode(FileType.self, from: jsonData)
         XCTAssertEqual(decoded, .video)
     }
+
+    // MARK: - FileType.fromV2 (Stela V2 `type` strings)
+    // The V2 /folders/{id}/children payload serializes FOLDER types as a pretty string
+    // ("public", "private-root", …) that does NOT match FileType's raw values, while
+    // RECORDS keep the legacy "type.record.*" raw string. Getting this wrong silently
+    // turns a folder into a record: `didSelectItemAt` keys the drill-in vs open-preview
+    // decision on `file.type.isFolder`, so a mis-mapped folder would open the file
+    // preview instead of navigating into it.
+
+    func testFromV2_FolderTypes_MapToFolderCases() {
+        // "public" is the Public Gallery's case — the gallery is the first screen whose
+        // V2 children come back public rather than private (verified against staging).
+        let cases: [(String, FileType)] = [
+            ("public", .publicFolder),
+            ("public-root", .publicRootFolder),
+            ("public_root", .publicRootFolder),
+            ("private", .privateFolder),
+            ("private-root", .privateRootFolder),
+            ("private_root", .privateRootFolder),
+            ("share", .sharedFolder),
+            ("share-root", .sharedFolder),
+            ("share_root", .sharedFolder)
+        ]
+
+        for (raw, expected) in cases {
+            let mapped = FileType.fromV2(typeString: raw, isFolder: true)
+            XCTAssertEqual(mapped, expected, "V2 folder type \"\(raw)\" must map to \(expected.rawValue)")
+            XCTAssertTrue(mapped.isFolder, "V2 folder type \"\(raw)\" must stay tappable as a folder")
+        }
+    }
+
+    func testFromV2_UnknownFolderType_FallsBackToAFolder() {
+        // An unrecognized folder type must still be a FOLDER. Falling back to a record
+        // case would make the item open a file preview that can never load.
+        for raw in ["something-new", "", "type.folder.public"] {
+            let mapped = FileType.fromV2(typeString: raw, isFolder: true)
+            XCTAssertTrue(mapped.isFolder, "unknown V2 folder type \"\(raw)\" must still be a folder")
+        }
+        XCTAssertTrue(FileType.fromV2(typeString: nil, isFolder: true).isFolder)
+    }
+
+    func testFromV2_RecordTypes_KeepLegacyRawValues() {
+        let cases: [(String, FileType)] = [
+            ("type.record.image", .image),
+            ("type.record.video", .video),
+            ("type.record.audio", .audio),
+            ("type.record.pdf", .pdf),
+            ("type.record.misc", .miscellaneous)
+        ]
+
+        for (raw, expected) in cases {
+            let mapped = FileType.fromV2(typeString: raw, isFolder: false)
+            XCTAssertEqual(mapped, expected, "V2 record type \"\(raw)\" must decode from its raw value")
+            XCTAssertFalse(mapped.isFolder, "V2 record type \"\(raw)\" must not be treated as a folder")
+        }
+    }
+
+    func testFromV2_UnknownRecordType_FallsBackToMiscellaneous() {
+        for raw in ["type.record.brand.new", "public", ""] {
+            let mapped = FileType.fromV2(typeString: raw, isFolder: false)
+            XCTAssertEqual(mapped, .miscellaneous, "unknown V2 record type \"\(raw)\" must degrade to .miscellaneous")
+            XCTAssertFalse(mapped.isFolder)
+        }
+        XCTAssertEqual(FileType.fromV2(typeString: nil, isFolder: false), .miscellaneous)
+    }
 }

--- a/PermanentTests/PublicArchiveViewModelTests.swift
+++ b/PermanentTests/PublicArchiveViewModelTests.swift
@@ -8,7 +8,36 @@
 import XCTest
 @testable import Permanent
 
+/// Public gallery view model with the V1 navigation leg stubbed out. `performV1NavigateMin`
+/// issues a real network request, which a unit test must not do: on a logged-in simulator it
+/// carries a Bearer token, and a 401 posts `sessionExpiredNotificationName` → an async
+/// `logout()` that clears the session other tests depend on. Recording the call is also a
+/// stronger assertion than reading the process-wide `lastNavigationSource` string.
+final class StubV1GalleryViewModel: PublicArchiveViewModel {
+    var v1NavigateMinCallCount = 0
+    var v1NavigateMinBackNavigation: [Bool] = []
+    /// What the stubbed V1 leg reports back; `.success` mirrors a healthy legacy response.
+    var v1NavigateMinResult: RequestStatus = .success
+
+    override func performV1NavigateMin(params: NavigateMinParams, backNavigation: Bool, then handler: @escaping ServerResponse) {
+        v1NavigateMinCallCount += 1
+        v1NavigateMinBackNavigation.append(backNavigation)
+        handler(v1NavigateMinResult)
+    }
+}
+
 final class PublicArchiveViewModelTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        #if DEBUG
+        // `lastNavigationSource` is a process-wide static shared by every screen, so a
+        // leftover "v1" from an earlier test would make the assertions below pass without
+        // this run's navigation having reached the V1 path at all. Reset to a value that
+        // neither path ever writes.
+        FilesViewModel.lastNavigationSource = "none"
+        #endif
+    }
 
     private func makeRecordFile(name: String = "photo.jpg") -> FileModel {
         return FileModel(
@@ -140,4 +169,342 @@ final class PublicArchiveViewModelTests: XCTestCase {
         XCTAssertNotNil(url)
         XCTAssertTrue(url!.absoluteString.contains("record"))
     }
+
+    // MARK: - VSP-1811: V1 getPublicRoot → V2 /children handoff
+    // Stela's /archives is scoped to callerMembershipRole, so a FOREIGN archive is never
+    // listed and the V2 section-root resolver can't bootstrap this screen. V1 getPublicRoot
+    // stays as the bootstrap; when the flag is on, onGetRootSuccess seeds the public root as
+    // the V2 navigation target so the listing itself is served by /folders/{id}/children.
+
+    /// Mirrors the live staging `POST /folder/getPublicRoot` payload for a foreign public
+    /// archive (verified 2026-07-28 against 00js-0000). `folderId` is parameterized so the
+    /// `folderId > 0` gate in navigateMin can be exercised.
+    private func decodeGetRoot(_ json: String) throws -> GetRootResponse {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder().decode(GetRootResponse.self, from: data)
+    }
+
+    private func makeGetRootResponse(folderId: String = "42618") throws -> GetRootResponse {
+        return try decodeGetRoot("""
+        { "Results": [ { "data": [ { "FolderVO": {
+            \(folderId.isEmpty ? "" : "\"folderId\": \(folderId),")
+            "folder_linkId": 107086,
+            "archiveNbr": "00js-0009",
+            "archiveId": 1694,
+            "displayName": "Public",
+            "type": "type.folder.root.public"
+        } } ] } ], "isSuccessful": true }
+        """)
+    }
+
+    /// Captures whether the V2 children seam fired, and for which folder id. The V1 leg is
+    /// stubbed too (see `StubV1GalleryViewModel`) so a test that deliberately drives the
+    /// failsafe observes it directly instead of issuing a real POST /folder/navigateMin.
+    private func makeGalleryVM(outcome: FilesViewModel.ChildrenFetchOutcome = .committed)
+    -> (StubV1GalleryViewModel, () -> String?) {
+        let vm = StubV1GalleryViewModel()
+        var requestedFolderId: String?
+        vm.childrenFetchV2Request = { folderId, completion in
+            requestedFolderId = folderId
+            completion(outcome)
+        }
+        return (vm, { requestedFolderId })
+    }
+
+    func testGetRootFixture_CarriesFolderId() throws {
+        // Guards the fixture itself: if the V1 payload ever stops carrying folderId, the
+        // handoff below silently degrades to V1 and the tests would still "pass".
+        let folderVO = try XCTUnwrap(makeGetRootResponse().results?.first?.data?.first?.folderVO)
+        XCTAssertEqual(folderVO.folderID, 42618)
+        XCTAssertEqual(FileModel(model: folderVO).folderId, 42618,
+                       "FileModel must carry the V1 folderId through, or navigateMin's gate rejects the target")
+    }
+
+    func testOnGetRootSuccess_FlagOn_HandsPublicRootToV2Children() throws {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vm, requestedFolderId) = makeGalleryVM(outcome: .committed)
+
+        var status: RequestStatus?
+        vm.onGetRootSuccess(try makeGetRootResponse()) { status = $0 }
+
+        XCTAssertEqual(requestedFolderId(), "42618", "the V1 public root must hand off to V2 /children")
+        XCTAssertEqual(status, .success)
+        XCTAssertEqual(vm.navigationStack.last?.folderId, 42618, "the root must be on the stack")
+        XCTAssertTrue(vm.currentFolderIsRoot, "one entry deep is root for this screen")
+    }
+
+    func testOnGetRootSuccess_FlagOff_NeverTouchesV2() throws {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = false
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vm, requestedFolderId) = makeGalleryVM()
+        vm.onGetRootSuccess(try makeGetRootResponse()) { _ in }
+
+        XCTAssertNil(requestedFolderId(), "with the flag off the public root must list via V1")
+        XCTAssertEqual(vm.v1NavigateMinCallCount, 1, "the flag-off path must go through the V1 leg exactly once")
+    }
+
+    func testOnGetRootSuccess_PublicRootWithoutFolderId_FallsThroughToV1() throws {
+        // The V1 payload is all-optional. A root with no folderId maps to folderId == -1,
+        // which navigateMin's `target.folderId > 0` gate must reject rather than issuing
+        // GET /folders/-1/children. Seeding can only ever ADD a V2 attempt, never break V1.
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vm, requestedFolderId) = makeGalleryVM()
+        vm.onGetRootSuccess(try makeGetRootResponse(folderId: "")) { _ in }
+
+        XCTAssertNil(requestedFolderId(), "an id-less root must not reach the V2 endpoint")
+        XCTAssertEqual(vm.v1NavigateMinCallCount, 1, "an id-less root must fall through to the V1 leg")
+    }
+
+    func testOnGetRootSuccess_MalformedResponse_ErrorsWithoutNavigating() throws {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vm, requestedFolderId) = makeGalleryVM()
+        let empty = try decodeGetRoot(#"{"Results":[],"isSuccessful":true}"#)
+
+        var status: RequestStatus?
+        vm.onGetRootSuccess(empty) { status = $0 }
+
+        XCTAssertNil(requestedFolderId())
+        XCTAssertTrue(vm.navigationStack.isEmpty)
+        guard case .error = status else {
+            return XCTFail("a rootless payload must surface an error, not a silent success")
+        }
+    }
+
+    func testGetRoot_NoArchive_ErrorsInsteadOfCrashing() {
+        // `currentArchive` comes from the host VC's implicitly-unwrapped `archiveData`, and
+        // `archiveNbr` is optional on the VO. Both used to be force-unwrapped, so a nil
+        // archive crashed the public browser instead of surfacing the error the rest of
+        // getRoot's failure branches already report. The guard returns BEFORE the request,
+        // so this asserts synchronously without touching the network.
+        let vm = PublicArchiveViewModel()
+        XCTAssertNil(vm.currentArchive, "precondition: no archive assigned")
+
+        var status: RequestStatus?
+        vm.getRoot(then: { status = $0 })
+
+        guard case .error = status else {
+            return XCTFail("a missing archive must surface an error, not crash or silently succeed")
+        }
+        XCTAssertTrue(vm.navigationStack.isEmpty, "nothing may be navigated without an archive")
+    }
+
+    // MARK: - VSP-1811: V2 drill-in
+
+    /// Folder built via the V2 decode path — the convenience `init(name:recordId:…)` can't
+    /// set `folderId`, which is exactly what navigateMin's gate reads.
+    private func makeV2Folder(folderId: Int) throws -> FileModel {
+        let json = """
+        { "items": [ { "folderId": "\(folderId)", "displayName": "Folder \(folderId)",
+          "type": "private", "status": "ok", "folderLinkId": "11", "archiveNumber": "00js-0032" } ] }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let response = try FolderChildrenV2Response.decoder.decode(FolderChildrenV2Response.self, from: data)
+        let child = try XCTUnwrap(response.items?.first)
+        return FileModel(model: child, permissions: [.read], accessRole: .viewer)
+    }
+
+    func testNavigateV2_DrillIn_CommittedAppendsAndLeavesRoot() throws {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vm, requestedFolderId) = makeGalleryVM(outcome: .committed)
+        vm.navigationStack.append(try makeV2Folder(folderId: 42618))   // already at the public root
+        vm.v2NavigationTarget = try makeV2Folder(folderId: 42668)
+
+        var status: RequestStatus?
+        vm.navigateMin(params: ("00js-0032", 11, nil), backNavigation: false) { status = $0 }
+
+        XCTAssertEqual(requestedFolderId(), "42668")
+        XCTAssertEqual(status, .success)
+        XCTAssertEqual(vm.navigationStack.map { $0.folderId }, [42618, 42668])
+        XCTAssertFalse(vm.currentFolderIsRoot, "two deep is no longer the root")
+    }
+
+    func testNavigateV2_DrillIn_FailedFallsBackToV1WithoutNavigating() throws {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vm, requestedFolderId) = makeGalleryVM(outcome: .failed(message: "boom"))
+        vm.v2NavigationTarget = try makeV2Folder(folderId: 42668)
+
+        vm.navigateMin(params: ("00js-0032", 11, nil), backNavigation: false) { _ in }
+
+        XCTAssertEqual(requestedFolderId(), "42668", "V2 was attempted")
+        XCTAssertTrue(vm.navigationStack.isEmpty, "a failed V2 fetch must not commit navigation")
+        XCTAssertEqual(vm.v1NavigateMinCallCount, 1, "failure must reach the V1 failsafe exactly once")
+        XCTAssertEqual(vm.v1NavigateMinBackNavigation, [false], "the failsafe must preserve the forward direction")
+    }
+}
+
+// MARK: - PublicArchiveFileViewController (VSP-1811)
+// Lives in this file rather than its own because adding a test FILE needs a project-file
+// change in Xcode; move it out when convenient. Mirrors the SharesViewControllerTests /
+// MainViewControllerTests pattern: instantiate the VC directly and wire the outlets by hand.
+
+@MainActor
+final class PublicArchiveFileViewControllerTests: XCTestCase {
+
+    private func makeController(width: CGFloat = 402, height: CGFloat = 874)
+    -> (PublicArchiveFileViewController, UICollectionView) {
+        let vc = PublicArchiveFileViewController()
+        // V1 leg stubbed — a flag-off tap would otherwise POST /folder/navigateMin for real.
+        vc.viewModel = StubV1GalleryViewModel()
+
+        let collectionView = UICollectionView(
+            frame: CGRect(x: 0, y: 0, width: width, height: height),
+            collectionViewLayout: UICollectionViewFlowLayout()
+        )
+        // Same layout configuration setupCollectionView() installs: the 6pt side gutters live
+        // on the LAYOUT, and sizeForItemAt reads them back off it.
+        if let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            flowLayout.minimumInteritemSpacing = 6
+            flowLayout.minimumLineSpacing = 0
+            flowLayout.sectionInset = UIEdgeInsets(top: 0, left: 6, bottom: 0, right: 6)
+        }
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 60, right: 0)
+
+        // Keep the weak outlets alive on a retained root view.
+        let rootView = UIView(frame: CGRect(x: 0, y: 0, width: width, height: height))
+        let directoryLabel = UILabel()
+        let backButton = UIButton(type: .system)
+        let linkButton = UIButton(type: .system)
+        [directoryLabel, backButton, linkButton, collectionView].forEach { rootView.addSubview($0) }
+
+        vc.view = rootView
+        vc.collectionView = collectionView
+        vc.directoryLabel = directoryLabel
+        vc.backButton = backButton
+        vc.linkButton = linkButton
+
+        return (vc, collectionView)
+    }
+
+    private func makeV2Folder(folderId: Int) throws -> FileModel {
+        // "public" is what the gallery's own children really carry (verified against staging),
+        // unlike the "private" the other screens see.
+        let json = """
+        { "items": [ { "folderId": "\(folderId)", "displayName": "Folder \(folderId)",
+          "type": "public", "status": "ok", "folderLinkId": "107367", "archiveNumber": "00js-0032" } ] }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let response = try FolderChildrenV2Response.decoder.decode(FolderChildrenV2Response.self, from: data)
+        let child = try XCTUnwrap(response.items?.first)
+        return FileModel(model: child, permissions: [.read], accessRole: .viewer)
+    }
+
+    private func size(of vc: PublicArchiveFileViewController, _ collectionView: UICollectionView) -> CGSize {
+        return vc.collectionView(
+            collectionView,
+            layout: collectionView.collectionViewLayout,
+            sizeForItemAt: IndexPath(row: 0, section: 0)
+        )
+    }
+
+    // MARK: - Grid geometry
+
+    func testSizeForItem_TwoUpGridFitsWithinTheCollectionViewWidth() {
+        // The invariant that matters: two cells plus both gutters plus the inter-item gap
+        // must never exceed the available width, or the flow layout drops to one column.
+        for width in [320, 375, 390, 393, 402, 414, 428, 430, 440].map(CGFloat.init) {
+            let (vc, collectionView) = makeController(width: width)
+            let itemSize = size(of: vc, collectionView)
+
+            XCTAssertLessThanOrEqual(itemSize.width * 2 + 6 + 6 + 6, width,
+                                     "two-up grid must fit inside \(width)pt")
+            XCTAssertEqual(itemSize.width, ((width - 18) / 2).rounded(.down),
+                           "width must derive from the collection view, not UIScreen (at \(width)pt)")
+            XCTAssertEqual(itemSize.height, itemSize.width + 39,
+                           "height must stay width + 39 — the old (W/2 + 30) minus (W/2 - 9)")
+        }
+    }
+
+    func testSizeForItem_NarrowerCollectionViewShrinksTheCell() {
+        // The actual regression the rewrite fixes: sizing off UIScreen ignored the real
+        // container, so a narrower collection view overflowed instead of shrinking.
+        let (wideVC, wideCollectionView) = makeController(width: 402)
+        let (narrowVC, narrowCollectionView) = makeController(width: 300)
+
+        let wide = size(of: wideVC, wideCollectionView)
+        let narrow = size(of: narrowVC, narrowCollectionView)
+
+        XCTAssertLessThan(narrow.width, wide.width, "a narrower container must produce narrower cells")
+        XCTAssertLessThanOrEqual(narrow.width * 2 + 18, 300)
+    }
+
+    func testSizeForItem_ZeroWidthCollectionViewStaysPositive() {
+        // First layout pass can run before bounds resolve; a zero/negative size makes
+        // UICollectionViewFlowLayout throw.
+        let (vc, collectionView) = makeController(width: 0, height: 0)
+        let itemSize = size(of: vc, collectionView)
+
+        XCTAssertGreaterThan(itemSize.width, 0)
+        XCTAssertGreaterThan(itemSize.height, 0)
+    }
+
+    // MARK: - V2 drill-in seeding (the ticket's deliverable)
+
+    func testDidSelectFolder_FlagOn_SeedsTargetAndListsViaV2Children() throws {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = true
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vc, collectionView) = makeController()
+        let vm = try XCTUnwrap(vc.viewModel)
+
+        var requestedFolderId: String?
+        vm.childrenFetchV2Request = { folderId, completion in
+            requestedFolderId = folderId
+            completion(.committed)
+        }
+
+        let folder = try makeV2Folder(folderId: 42668)
+        vm.viewModels = [folder]
+
+        vc.collectionView(collectionView, didSelectItemAt: IndexPath(row: 0, section: 0))
+
+        XCTAssertEqual(requestedFolderId, "42668",
+                       "tapping a gallery folder must drill in through /folders/{id}/children")
+        XCTAssertEqual(vm.navigationStack.map { $0.folderId }, [42668])
+        XCTAssertEqual(vc.directoryLabel.text, folder.name)
+        XCTAssertFalse(vc.backButton.isHidden, "entering a folder must reveal the back button")
+        XCTAssertNil(vm.v2NavigationTarget, "the forward target is one-shot and must be consumed")
+    }
+
+    func testDidSelectFolder_FlagOff_NeverReachesV2() throws {
+        let prevFlag = FeatureFlags.useStelaNavigation
+        FeatureFlags.useStelaNavigation = false
+        defer { FeatureFlags.useStelaNavigation = prevFlag }
+
+        let (vc, collectionView) = makeController()
+        let vm = try XCTUnwrap(vc.viewModel as? StubV1GalleryViewModel)
+
+        var didReachV2 = false
+        vm.childrenFetchV2Request = { _, completion in
+            didReachV2 = true
+            completion(.committed)
+        }
+
+        vm.viewModels = [try makeV2Folder(folderId: 42668)]
+        vc.collectionView(collectionView, didSelectItemAt: IndexPath(row: 0, section: 0))
+
+        XCTAssertFalse(didReachV2, "with the flag off the gallery must stay on the V1 two-step path")
+        XCTAssertEqual(vm.v1NavigateMinCallCount, 1, "the tap must still navigate, via the V1 leg")
+    }
+
+    // NOTE: the record branch of didSelectItemAt is deliberately NOT tested here — it calls
+    // presentFileDetails, which stands up the whole preview stack and fires a real record
+    // fetch. Covered at the view-model level instead (FilePreviewViewModelTests).
 }


### PR DESCRIPTION
Record rename: restrict the Stela V2 PATCH to own-archive records

FilesViewModel.rename gated the V2 path on the flag, a non-folder and a
positive recordId, but not on archive ownership — despite its own comment
saying "My Files only". Every other V2 write checks isInCurrentArchive.

SharedFilesViewModel opts into the flag and the Shares tab offers Rename
whenever .edit is present, so renaming a shared-with-me record (a FOREIGN
archive) sent PATCH /api/v2/records/{id} bearer-only, with no share token.
The rename itself recovered via the V1 failsafe, but patchRecord is not
exempt from the 401 handler (ignoreErrors == false, and /api/v2/records is
not a non-critical path), so a 401 posts sessionExpiredNotificationName and
logs the user out for a rename they were allowed to make.

Add isInSessionArchive, which reads the SESSION's selected archive rather
than `currentArchive` — subclasses override currentArchive to mean the
archive being VIEWED (PublicArchiveViewModel returns the foreign archive
being browsed), so comparing against it would report someone else's records
as ours. Extract the whole gate into canRenameViaStelaPatch so both the
positive and negative case are unit-testable without issuing a request, and
make performV1Rename overridable for the same reason.

Deliberately NOT adding /api/v2/records to isNonCriticalEndpoint: that list
is documented as the per-case escape hatch being ignoreErrors, and blanket
suppression would mask genuine session expiry on patchRecord/copyRecord.
Gating at the source fixes the foreign case while keeping that intact.

Tests: the isInSessionArchive matrix (own / foreign / absent id / no session /
overridden currentArchive), the predicate's other guards, the reported
Shares scenario, and a positive case pinning that own-archive renames still
use V2 so the gate cannot silently over-tighten. Verified by mutation:
removing the ownership check fails exactly the two intended tests.
Suite 2840 / 0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>