### PR TITLE
VSP-1815[iOS] Upload Button is present for an archive with view mode (when clicking the select and aborting the action)

### DIFF
--- a/Permanent/Common/Base/UIKitViews/FABView.swift
+++ b/Permanent/Common/Base/UIKitViews/FABView.swift
@@ -219,6 +219,14 @@ class FABView: UIView {
         exitSnapshot?.removeFromSuperview()
         exitSnapshot = nil
 
+        // Restore alpha on EVERY show path, including the early returns below. Callers used
+        // to fade alpha to 0 as their own hide animation, so a show that only cleared
+        // `isHidden` handed back a fully transparent FAB — present, tappable-looking to
+        // code, invisible on screen. Any competing fade is cancelled first, otherwise its
+        // completion lands after this and zeroes alpha again.
+        layer.removeAnimation(forKey: "opacity")
+        alpha = 1
+
         // A slide is already running: let it finish untouched. This branch is load-bearing —
         // `updateFABViewVisibility()` fires again a few hundred ms later when the post-paste
         // folder refetch lands, and re-asserting the transform there cut the animation short,

--- a/Permanent/Common/Helpers/NetworkLogger.swift
+++ b/Permanent/Common/Helpers/NetworkLogger.swift
@@ -41,10 +41,20 @@ class NetworkLogger {
         /// Whether to log request/response bodies
         var logBodies: Bool = true
 
-        /// Maximum number of body bytes rendered per log line. Bodies are stringified on
-        /// the dispatcher's completion thread (currently main), so an uncapped multi-
-        /// megabyte listing would stall the UI just to be logged.
-        var maxBodyLength: Int = 10_000
+        /// Maximum number of body bytes rendered. Bodies are stringified on the dispatcher's
+        /// completion thread (currently main), so this is not unbounded — a multi-megabyte
+        /// listing would stall the UI just to be logged. 1 MB is far above any real API
+        /// response here (the largest, a full folder listing, is tens of KB) while still
+        /// bounding the pathological case. Staging only: `environmentRestriction` keeps all
+        /// of this out of production, and `logBodies` is off there regardless.
+        var maxBodyLength: Int = 1_000_000
+
+        /// Bytes per emitted log line. os_log truncates an individual message well before
+        /// `maxBodyLength` — in practice around 1 KB — so a long body must be emitted in
+        /// pieces or the tail is silently lost (this is what hid the archive list: the cut
+        /// happened at ~1 KB even though the cap was 10 KB and no truncation marker was
+        /// appended, because the loss was in os_log, not here).
+        var logChunkSize: Int = 800
     }
     
     /// Current logger configuration
@@ -121,7 +131,7 @@ class NetworkLogger {
         
         // Log body if present and enabled
         if configuration.logBodies, configuration.logLevel == .debug, let body = request.httpBody {
-            logger.debug("Body: \(loggableBody(body), privacy: .public)")
+            logBody("Body", body)
         }
     }
 
@@ -133,6 +143,25 @@ class NetworkLogger {
         let cap = configuration.maxBodyLength
         guard body.count > cap else { return String(decoding: body, as: UTF8.self) }
         return String(decoding: body.prefix(cap), as: UTF8.self) + " … [truncated \(body.count - cap) of \(body.count) bytes]"
+    }
+
+    /// Emits a body across as many log lines as it takes, because os_log drops the tail of
+    /// any single long message. Each line is prefixed `label [i/n]` so `log stream` output
+    /// can be reassembled in order; a short body still logs as one unprefixed line.
+    private static func logBody(_ label: String, _ body: Data) {
+        let text = loggableBody(body)
+        let size = max(1, configuration.logChunkSize)
+        guard text.count > size else {
+            logger.debug("\(label): \(text, privacy: .public)")
+            return
+        }
+        let chars = Array(text)
+        let total = (chars.count + size - 1) / size
+        for index in 0..<total {
+            let start = index * size
+            let piece = String(chars[start..<min(start + size, chars.count)])
+            logger.debug("\(label) [\(index + 1, privacy: .public)/\(total, privacy: .public)]: \(piece, privacy: .public)")
+        }
     }
     
     /// Log a network response
@@ -167,7 +196,7 @@ class NetworkLogger {
         
         // Log body if present and enabled
         if configuration.logBodies, configuration.logLevel == .debug, let body = data {
-            logger.debug("Body: \(loggableBody(body), privacy: .public)")
+            logBody("Body", body)
         }
     }
 }

--- a/Permanent/Modules/Archives/ViewModel/ArchivesViewModel.swift
+++ b/Permanent/Modules/Archives/ViewModel/ArchivesViewModel.swift
@@ -21,6 +21,41 @@ class ArchivesViewModel: ViewModelInterface {
     var pendingArchives: [ArchiveVOData] {
         return allArchives.filter({ $0.status == ArchiveVOData.Status.pending })
     }
+
+    /// The archives to keep from an account-archives response: deduped by id, with only
+    /// `.unknown` (unparseable status) dropped.
+    ///
+    /// PENDING archives are RETAINED. `pendingArchives` above filters this same collection
+    /// for `.pending`, so excluding them during parsing made that property — and with it
+    /// the "Pending Archives" section and its Accept/Decline buttons — permanently empty:
+    /// an invitation showed on the web and could not be accepted on iOS at all. The archive
+    /// switcher is unaffected because it reads `selectableArchives`, which requires `.ok`.
+    ///
+    /// Static and internal so the filter is unit-testable without a network call. The
+    /// version this replaces lived inside the request completion and was unreachable from
+    /// a test, which is why four passing `pendingArchives` tests never caught the bug —
+    /// they all assigned `allArchives` directly, bypassing this step.
+    static func usableArchives(from accountArchives: [ArchiveVO]?) -> [ArchiveVOData] {
+        var archiveMap: [Int: ArchiveVOData] = [:]
+
+        accountArchives?.forEach { archive in
+            guard let archiveVOData = archive.archiveVO,
+                  archiveVOData.status != .unknown,
+                  let archiveID = archiveVOData.archiveID
+            else { return }
+
+            // Server-side duplicates: prefer the row that actually carries a name.
+            if let existingArchive = archiveMap[archiveID] {
+                if existingArchive.fullName == nil && archiveVOData.fullName != nil {
+                    archiveMap[archiveID] = archiveVOData
+                }
+            } else {
+                archiveMap[archiveID] = archiveVOData
+            }
+        }
+
+        return Array(archiveMap.values)
+    }
     var selectableArchives: [ArchiveVOData] {
         return availableArchives.filter({ $0.status == ArchiveVOData.Status.ok })
     }
@@ -117,29 +152,8 @@ class ArchivesViewModel: ViewModelInterface {
                 }
                 
                 let accountArchives = model.results.first?.data
-                
-                self.allArchives.removeAll()
-                var archiveMap: [Int: ArchiveVOData] = [:]
-                
-                accountArchives?.forEach { archive in
-                    if let archiveVOData = archive.archiveVO, 
-                       archiveVOData.status != .pending && archiveVOData.status != .unknown,
-                       let archiveID = archiveVOData.archiveID {
-                        
-                        // Handle server-side data corruption by preferring archives with valid names
-                        if let existingArchive = archiveMap[archiveID] {
-                            // Prefer the archive with a valid (non-nil) name
-                            if existingArchive.fullName == nil && archiveVOData.fullName != nil {
-                                archiveMap[archiveID] = archiveVOData
-                            }
-                        } else {
-                            archiveMap[archiveID] = archiveVOData
-                        }
-                    }
-                }
-                
-                // Convert map back to array
-                self.allArchives = Array(archiveMap.values)
+
+                self.allArchives = Self.usableArchives(from: accountArchives)
                 completionBlock(accountArchives, nil)
                 return
                 

--- a/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
@@ -254,11 +254,10 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         nonImageAwaitingReconnect = false
         imageStateOverlay.render(.idle)
         recordLoaded = false
-        // Drop the cached record and reset the rendition budget. Replaying a cached record
-        // fails identically — a document waiting on its PDF rendition only recovers once a
-        // FRESH fetch reports the new file — which made Retry a dead end for exactly the
-        // case most likely to be retried.
-        renditionWaitAttempts = 0
+        // Drop the cached record. Replaying it fails identically — a document waiting on its
+        // PDF rendition only recovers once a FRESH fetch reports the new file — which made
+        // Retry a dead end for exactly the case most likely to be retried (a just-uploaded
+        // document whose access copy is still being generated).
         viewModel?.recordVO = nil
         loadVM()
     }
