### PR TITLE
VSP-1811[iOS] Public-Gallery-record-detail-on-Stela-V2

### DIFF
--- a/Permanent/Common/Helpers/NetworkLogger.swift
+++ b/Permanent/Common/Helpers/NetworkLogger.swift
@@ -48,13 +48,6 @@ class NetworkLogger {
         /// bounding the pathological case. Staging only: `environmentRestriction` keeps all
         /// of this out of production, and `logBodies` is off there regardless.
         var maxBodyLength: Int = 1_000_000
-
-        /// Bytes per emitted log line. os_log truncates an individual message well before
-        /// `maxBodyLength` — in practice around 1 KB — so a long body must be emitted in
-        /// pieces or the tail is silently lost (this is what hid the archive list: the cut
-        /// happened at ~1 KB even though the cap was 10 KB and no truncation marker was
-        /// appended, because the loss was in os_log, not here).
-        var logChunkSize: Int = 800
     }
     
     /// Current logger configuration
@@ -145,23 +138,20 @@ class NetworkLogger {
         return String(decoding: body.prefix(cap), as: UTF8.self) + " … [truncated \(body.count - cap) of \(body.count) bytes]"
     }
 
-    /// Emits a body across as many log lines as it takes, because os_log drops the tail of
-    /// any single long message. Each line is prefixed `label [i/n]` so `log stream` output
-    /// can be reassembled in order; a short body still logs as one unprefixed line.
+    /// Emits the body as ONE unbroken line, via stdout rather than os_log.
+    ///
+    /// os_log hard-truncates any individual message at roughly 1 KB, so a real response body
+    /// cannot go through `logger` at all — it used to lose its tail with no marker, which is
+    /// what hid the `getAllArchives` response and made a server payload look incomplete.
+    /// Splitting it across numbered lines fixed the loss but left the JSON in pieces, so it
+    /// could not be copied into a formatter. stdout has no per-message cap: Xcode's console
+    /// shows the whole body as a single entry you can select, copy and paste as-is.
+    ///
+    /// Staging only — `isLoggingEnabled` gates every caller and `logBodies` is off in
+    /// production. Note this is deliberately NOT visible to `log stream`, which only carries
+    /// os_log; use Xcode's console, or `simctl launch --console`, to read bodies.
     private static func logBody(_ label: String, _ body: Data) {
-        let text = loggableBody(body)
-        let size = max(1, configuration.logChunkSize)
-        guard text.count > size else {
-            logger.debug("\(label): \(text, privacy: .public)")
-            return
-        }
-        let chars = Array(text)
-        let total = (chars.count + size - 1) / size
-        for index in 0..<total {
-            let start = index * size
-            let piece = String(chars[start..<min(start + size, chars.count)])
-            logger.debug("\(label) [\(index + 1, privacy: .public)/\(total, privacy: .public)]: \(piece, privacy: .public)")
-        }
+        print("\(label): \(loggableBody(body))")
     }
     
     /// Log a network response