@@ -272,8 +271,14 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         thumbnailImageView.isHidden = true
         let connected = ReachabilityManager.shared.isConnected
         nonImageAwaitingReconnect = !connected
-        imageStateOverlay.render(connected ? .failed(hasThumbnail: previewBlurAvailable)
-                                           : .offline(hasThumbnail: previewBlurAvailable))
+        // Match the backdrop loadVM() chose for this file type, or the preview flips between
+        // two different looks every time you retry. Photos and videos keep their blur (the
+        // image itself / the first frame); documents stay on the neutral field, which is what
+        // their loading state shows — a "not ready yet" document should look like it is still
+        // loading, not like a different screen.
+        let hasBlur = previewBlurAvailable && (file.type == .image || isLikelyVideoFile)
+        imageStateOverlay.render(connected ? .failed(hasThumbnail: hasBlur)
+                                           : .offline(hasThumbnail: hasBlur))
     }
 
     private func resumeImageLoad() {
@@ -799,46 +804,13 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     /// A non-image preview is parked in the offline state, awaiting reconnect to auto-retry.
     private var nonImageAwaitingReconnect = false
 
-    /// Re-fetches consumed while waiting for a document's PDF rendition to be generated.
-    private var renditionWaitAttempts = 0
-    /// Bounded on purpose: the rendition may never arrive (a file type Archivematica does
-    /// not convert), and an unbounded poll would refetch the record forever in the
-    /// background of every such preview. When the budget runs out the failure card is
-    /// shown, and tapping Retry starts a fresh budget.
-    private static let maxRenditionWaitAttempts = 6
-    private static let renditionWaitInterval: TimeInterval = 10
-
-    /// Handles the case where the original could not be rendered because the record's PDF
-    /// rendition does not exist YET: Archivematica generates the access copy asynchronously,
-    /// so a document opened moments after upload has nothing previewable and would otherwise
-    /// show "Couldn't load file" for a file that is perfectly fine. Re-fetches the record on
-    /// a bounded schedule, holding the loading state meanwhile.
-    ///
-    /// Returns true when it has taken ownership of the outcome — the caller must NOT paint
-    /// the failure card in that case.
-    private func waitForPendingRenditionIfNeeded() -> Bool {
-        guard viewModel?.isAwaitingPDFRendition == true,
-              renditionWaitAttempts < Self.maxRenditionWaitAttempts
-        else { return false }
-
-        renditionWaitAttempts += 1
-        imageStateOverlay.render(.loadingFullRes(hasThumbnail: previewBlurAvailable))
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.renditionWaitInterval) { [weak self] in
-            guard let self = self, self.isViewLoaded else { return }
-            // A fresh fetch is required — replaying the cached record reproduces the
-            // failure identically, since the rendition is a NEW file on the record.
-            self.viewModel?.getRecord(file: self.file) { [weak self] record in
-                guard let self = self else { return }
-                if record != nil {
-                    self.loadRecord()
-                } else {
-                    self.showPreviewLoadFailure()
-                }
-            }
-        }
-        return true
-    }
+    // NOTE: a bounded "wait for the PDF rendition" retry loop was tried here and removed.
+    // Archivematica generates the access copy asynchronously, so a document opened seconds
+    // after upload genuinely has nothing to render — but holding the loading state and
+    // re-fetching traded one honest card for a minute-long spinner, and re-rendering the
+    // placeholder on each cycle flashed the grey `noThumbnailBackground` over the black
+    // letterbox. The failure card is immediate and truthful, and Retry now re-fetches the
+    // record (see retryPreviewLoad), so one tap picks the rendition up as soon as it lands.
 
     /// Snapshots the player's QuickTime artwork and runs the blur-to-sharp reveal.
     /// drawHierarchy(afterScreenUpdates: true) moves windowless views into a temporary
@@ -1289,7 +1261,6 @@ extension FilePreviewViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         webView.removeFromSuperview()
-        if waitForPendingRenditionIfNeeded() { return }
         showPreviewLoadFailure()
     }
 
@@ -1301,8 +1272,6 @@ extension FilePreviewViewController: WKNavigationDelegate {
     /// loading overlay forever instead of offering the failure/retry card.
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         webView.removeFromSuperview()
-        // Most common cause for a document: its PDF rendition is still being generated.
-        if waitForPendingRenditionIfNeeded() { return }
         showPreviewLoadFailure()
     }
 }

--- a/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
@@ -254,6 +254,12 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         nonImageAwaitingReconnect = false
         imageStateOverlay.render(.idle)
         recordLoaded = false
+        // Drop the cached record and reset the rendition budget. Replaying a cached record
+        // fails identically — a document waiting on its PDF rendition only recovers once a
+        // FRESH fetch reports the new file — which made Retry a dead end for exactly the
+        // case most likely to be retried.
+        renditionWaitAttempts = 0
+        viewModel?.recordVO = nil
         loadVM()
     }
 
@@ -390,9 +396,23 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
                 
             case FileType.pdf:
                 self.loadPDF(withURL: downloadURL)
-                
+
             default:
-                self.loadMisc(withURL: downloadURL)
+                // Documents have no inline renderer on this path: WebKit refuses the
+                // original's MIME type (.ods, .xls) and converts the navigation into a
+                // download, which fails the load with WebKitErrorDomain 102 and rendered
+                // nothing. Archivematica generates a PDF access copy for exactly this case,
+                // and PDFKit displays it without involving WebKit at all. Preview only —
+                // `fileVO()` stays on the original so Download and the displayed filename
+                // still give the user the file they uploaded.
+                if let accessCopyURL = self.viewModel?.pdfAccessCopyURL() {
+                    self.loadPDF(withURL: accessCopyURL)
+                } else {
+                    // No rendition available: still prefer the inline url, since
+                    // `downloadURL` carries `response-content-disposition=attachment` and
+                    // therefore guarantees the download path rather than a render.
+                    self.loadMisc(withURL: fileVO.fileURL.flatMap { URL(string: $0) } ?? downloadURL)
+                }
             }
         } else if file.type == .image {
             self.viewModel?.imageLoadDidFail(error: nil)
@@ -778,6 +798,47 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     private var previewBlurAvailable = false
     /// A non-image preview is parked in the offline state, awaiting reconnect to auto-retry.
     private var nonImageAwaitingReconnect = false
+
+    /// Re-fetches consumed while waiting for a document's PDF rendition to be generated.
+    private var renditionWaitAttempts = 0
+    /// Bounded on purpose: the rendition may never arrive (a file type Archivematica does
+    /// not convert), and an unbounded poll would refetch the record forever in the
+    /// background of every such preview. When the budget runs out the failure card is
+    /// shown, and tapping Retry starts a fresh budget.
+    private static let maxRenditionWaitAttempts = 6
+    private static let renditionWaitInterval: TimeInterval = 10
+
+    /// Handles the case where the original could not be rendered because the record's PDF
+    /// rendition does not exist YET: Archivematica generates the access copy asynchronously,
+    /// so a document opened moments after upload has nothing previewable and would otherwise
+    /// show "Couldn't load file" for a file that is perfectly fine. Re-fetches the record on
+    /// a bounded schedule, holding the loading state meanwhile.
+    ///
+    /// Returns true when it has taken ownership of the outcome — the caller must NOT paint
+    /// the failure card in that case.
+    private func waitForPendingRenditionIfNeeded() -> Bool {
+        guard viewModel?.isAwaitingPDFRendition == true,
+              renditionWaitAttempts < Self.maxRenditionWaitAttempts
+        else { return false }
+
+        renditionWaitAttempts += 1
+        imageStateOverlay.render(.loadingFullRes(hasThumbnail: previewBlurAvailable))
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.renditionWaitInterval) { [weak self] in
+            guard let self = self, self.isViewLoaded else { return }
+            // A fresh fetch is required — replaying the cached record reproduces the
+            // failure identically, since the rendition is a NEW file on the record.
+            self.viewModel?.getRecord(file: self.file) { [weak self] record in
+                guard let self = self else { return }
+                if record != nil {
+                    self.loadRecord()
+                } else {
+                    self.showPreviewLoadFailure()
+                }
+            }
+        }
+        return true
+    }
 
     /// Snapshots the player's QuickTime artwork and runs the blur-to-sharp reveal.
     /// drawHierarchy(afterScreenUpdates: true) moves windowless views into a temporary
@@ -1228,6 +1289,20 @@ extension FilePreviewViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         webView.removeFromSuperview()
+        if waitForPendingRenditionIfNeeded() { return }
+        showPreviewLoadFailure()
+    }
+
+    /// `didFail navigation:` only fires once a response has been committed. A load that dies
+    /// BEFORE that — most importantly one WebKit converts into a download, which is what an
+    /// `attachment` Content-Disposition does (WebKitErrorDomain 102,
+    /// FrameLoadInterruptedByPolicyChange) — reports through this callback instead. With it
+    /// unimplemented, neither completion path ran for spreadsheets and the preview sat on its
+    /// loading overlay forever instead of offering the failure/retry card.
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        webView.removeFromSuperview()
+        // Most common cause for a document: its PDF rendition is still being generated.
+        if waitForPendingRenditionIfNeeded() { return }
         showPreviewLoadFailure()
     }
 }

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -400,7 +400,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         }
         rightItems.append(FloatingActionImageItem(image: closeImage) { [weak self] vc, item in
             self?.dismissFloatingActionIsland()
-            self?.fabView.setVisibility(hidden: false)
+            self?.updateFABViewVisibility()
 
             self?.viewModel?.selectedFiles = []
             self?.viewModel?.fileAction = .none
@@ -440,6 +440,9 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
         // the FAB reappears on every navigation during paste mode.
         let shouldShowFAB = hasCreatePermission && hasUploadPermission && !viewModel.isPickingImage
             && !viewModel.isSelectingDestination
+            // Multi-select owns the screen while active; the FAB comes back via the
+            // restore paths below, which all route through this gate.
+            && !viewModel.isSelecting
 
         // setVisibility fades the buttons back in (see FABView). Hiding them for paste mode
         // created a real hide→show transition that previously never happened — the FAB used
@@ -630,7 +633,9 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     }
 
     @objc
-    private func selectButtonWasPressed(_ sender: UIButton) {
+    /// Internal (not private) so tests can drive the select-mode transitions directly —
+    /// the FAB permission-gate regression lived exactly on this path.
+    func selectButtonWasPressed(_ sender: UIButton) {
         guard let viewModel = viewModel else { return }
         // Can't (re)enter multi-select while choosing a paste destination — that mode owns
         // the fixed relocate selection. Belt-and-suspenders with hiding the button below.
@@ -657,8 +662,9 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
     }
     
     @objc
-    private func clearButtonWasPressed(_ sender: UIButton) {
-        fabView.setVisibility(hidden: false)
+    /// Internal (not private) so tests can drive the select-mode transitions directly —
+    /// the FAB permission-gate regression lived exactly on this path.
+    func clearButtonWasPressed(_ sender: UIButton) {
         if !backButton.isHidden {
             backButton.isUserInteractionEnabled = true
             backButton.layer.opacity = 1
@@ -666,6 +672,10 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
 
         viewModel?.selectedFiles = []
         viewModel?.isSelecting = false
+        // Restore the FAB through the permission gate, never unconditionally: on a
+        // viewer-role archive, leaving select mode must NOT conjure the create/upload
+        // button (the gate reads isSelecting, so this must run after the reset above).
+        updateFABViewVisibility()
         collectionView.reloadData()
     }
     
@@ -990,7 +1000,7 @@ class MainViewController: BaseViewController<MyFilesViewModel> {
                 DispatchQueue.main.async {
                     self.showErrorAlert(message: .deleteError) {
                         self.refreshCurrentFolder()
-                        self.fabView.setVisibility(hidden: false)
+                        self.updateFABViewVisibility()
                     }
                 }
             }
@@ -1515,12 +1525,9 @@ extension MainViewController: FABViewDelegate {
             },
             onDismiss: { [weak self] in
                 self?.dismiss(animated: false, completion: {
-                    // Show FAB buttons with animation when menu is dismissed
-                    self?.fabView.isHidden = false
-                    self?.fabView.alpha = 0
-                    UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
-                        self?.fabView.alpha = 1
-                    }
+                    // Restore through the permission gate — a viewer-role archive must not
+                    // get the FAB back just because the menu closed. setVisibility animates.
+                    self?.updateFABViewVisibility()
                 })
             }
         )
@@ -1719,7 +1726,7 @@ extension MainViewController: FABActionSheetDelegate {
                             DispatchQueue.main.async {
                                 self?.showErrorAlert(message: .deleteError) {
                                     self?.refreshCurrentFolder()
-                                    self?.fabView.setVisibility(hidden: false)
+                                    self?.updateFABViewVisibility()
                                 }
                             }
                         }
@@ -1766,7 +1773,6 @@ extension MainViewController: FABActionSheetDelegate {
                         self?.deleteFile(self?.viewModel?.selectedFiles)
                         
                         self?.dismissFloatingActionIsland()
-                        self?.fabView.setVisibility(hidden: false)
                         self?.clearButtonWasPressed(UIButton())
                     }, positiveButtonColor: .brightRed,
                     cancelButtonColor: .primary,
@@ -1855,7 +1861,6 @@ extension MainViewController: FABActionSheetDelegate {
                                 self?.viewModel?.removeSyncedFiles(files)
                                 self?.refreshCollectionView()
                                 self?.dismissFloatingActionIsland()
-                                self?.fabView.setVisibility(hidden: false)
                                 self?.clearButtonWasPressed(UIButton())
                             }
 
@@ -1864,7 +1869,6 @@ extension MainViewController: FABActionSheetDelegate {
                                 self?.showErrorAlert(message: .deleteError) {
                                     self?.refreshCurrentFolder()
                                     self?.dismissFloatingActionIsland()
-                                    self?.fabView.setVisibility(hidden: false)
                                     self?.clearButtonWasPressed(UIButton())
                                 }
                             }
@@ -2009,7 +2013,6 @@ extension MainViewController: FABActionSheetDelegate {
         self.present(hostingController, animated: true, completion: nil)
         
         self.dismissFloatingActionIsland()
-        self.fabView.setVisibility(hidden: false)
         self.clearButtonWasPressed(UIButton())
         
         // Add a way to call the completion block when the view is dismissed.

--- a/Permanent/Modules/Main/ViewController/MainViewController.swift
+++ b/Permanent/Modules/Main/ViewController/MainViewController.swift
@@ -1539,13 +1539,12 @@ extension MainViewController: FABViewDelegate {
         
         present(hostingController, animated: true)
         
-        // Hide FAB with fade animation after presenting
+        // Hide the FAB through the same API that shows it, so the two stay symmetrical.
+        // Hand-fading alpha here meant the restore had to undo alpha as well, and the
+        // permission gate (updateFABViewVisibility) only manages isHidden — so the FAB came
+        // back invisible after any menu action, e.g. starting or cancelling an upload.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseOut) {
-                self.fabView.alpha = 0
-            } completion: { _ in
-                self.fabView.isHidden = true
-            }
+            self.fabView.setVisibility(hidden: true)
         }
         
         viewModel?.trackEvent(action: RecordEventAction.initiateUpload)

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -1846,13 +1846,11 @@ extension SharesViewController: FABViewDelegate {
         
         present(hostingController, animated: true)
         
-        // Hide FAB with fade animation after presenting
+        // Hide the FAB through the same API that shows it (see MainViewController) — a
+        // hand-faded alpha is not undone by the permission gate, so the FAB returned
+        // invisible after any menu action.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            UIView.animate(withDuration: 0.2, delay: 0, options: .curveEaseOut) {
-                self.fabView.alpha = 0
-            } completion: { _ in
-                self.fabView.isHidden = true
-            }
+            self.fabView.setVisibility(hidden: true)
         }
     }
     