--- a/Permanent/Modules/FileOperations/ViewController/FilePreviewListViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FilePreviewListViewController.swift
@@ -111,8 +111,10 @@ class FilePreviewListViewController: BaseViewController<FilesViewModel> {
     private func createFilePreviewViewController(for file: FileModel) -> FilePreviewViewController {
         let filePreviewVC = UIViewController.create(withIdentifier: .filePreview, from: .main) as! FilePreviewViewController
         filePreviewVC.file = file
-        // usesStelaDetail keeps its property default (the in-app flag); the VM scopes V2
-        // to own-archive records and auto-falls back to V1. loadVM() builds the VM.
+        // usesStelaDetail keeps its property default (the in-app flag). The VM scopes V2 to
+        // own-archive records, plus the public gallery's foreign-but-public ones, and auto-
+        // falls back to V1. loadVM() builds the VM, so this must be set before it runs.
+        filePreviewVC.allowsForeignStelaDetail = viewModel is PublicArchiveViewModel
 
         // If opened from notification, pass close action to child VC
         if isFromNotification {
@@ -265,8 +267,10 @@ extension FilePreviewListViewController: UIPageViewControllerDataSource, UIPageV
             fileDetailsVC.onDidActivatePlaybackAudioSession = { [weak self] in
                 self?.didActivatePreviewAudioSession = true
             }
-            // usesStelaDetail keeps its property default (the in-app flag); the VM scopes
-            // V2 to own-archive records with a V1 failsafe.
+            // usesStelaDetail keeps its property default (the in-app flag); the VM scopes V2
+            // to own-archive records plus the gallery's public ones, with a V1 failsafe.
+            // Must precede loadVM(), which is what builds the view model.
+            fileDetailsVC.allowsForeignStelaDetail = viewModel is PublicArchiveViewModel
             fileDetailsVC.view.isHidden = false // preload the view
             fileDetailsVC.loadVM()
             

--- a/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
+++ b/Permanent/Modules/FileOperations/ViewController/FilePreviewViewController.swift
@@ -31,6 +31,9 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
     /// restricts V2 to records in the user's own archive and auto-falls back to V1 on
     /// any error/thin payload, so no presenter needs to override this default.
     var usesStelaDetail: Bool = FeatureFlags.useStelaNavigation
+    /// Set by the public gallery: its records live in a FOREIGN archive but are public, so
+    /// the V2 read applies there too. See FilePreviewViewModel.allowsForeignDetail.
+    var allowsForeignStelaDetail: Bool = false
 
     var playerItem: AVPlayerItem?
     var videoPlayer: AVPlayerViewController?
@@ -170,7 +173,9 @@ class FilePreviewViewController: BaseViewController<FilePreviewViewModel> {
         }
 
         if viewModel == nil || viewModel?.recordVO == nil {
-            viewModel = FilePreviewViewModel(file: file, usesStelaDetail: usesStelaDetail)
+            viewModel = FilePreviewViewModel(file: file,
+                                            usesStelaDetail: usesStelaDetail,
+                                            allowsForeignDetail: allowsForeignStelaDetail)
             bindImagePreviewState()
 
             if file.type == .image {

--- a/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
+++ b/Permanent/ViewModels/ViewModel/FilePreviewViewModel.swift
@@ -51,8 +51,16 @@ class FilePreviewViewModel: ViewModelInterface {
     /// Stela V2 getRecordById, with the legacy V1 getRecord as an automatic failsafe.
     private let usesStelaDetail: Bool
 
-    init(file: FileModel, usesStelaDetail: Bool = false, tagsRepository: TagsRepository = TagsRepository(), reachability: ReachabilityProviding = ReachabilityManager.shared) {
+    /// Extends the V2 record READ to records outside the current archive. Set by the public
+    /// gallery, where you browse a FOREIGN archive whose records are public — the same
+    /// bearer-only credentials already list that archive's folder children on V2, so there is
+    /// no reason the record read should need V1. Read only: writes (patch/copy) stay
+    /// own-archive regardless, and the gallery is pinned read-only anyway.
+    private let allowsForeignDetail: Bool
+
+    init(file: FileModel, usesStelaDetail: Bool = false, allowsForeignDetail: Bool = false, tagsRepository: TagsRepository = TagsRepository(), reachability: ReachabilityProviding = ReachabilityManager.shared) {
         self.usesStelaDetail = usesStelaDetail
+        self.allowsForeignDetail = allowsForeignDetail
         self.tagsRepository = tagsRepository
         self.reachability = reachability
         self.file = file
@@ -144,10 +152,14 @@ class FilePreviewViewModel: ViewModelInterface {
         }
         #endif
 
-        // Stela V2 detail (own-archive records on ANY screen) with the legacy V1 fetch as
-        // an automatic failsafe. Foreign/shared records stay on V1: they're authorized
-        // server-side via share membership, which the bearer-only V2 read can't carry.
-        if usesStelaDetail, file.recordId > 0, isInCurrentArchive(file) {
+        // Stela V2 detail with the legacy V1 fetch as an automatic failsafe. Own-archive
+        // records on any screen, plus foreign records where the caller says the read is
+        // public (`allowsForeignDetail` — the gallery). Shared-with-me records still go to
+        // V1: those are authorized server-side via share membership, which the bearer-only
+        // V2 read can't carry. The failsafe makes a wrong guess cheap — a rejected V2 read
+        // silently becomes the V1 read, costing one request, because record reads are
+        // idempotent (unlike copy, which is why copy has no fallback).
+        if usesStelaDetail, file.recordId > 0, isInCurrentArchive(file) || allowsForeignDetail {
             getRecordV2(file: file, then: handler)
             return
         }


### PR DESCRIPTION
Public gallery record detail now uses the Stela V2 record endpoint instead of dropping to the old one.

VSP-1811 moved gallery navigation to V2 but left record detail on V1: the gate required the record to be in the CURRENT archive, which is never true when browsing a foreign public archive — so every gallery record fell back to /api/record/get. The stated reason (foreign records need share membership, the bearer-only V2 read can't carry) does not hold for public content: the gallery already lists that same archive's folder children on V2 with the same credentials and no share token.