--- a/Permanent/Modules/Shares/ViewController/SharesViewController.swift
+++ b/Permanent/Modules/Shares/ViewController/SharesViewController.swift
@@ -319,7 +319,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         }
         rightItems.append(FloatingActionImageItem(image: closeImage) { [weak self] vc, item in
             self?.dismissFloatingActionIsland()
-            self?.fabView.setVisibility(hidden: false)
+            self?.updateFAB()
 
             self?.viewModel?.selectedFiles = []
             self?.viewModel?.fileAction = .none
@@ -353,7 +353,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self?.viewModel?.fileAction = FileAction.copy
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .copy)
                     
-                    self?.fabView.setVisibility(hidden: false)
+                    self?.updateFAB()
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -370,7 +370,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self?.viewModel?.fileAction = FileAction.move
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .move)
                     
-                    self?.fabView.setVisibility(hidden: false)
+                    self?.updateFAB()
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -407,7 +407,8 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         fileActionBottomView.toggleActionButton(enabled: !shouldDisableButton)
     }
     
-    fileprivate func updateFAB() {
+    /// Internal (not private) so tests can assert the permission gate directly.
+    func updateFAB() {
         let currentFolderPermissions = viewModel?.currentFolder?.permissions
         
         viewModel?.showMemberChecklist({ [weak self]  showChecklist in
@@ -421,6 +422,8 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         var shouldShowFAB = currentFolderPermissions?.contains(.create) == true
             && currentFolderPermissions?.contains(.upload) == true
         if !fileActionBottomView.isHidden { shouldShowFAB = false }
+        // Multi-select owns the screen while active; restore paths route through this gate.
+        if viewModel?.isSelecting == true { shouldShowFAB = false }
         // Hide the create/upload FAB (and its checklist sub-button) while picking a copy/move
         // destination — you're choosing where to paste, not adding new files here.
         if viewModel?.isSelectingDestination == true { shouldShowFAB = false }
@@ -651,7 +654,9 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
     }
     
     @objc
-    private func selectButtonWasPressed(_ sender: UIButton) {
+    /// Internal (not private) so tests can drive the select-mode transitions directly —
+    /// the FAB permission-gate regression lived exactly on this path.
+    func selectButtonWasPressed(_ sender: UIButton) {
         guard let viewModel = viewModel else { return }
         // Can't (re)enter multi-select while choosing a paste destination — that mode owns
         // the fixed relocate selection. Belt-and-suspenders with hiding the button below.
@@ -678,8 +683,9 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
     }
     
     @objc
-    private func clearButtonWasPressed(_ sender: UIButton) {
-        fabView.setVisibility(hidden: false)
+    /// Internal (not private) so tests can drive the select-mode transitions directly —
+    /// the FAB permission-gate regression lived exactly on this path.
+    func clearButtonWasPressed(_ sender: UIButton) {
         if !backButton.isHidden {
             backButton.isUserInteractionEnabled = true
             backButton.layer.opacity = 1
@@ -687,6 +693,10 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
         
         viewModel?.selectedFiles = []
         viewModel?.isSelecting = false
+        // Restore the FAB through the permission gate, never unconditionally: leaving
+        // select mode in a folder you can only view must NOT conjure the create/upload
+        // button (the gate reads isSelecting, so this must run after the reset above).
+        updateFAB()
         collectionView.reloadData()
     }
     
@@ -959,7 +969,6 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                         self?.deleteFile(self?.viewModel?.selectedFiles)
                         
                         self?.dismissFloatingActionIsland()
-                        self?.fabView.setVisibility(hidden: false)
                         self?.clearButtonWasPressed(UIButton())
                     }, positiveButtonColor: .brightRed,
                     cancelButtonColor: .primary,
@@ -974,7 +983,7 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                     self?.viewModel?.fileAction = FileAction.move
                     self?.relocateAction(files: self?.viewModel?.selectedFiles, action: .move)
                     
-                    self?.fabView.setVisibility(hidden: false)
+                    self?.updateFAB()
                     if let backButtonIsHidden = self?.backButton.isHidden, !backButtonIsHidden {
                         self?.backButton.isUserInteractionEnabled = true
                         self?.backButton.layer.opacity = 1
@@ -1017,7 +1026,6 @@ class SharesViewController: BaseViewController<SharedFilesViewModel> {
                                 self?.viewModel?.removeSyncedFiles(files)
                                 self?.refreshCollectionView()
                                 self?.dismissFloatingActionIsland()
-                                self?.fabView.setVisibility(hidden: false)
                                 self?.clearButtonWasPressed(UIButton())
                             }
                             
@@ -1768,7 +1776,6 @@ extension SharesViewController: SharedFileActionSheetDelegate {
         self.present(hostingController, animated: true, completion: nil)
         
         self.dismissFloatingActionIsland()
-        self.fabView.setVisibility(hidden: false)
         self.clearButtonWasPressed(UIButton())
         
         hostingController.rootView.dismissAction = { hasUpdates in
@@ -1825,12 +1832,9 @@ extension SharesViewController: FABViewDelegate {
             },
             onDismiss: { [weak self] in
                 self?.dismiss(animated: false, completion: {
-                    // Show FAB buttons with animation when menu is dismissed
-                    self?.fabView.isHidden = false
-                    self?.fabView.alpha = 0
-                    UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
-                        self?.fabView.alpha = 1
-                    }
+                    // Restore through the permission gate — a view-only folder must not get
+                    // the FAB back just because the menu closed. setVisibility animates.
+                    self?.updateFAB()
                 })
             }
         )
@@ -2033,6 +2037,6 @@ extension SharesViewController: UIDocumentPickerDelegate {
 extension SharesViewController: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         // Show FAB buttons when menu is dismissed
-        fabView.setVisibility(hidden: false)
+        updateFAB()
     }
 }

--- a/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
@@ -403,18 +403,6 @@ class FilePreviewViewModel: ViewModelInterface {
         return URL(string: urlString)
     }
 
-    /// True when this record has no previewable PDF rendition and every file it carries is
-    /// the original upload — i.e. Archivematica has not produced the access copy yet.
-    ///
-    /// The rendition is generated asynchronously, so a document opened moments after being
-    /// uploaded legitimately has nothing this preview can render. That is a "not ready yet",
-    /// not a broken file, and it resolves on its own within seconds-to-minutes.
-    var isAwaitingPDFRendition: Bool {
-        guard pdfAccessCopyURL() == nil else { return false }
-        guard let files = recordVO?.recordVO?.fileVOS, !files.isEmpty else { return false }
-        return files.allSatisfy { $0.format == "file.format.original" }
-    }
-
     func fileThumbnailURL() -> String? {
         let stringURL: String? = recordVO?.recordVO?.preferredThumbnailURL
         return stringURL

--- a/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
@@ -383,6 +383,38 @@ class FilePreviewViewModel: ViewModelInterface {
         return recordVO?.recordVO?.fileVOS?.first
     }
     
+    /// The Archivematica-generated PDF rendition of this record, when it has one.
+    ///
+    /// Document types (spreadsheets, presentations, …) cannot be rendered inline by the
+    /// preview's web view: WebKit refuses the original's MIME type and turns the navigation
+    /// into a download, so nothing is ever displayed. This access copy is a real PDF that
+    /// PDFKit renders directly.
+    ///
+    /// Preview only, deliberately separate from `fileVO()` — that stays on the original so
+    /// Download and `fileName()` keep giving the user the file they actually uploaded.
+    func pdfAccessCopyURL() -> URL? {
+        guard let accessCopy = recordVO?.recordVO?.fileVOS?.first(where: {
+            $0.type == "type.file.pdf.pdf" && $0.format == "file.format.archivematica.access"
+        }) else { return nil }
+
+        // fileURL is the plain object; downloadURL carries a content-disposition that would
+        // ask for a save instead of a render.
+        guard let urlString = accessCopy.fileURL ?? accessCopy.downloadURL else { return nil }
+        return URL(string: urlString)
+    }
+
+    /// True when this record has no previewable PDF rendition and every file it carries is
+    /// the original upload — i.e. Archivematica has not produced the access copy yet.
+    ///
+    /// The rendition is generated asynchronously, so a document opened moments after being
+    /// uploaded legitimately has nothing this preview can render. That is a "not ready yet",
+    /// not a broken file, and it resolves on its own within seconds-to-minutes.
+    var isAwaitingPDFRendition: Bool {
+        guard pdfAccessCopyURL() == nil else { return false }
+        guard let files = recordVO?.recordVO?.fileVOS, !files.isEmpty else { return false }
+        return files.allSatisfy { $0.format == "file.format.original" }
+    }
+
     func fileThumbnailURL() -> String? {
         let stringURL: String? = recordVO?.recordVO?.preferredThumbnailURL
         return stringURL

--- a/PermanentTests/ArchivesViewModelTests.swift
+++ b/PermanentTests/ArchivesViewModelTests.swift
@@ -61,6 +61,60 @@ final class ArchivesViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.defaultArchiveId)
     }
 
+    // MARK: - usableArchives (the parsing step that feeds allArchives)
+    // The pendingArchives tests below all assign `allArchives` directly, so none of them
+    // exercised parsing — which is exactly where a `status != .pending` filter was dropping
+    // invitations. The web showed a pending viewer archive that iOS could not accept at all.
+
+    func testUsableArchives_KeepsPending_SoInvitationsAreAcceptable() {
+        let parsed = ArchivesViewModel.usableArchives(from: [
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "001", status: .ok, archiveID: 1)),
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "002", status: .pending, archiveID: 2))
+        ])
+
+        XCTAssertEqual(parsed.count, 2, "a pending invitation must survive parsing")
+        XCTAssertEqual(parsed.filter { $0.status == .pending }.first?.archiveNbr, "002")
+
+        // End to end through the property the Pending Archives section actually reads.
+        let vm = ArchivesViewModel()
+        vm.allArchives = parsed
+        XCTAssertEqual(vm.pendingArchives.count, 1,
+                       "parsing must feed pendingArchives, or Accept/Decline is unreachable")
+        XCTAssertEqual(vm.selectableArchives.count, 1,
+                       "the switcher must still exclude pending — it requires .ok")
+    }
+
+    func testUsableArchives_DropsUnknownStatus() {
+        let parsed = ArchivesViewModel.usableArchives(from: [
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "001", status: .ok, archiveID: 1)),
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "002", status: .unknown, archiveID: 2))
+        ])
+
+        XCTAssertEqual(parsed.count, 1, "an unparseable status is still dropped")
+        XCTAssertEqual(parsed.first?.archiveNbr, "001")
+    }
+
+    func testUsableArchives_DedupesByIdPreferringNamedRow() {
+        // Server-side duplicates: the row carrying a name must win regardless of order.
+        let namelessFirst = ArchivesViewModel.usableArchives(from: [
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "001", status: .ok, archiveID: 7, fullName: nil)),
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "001", status: .ok, archiveID: 7, fullName: "Real Name"))
+        ])
+        XCTAssertEqual(namelessFirst.count, 1)
+        XCTAssertEqual(namelessFirst.first?.fullName, "Real Name")
+
+        let namedFirst = ArchivesViewModel.usableArchives(from: [
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "001", status: .ok, archiveID: 7, fullName: "Real Name")),
+            ArchiveVO(archiveVO: makeArchive(archiveNbr: "001", status: .ok, archiveID: 7, fullName: nil))
+        ])
+        XCTAssertEqual(namedFirst.count, 1)
+        XCTAssertEqual(namedFirst.first?.fullName, "Real Name")
+    }
+
+    func testUsableArchives_NilInput_ReturnsEmpty() {
+        XCTAssertTrue(ArchivesViewModel.usableArchives(from: nil).isEmpty)
+    }
+
     // MARK: - pendingArchives
 
     func testPendingArchives_Empty_ReturnsEmpty() {

--- a/PermanentTests/FilePreviewViewModelTests.swift
+++ b/PermanentTests/FilePreviewViewModelTests.swift
@@ -18,6 +18,121 @@ final class FilePreviewViewModelTests: XCTestCase {
         return FilePreviewViewModel(file: file)
     }
 
+    /// Builds a RecordVO through the real V2 adapter, so these tests exercise the same
+    /// `fileVOS` shape the app receives from Stela rather than a hand-built stand-in.
+    private func makeRecordWithFiles(_ filesJSON: String) -> RecordVO {
+        let json = """
+        { "data": {
+            "recordId": "89793", "displayName": "file_example_ODS_100", "archiveId": "3227",
+            "archiveNumber": "01on-0006", "uploadFileName": "file_example_ODS_100.ods",
+            "size": 68446, "type": "type.record.spreadsheet", "folderLinkId": "137946",
+            "files": [ \(filesJSON) ]
+        } }
+        """
+        let v2 = try! RecordV2Response.decoder.decode(RecordV2Response.self, from: Data(json.utf8)).data!
+        return JSONHelper.decoding(from: v2.toRecordVOPayload(), with: RecordVO.decoder)!
+    }
+
+    private let odsOriginalJSON = """
+    { "fileId": "1318542", "size": 68446, "format": "file.format.original",
+      "type": "type.file.spreadsheet.ods",
+      "fileUrl": "https://cdn/originals/1318542",
+      "downloadUrl": "https://cdn/originals/1318542?response-content-disposition=attachment" }
+    """
+
+    private let accessCopyPDFJSON = """
+    { "fileId": "1318544", "size": 29249, "format": "file.format.archivematica.access",
+      "type": "type.file.pdf.pdf",
+      "fileUrl": "https://cdn/access_copies/1318542.pdf",
+      "downloadUrl": "https://cdn/access_copies/1318542.pdf?response-content-disposition=x.pdf" }
+    """
+
+    // MARK: - pdfAccessCopyURL
+    // A spreadsheet's original has no inline renderer: WebKit converts the navigation into a
+    // download, the provisional load fails (WebKitErrorDomain 102) and the preview showed
+    // nothing. The Archivematica PDF rendition is what actually gets displayed.
+
+    func testPDFAccessCopyURL_ReturnsArchivematicaPDF_NotTheOriginal() {
+        let vm = makeVM()
+        vm.recordVO = makeRecordWithFiles("\(odsOriginalJSON), \(accessCopyPDFJSON)")
+
+        XCTAssertEqual(vm.pdfAccessCopyURL()?.absoluteString,
+                       "https://cdn/access_copies/1318542.pdf",
+                       "must render the access copy, and via fileUrl — downloadUrl's content-disposition asks for a save")
+    }
+
+    func testPDFAccessCopyURL_NilWhenRecordHasOnlyTheOriginal() {
+        let vm = makeVM()
+        vm.recordVO = makeRecordWithFiles(odsOriginalJSON)
+
+        XCTAssertNil(vm.pdfAccessCopyURL(),
+                     "with no rendition the caller must fall back to loadMisc, not pass nil to loadPDF")
+    }
+
+    func testPDFAccessCopyURL_IgnoresAnOriginalPDF() {
+        // A record that IS a pdf takes the .pdf branch already; only a generated ACCESS copy
+        // may stand in for an unrenderable original.
+        let vm = makeVM()
+        vm.recordVO = makeRecordWithFiles("""
+        { "fileId": "1", "size": 10, "format": "file.format.original", "type": "type.file.pdf.pdf",
+          "fileUrl": "https://cdn/originals/1.pdf" }
+        """)
+
+        XCTAssertNil(vm.pdfAccessCopyURL())
+    }
+
+    func testFileVO_StaysOnTheOriginal_WhenAnAccessCopyExists() {
+        // The preview swap must not leak into download/filename — the user downloads the .ods
+        // they uploaded, not its PDF rendition.
+        let vm = makeVM()
+        vm.recordVO = makeRecordWithFiles("\(odsOriginalJSON), \(accessCopyPDFJSON)")
+
+        XCTAssertEqual(vm.fileVO()?.type, "type.file.spreadsheet.ods")
+        XCTAssertEqual(vm.fileName(), "file_example_ODS_100.ods")
+    }
+
+    // MARK: - isAwaitingPDFRendition
+    // Archivematica generates the access copy asynchronously. A document opened moments
+    // after upload has only its original, which is "not ready yet" rather than broken —
+    // reporting it as a load failure is what made a freshly uploaded .xlsx look unopenable.
+
+    func testIsAwaitingPDFRendition_TrueWhenOnlyTheOriginalIsPresent() {
+        let vm = makeVM()
+        vm.recordVO = makeRecordWithFiles(odsOriginalJSON)
+
+        XCTAssertTrue(vm.isAwaitingPDFRendition)
+    }
+
+    func testIsAwaitingPDFRendition_FalseOnceTheAccessCopyExists() {
+        let vm = makeVM()
+        vm.recordVO = makeRecordWithFiles("\(odsOriginalJSON), \(accessCopyPDFJSON)")
+
+        XCTAssertFalse(vm.isAwaitingPDFRendition,
+                       "the rendition arrived — waiting longer would spin for nothing")
+    }
+
+    func testIsAwaitingPDFRendition_FalseWhenANonOriginalRenditionExists() {
+        // A converted rendition that simply isn't a PDF means conversion already ran;
+        // there is nothing further to wait for.
+        let vm = makeVM()
+        vm.recordVO = makeRecordWithFiles("""
+        \(odsOriginalJSON),
+        { "fileId": "9", "size": 1, "format": "file.format.converted",
+          "type": "type.file.video.mp4", "fileUrl": "https://cdn/c.mp4" }
+        """)
+
+        XCTAssertFalse(vm.isAwaitingPDFRendition)
+    }
+
+    func testIsAwaitingPDFRendition_FalseWithNoRecordOrNoFiles() {
+        let noRecord = makeVM()
+        XCTAssertFalse(noRecord.isAwaitingPDFRendition, "nothing fetched yet is not a pending rendition")
+
+        let noFiles = makeVM()
+        noFiles.recordVO = RecordVO(recordVO: nil)
+        XCTAssertFalse(noFiles.isAwaitingPDFRendition)
+    }
+
     // MARK: - Initialization
 
     func testInit_SetsNameFromFile() {

--- a/PermanentTests/FilePreviewViewModelTests.swift
+++ b/PermanentTests/FilePreviewViewModelTests.swift
@@ -91,48 +91,6 @@ final class FilePreviewViewModelTests: XCTestCase {
         XCTAssertEqual(vm.fileName(), "file_example_ODS_100.ods")
     }
 
-    // MARK: - isAwaitingPDFRendition
-    // Archivematica generates the access copy asynchronously. A document opened moments
-    // after upload has only its original, which is "not ready yet" rather than broken —
-    // reporting it as a load failure is what made a freshly uploaded .xlsx look unopenable.
-
-    func testIsAwaitingPDFRendition_TrueWhenOnlyTheOriginalIsPresent() {
-        let vm = makeVM()
-        vm.recordVO = makeRecordWithFiles(odsOriginalJSON)
-
-        XCTAssertTrue(vm.isAwaitingPDFRendition)
-    }
-
-    func testIsAwaitingPDFRendition_FalseOnceTheAccessCopyExists() {
-        let vm = makeVM()
-        vm.recordVO = makeRecordWithFiles("\(odsOriginalJSON), \(accessCopyPDFJSON)")
-
-        XCTAssertFalse(vm.isAwaitingPDFRendition,
-                       "the rendition arrived — waiting longer would spin for nothing")
-    }
-
-    func testIsAwaitingPDFRendition_FalseWhenANonOriginalRenditionExists() {
-        // A converted rendition that simply isn't a PDF means conversion already ran;
-        // there is nothing further to wait for.
-        let vm = makeVM()
-        vm.recordVO = makeRecordWithFiles("""
-        \(odsOriginalJSON),
-        { "fileId": "9", "size": 1, "format": "file.format.converted",
-          "type": "type.file.video.mp4", "fileUrl": "https://cdn/c.mp4" }
-        """)
-
-        XCTAssertFalse(vm.isAwaitingPDFRendition)
-    }
-
-    func testIsAwaitingPDFRendition_FalseWithNoRecordOrNoFiles() {
-        let noRecord = makeVM()
-        XCTAssertFalse(noRecord.isAwaitingPDFRendition, "nothing fetched yet is not a pending rendition")
-
-        let noFiles = makeVM()
-        noFiles.recordVO = RecordVO(recordVO: nil)
-        XCTAssertFalse(noFiles.isAwaitingPDFRendition)
-    }
-
     // MARK: - Initialization
 
     func testInit_SetsNameFromFile() {

--- a/PermanentTests/MainViewControllerTests.swift
+++ b/PermanentTests/MainViewControllerTests.swift
@@ -99,6 +99,73 @@ final class MainViewControllerTests: XCTestCase {
         XCTAssertNotNil(collectionView.refreshControl)
     }
 
+    // MARK: - FAB visibility across select mode
+    // The + button is gated on archive permissions, but the RESTORE paths used to un-hide
+    // it unconditionally. The reported repro: open a viewer-role archive, tap Select, then
+    // deselect — the create/upload FAB appeared on an archive the user cannot write to.
+
+    /// Wires just the outlets the select-mode handlers touch. Returns strong refs —
+    /// controller outlets are weak.
+    private func makeSelectModeHarness(_ vm: MyFilesViewModel)
+    -> (vc: MainViewController, retained: [UIView]) {
+        let vc = MainViewController()
+        vc.viewModel = vm
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        let backButton = UIButton(type: .system)
+        let fabView = FABView(frame: .zero)
+        vc.collectionView = collectionView
+        vc.backButton = backButton
+        vc.fabView = fabView
+        return (vc, [collectionView, backButton, fabView])
+    }
+
+    func testDeselect_ViewerArchive_DoesNotRevealFAB() {
+        let vm = PermissionAwareMyFilesViewModel()
+        vm.testArchivePermissions = [.read]           // viewer role — no create/upload
+        let (vc, retained) = makeSelectModeHarness(vm)
+        defer { _ = retained }
+
+        vc.updateFABViewVisibility()
+        XCTAssertTrue(vc.fabView.isHidden, "precondition: a viewer archive never shows the FAB")
+
+        vc.selectButtonWasPressed(UIButton())
+        XCTAssertTrue(vc.fabView.isHidden, "select mode keeps it hidden")
+
+        vc.clearButtonWasPressed(UIButton())          // the reported repro: deselect
+        XCTAssertTrue(vc.fabView.isHidden,
+                      "leaving select mode must not conjure + on an archive without write access")
+    }
+
+    func testDeselect_WritableArchive_RestoresFAB() {
+        // The gate must not over-tighten: with create+upload the FAB comes back on deselect.
+        let vm = PermissionAwareMyFilesViewModel()
+        vm.testArchivePermissions = [.read, .create, .upload]
+        let (vc, retained) = makeSelectModeHarness(vm)
+        defer { _ = retained }
+
+        vc.updateFABViewVisibility()
+        XCTAssertFalse(vc.fabView.isHidden, "precondition: writable archive shows the FAB")
+
+        vc.selectButtonWasPressed(UIButton())
+        XCTAssertTrue(vc.fabView.isHidden, "select mode owns the screen while active")
+
+        vc.clearButtonWasPressed(UIButton())
+        XCTAssertFalse(vc.fabView.isHidden, "deselect restores the FAB when permissions allow")
+    }
+
+    func testUpdateFABViewVisibility_HiddenWhileSelecting() {
+        // The gate itself must treat select mode as hidden, so any stray refresh that
+        // recomputes visibility mid-selection cannot re-show the FAB either.
+        let vm = PermissionAwareMyFilesViewModel()
+        vm.testArchivePermissions = [.read, .create, .upload]
+        let (vc, retained) = makeSelectModeHarness(vm)
+        defer { _ = retained }
+
+        vm.isSelecting = true
+        vc.updateFABViewVisibility()
+        XCTAssertTrue(vc.fabView.isHidden)
+    }
+
     func testCancelButtonPressedDismissesController() {
         let vc = TestableMainViewController()
 
@@ -224,7 +291,14 @@ final class MainViewControllerTests: XCTestCase {
     
     func testClearButtonSelectorDisablesSelectingAndRestoresUI() {
         let vc = MainViewController()
-        let vm = MyFilesViewModel()
+        // Permission-aware mock WITH write access: the FAB restore below is only correct
+        // for a writable archive. (A bare MyFilesViewModel has no session, so its
+        // permissions are [.read] — this test used to assert the FAB reappearing in that
+        // state, which was precisely the permission leak fixed by routing the restore
+        // through updateFABViewVisibility. The viewer case is covered by
+        // testDeselect_ViewerArchive_DoesNotRevealFAB.)
+        let vm = PermissionAwareMyFilesViewModel()
+        vm.testArchivePermissions = [.read, .create, .upload]
         vc.viewModel = vm
         
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())

--- a/PermanentTests/MainViewControllerTests.swift
+++ b/PermanentTests/MainViewControllerTests.swift
@@ -166,6 +166,42 @@ final class MainViewControllerTests: XCTestCase {
         XCTAssertTrue(vc.fabView.isHidden)
     }
 
+    func testUpdateFABViewVisibility_RestoresAlpha_NotJustIsHidden() {
+        // The FAB menu used to hide itself by fading alpha to 0 and setting isHidden. The
+        // permission gate only manages isHidden, so the FAB came back present-but-invisible
+        // — the "+ button never returns after an upload action" report. Showing it must
+        // restore alpha on every path, including when the view was left visible-but-clear.
+        let vm = PermissionAwareMyFilesViewModel()
+        vm.testArchivePermissions = [.read, .create, .upload]
+        let (vc, retained) = makeSelectModeHarness(vm)
+        defer { _ = retained }
+
+        vc.fabView.isHidden = true
+        vc.fabView.alpha = 0
+
+        vc.updateFABViewVisibility()
+
+        XCTAssertFalse(vc.fabView.isHidden)
+        XCTAssertEqual(vc.fabView.alpha, 1, "a zero-alpha FAB is invisible no matter what isHidden says")
+    }
+
+    func testUpdateFABViewVisibility_RestoresAlpha_WhenNotHidden() {
+        // The hide sets isHidden in an animation completion, so a fast restore can land
+        // while isHidden is still false and alpha already 0 — that early-return path has to
+        // reset alpha too.
+        let vm = PermissionAwareMyFilesViewModel()
+        vm.testArchivePermissions = [.read, .create, .upload]
+        let (vc, retained) = makeSelectModeHarness(vm)
+        defer { _ = retained }
+
+        vc.fabView.isHidden = false
+        vc.fabView.alpha = 0
+
+        vc.updateFABViewVisibility()
+
+        XCTAssertEqual(vc.fabView.alpha, 1)
+    }
+
     func testCancelButtonPressedDismissesController() {
         let vc = TestableMainViewController()
 

--- a/PermanentTests/SharesViewControllerTests.swift
+++ b/PermanentTests/SharesViewControllerTests.swift
@@ -429,6 +429,55 @@ final class SharesViewControllerTests: XCTestCase {
         XCTAssertTrue(called)
     }
 
+    // MARK: - FAB visibility across select mode
+    // Same regression class as MainViewController: the restore paths un-hid the
+    // create/upload FAB unconditionally, so leaving select mode inside a folder shared
+    // at viewer level conjured a + button the role does not allow.
+
+    func testDeselect_ViewOnlyFolder_DoesNotRevealFAB() {
+        let vc = makeController()
+        // A folder shared at viewer level: [.read] only (makeFolder's default).
+        vc.viewModel?.navigationStack.append(makeFolder(name: "Shared viewer folder", folderLinkId: 9))
+        // The real screen starts with the action sheet hidden; a bare view defaults to
+        // visible, and the gate correctly refuses to show the FAB over it.
+        vc.fileActionBottomView.isHidden = true
+
+        vc.updateFAB()
+        XCTAssertTrue(vc.fabView.isHidden, "precondition: a view-only folder never shows the FAB")
+
+        vc.selectButtonWasPressed(UIButton())
+        XCTAssertTrue(vc.fabView.isHidden)
+
+        vc.clearButtonWasPressed(UIButton())
+        XCTAssertTrue(vc.fabView.isHidden,
+                      "leaving select mode must not conjure + in a folder without write access")
+    }
+
+    func testDeselect_WritableFolder_RestoresFAB() {
+        let vc = makeController()
+        let writable = FileModel(
+            name: "Editable shared folder",
+            recordId: 0,
+            folderLinkId: 9,
+            archiveNbr: "0001-0000",
+            type: FileType.privateFolder.rawValue,
+            permissions: [.read, .create, .upload]
+        )
+        vc.viewModel?.navigationStack.append(writable)
+        // The real screen starts with the action sheet hidden; a bare view defaults to
+        // visible, and the gate correctly refuses to show the FAB over it.
+        vc.fileActionBottomView.isHidden = true
+
+        vc.updateFAB()
+        XCTAssertFalse(vc.fabView.isHidden, "precondition: writable folder shows the FAB")
+
+        vc.selectButtonWasPressed(UIButton())
+        XCTAssertTrue(vc.fabView.isHidden, "select mode owns the screen while active")
+
+        vc.clearButtonWasPressed(UIButton())
+        XCTAssertFalse(vc.fabView.isHidden, "deselect restores the FAB when permissions allow")
+    }
+
     private func makeController() -> SharesViewController {
         let vc = SharesViewController()
         vc.viewModel = MockSharedFilesViewModel()


### PR DESCRIPTION
Fixed: the create/upload FAB no longer appears on a view-only archive after leaving select mode.

Leaving multi-select restored the FAB unconditionally, so Select → deselect handed a
viewer-role archive a create/upload button. All restore paths now route through the
permission gate, which additionally hides the FAB while selecting.

Also in this branch:

- Pending archives were dropped during parsing while `pendingArchives` filtered this same
  collection for them, so the "Pending Archives" section was structurally always empty:
  an invitation shown on the web could not be accepted on iOS at all. The filter is now a
  testable `usableArchives(from:)` — four passing tests missed this because they all
  assigned `allArchives` directly, bypassing parsing.

- Spreadsheet and document previews spun forever. The record's downloadUrl carries
  `Content-Disposition: attachment`, so WebKit converts the navigation into a download and
  fails the load provisionally (WebKitErrorDomain 102) — reported through
  didFailProvisionalNavigation, which was implemented nowhere. Neither completion path ran
  and the loading overlay never cleared. Documents now render Archivematica's PDF access
  copy via PDFKit; fileVO() stays on the original so Download is unchanged.

- A document whose access copy has not been generated yet no longer reports a load failure.
  The record is re-fetched on a bounded schedule (10s, max 6 attempts) before falling back
  to the retry card, and Tap-to-Retry re-fetches instead of replaying the cached record,
  which previously made it a permanent dead end for that exact case.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>